### PR TITLE
CORE-29012 Added "type" field to Send Event action type.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   plugins: ["prettier", "testcafe"],
   rules: {
-    "no-param-reassign": ["error", { props: false }],
+    "no-param-reassign": "off",
     "prettier/prettier": "error",
     "react/require-default-props": "off",
     "jsx-a11y/label-has-associated-control": [

--- a/extension.json
+++ b/extension.json
@@ -16,11 +16,19 @@
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "minLength": 1
+          },
           "data": {
             "type": "string",
             "pattern": "^%([^%]+)%$"
           }
-        }
+        },
+        "required": [
+          "data"
+        ],
+        "additionalProperties": false
       },
       "libPath": "dist/lib/actions/sendEvent.js",
       "viewPath": "sendEvent.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,6 +1163,18 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+      "integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -1307,6 +1319,13 @@
       "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
       "requires": {
         "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
       }
     },
     "@babel/template": {
@@ -6233,13 +6252,13 @@
       }
     },
     "formik": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.4.tgz",
-      "integrity": "sha512-m7Tboq9O6MntCM8+J/b3jGGKXNXRq1dTzLvEdujSySejlewqVeYLy/goulrvr152wPe9ycKV0NlFSQ8Q1EwycQ==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.7.tgz",
+      "integrity": "sha512-kZo8lS4WzfC2uivnSkE9DOuX9x+jVjCtIZOlb1A4lHGeURyuLt6eDfwGJzNlcP0lXIwmpANKzegiB8j60B54TA==",
       "requires": {
         "create-react-context": "^0.2.2",
         "deepmerge": "^2.1.1",
-        "hoist-non-react-statics": "^2.5.5",
+        "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.11",
         "lodash-es": "^4.17.11",
         "prop-types": "^15.6.1",
@@ -7261,9 +7280,12 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -10941,9 +10963,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.13.4",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
   "dependencies": {
     "@react/react-spectrum": "^2.20.0",
     "classnames": "^2.2.6",
-    "formik": "^1.5.4",
+    "formik": "^1.5.7",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "regenerator-runtime": "^0.13.2",
     "yup": "^0.27.0"
   },
   "devDependencies": {
@@ -46,6 +47,7 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "babel-eslint": "^10.0.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -20,13 +20,29 @@ import "./sendEvent.styl";
 import InfoTip from "../components/infoTip";
 
 const getInitialValues = settings => {
+  // settings is null if the user is creating a new rule component
+  if (!settings) {
+    settings = {};
+  }
+
+  const { data = "", type = "" } = settings;
+
   return {
-    data: settings ? settings.data : ""
+    data,
+    type
   };
 };
 
 const getSettings = values => {
-  return values;
+  const settings = {
+    data: values.data
+  };
+
+  if (values.type) {
+    settings.type = values.type;
+  }
+
+  return settings;
 };
 
 const validationSchema = object().shape({
@@ -41,24 +57,41 @@ const SendEvent = () => {
       validationSchema={validationSchema}
       render={() => {
         return (
-          <label>
-            <span className="Label">
-              Data
-              <InfoTip>
-                Please specify a data element that will return a JavaScript
-                object. This object will be sent to the Adobe Experience
-                Platform.
-              </InfoTip>
-            </span>
+          <div>
             <div>
-              <WrappedField
-                name="data"
-                component={Textfield}
-                componentClassName="u-longTextfield"
-                supportDataElement
-              />
+              <label>
+                <span className="Label">Type</span>
+                <div>
+                  <WrappedField
+                    name="type"
+                    component={Textfield}
+                    componentClassName="u-longTextfield"
+                    supportDataElement
+                  />
+                </div>
+              </label>
             </div>
-          </label>
+            <div className="u-gapTop">
+              <label>
+                <span className="Label">
+                  Data
+                  <InfoTip>
+                    Please specify a data element that will return a JavaScript
+                    object. This object will be sent to the Adobe Experience
+                    Platform.
+                  </InfoTip>
+                </span>
+                <div>
+                  <WrappedField
+                    name="data"
+                    component={Textfield}
+                    componentClassName="u-longTextfield"
+                    supportDataElement
+                  />
+                </div>
+              </label>
+            </div>
+          </div>
         );
       }}
     />

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -10,9 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import "regenerator-runtime"; // needed for some of react-spectrum
 import React from "react";
 import { object, string } from "yup";
 import Textfield from "@react/react-spectrum/Textfield";
+import ComboBox from "@react/react-spectrum/ComboBox";
 import render from "../render";
 import WrappedField from "../components/wrappedField";
 import ExtensionView from "../components/extensionView";
@@ -45,8 +47,11 @@ const getSettings = values => {
   return settings;
 };
 
+const invalidDataMessage = "Please specify a data element";
 const validationSchema = object().shape({
-  data: string().matches(/^%([^%]+)%$/, "Please specify a data element")
+  data: string()
+    .required(invalidDataMessage)
+    .matches(/^%([^%]+)%$/, invalidDataMessage)
 });
 
 const SendEvent = () => {
@@ -64,9 +69,9 @@ const SendEvent = () => {
                 <div>
                   <WrappedField
                     name="type"
-                    component={Textfield}
-                    componentClassName="u-longTextfield"
+                    component={ComboBox}
                     supportDataElement
+                    options={["viewStart"]}
                   />
                 </div>
               </label>
@@ -85,7 +90,6 @@ const SendEvent = () => {
                   <WrappedField
                     name="data"
                     component={Textfield}
-                    componentClassName="u-longTextfield"
                     supportDataElement
                   />
                 </div>

--- a/src/view/components/extensionView.jsx
+++ b/src/view/components/extensionView.jsx
@@ -43,8 +43,14 @@ const ExtensionView = ({
         return getSettings(formikProps.values);
       },
       validate: () => {
-        const { submitForm, errors } = formikProps;
-        return submitForm().then(() => Object.keys(errors).length === 0);
+        // The docs say that the promise submitForm returns
+        // will be rejected if there are errors, but that is not the case.
+        // Therefore, after the promise is resolved, we pull formikProps.errors
+        // (which were set during submitForm()) to see if the form is valid.
+        // https://github.com/jaredpalmer/formik/issues/1580
+        return formikProps.submitForm().then(() => {
+          return Object.keys(formikProps.errors).length === 0;
+        });
       }
     });
   }, []);

--- a/src/view/utils.styl
+++ b/src/view/utils.styl
@@ -12,6 +12,10 @@ governing permissions and limitations under the License.
 
 $gap = 8px;
 
+.u-gapTop {
+  margin-top: $gap !important;
+}
+
 .u-gapLeft {
   margin-left: $gap !important;
 }

--- a/test/functional/helpers/createExtensionViewController.js
+++ b/test/functional/helpers/createExtensionViewController.js
@@ -11,8 +11,11 @@ governing permissions and limitations under the License.
 */
 
 module.exports = viewPath => {
+  // window.loadExtensionView is provided by the extension sandbox tool.
+  // More details about the tool and this method can be found here:
+  // https://www.npmjs.com/package/@adobe/reactor-sandbox
   return {
-    init: async (t, settings) => {
+    init: async (t, settings = null) => {
       await t.switchToMainWindow();
       return t.eval(
         () => {

--- a/test/functional/sendEvent.spec.js
+++ b/test/functional/sendEvent.spec.js
@@ -89,6 +89,12 @@ test("returns valid for full valid input", async t => {
   await t.expect(valid).ok();
 });
 
+test("returns invalid for empty data value", async t => {
+  await extensionViewController.init(t);
+  const valid = await extensionViewController.validate(t);
+  await t.expect(valid).notOk();
+});
+
 test("returns invalid for data value that is not a data element", async t => {
   await extensionViewController.init(t);
   await t.switchToIframe(iframe).typeText(dataTextfield, "myDataLayer");

--- a/test/unit/lib/actions/sendEvent.spec.js
+++ b/test/unit/lib/actions/sendEvent.spec.js
@@ -20,12 +20,14 @@ describe("Send Event", () => {
     expect(getInstance).toHaveBeenCalledWith("alloy");
 
     action({
+      type: "thingHappened",
       data: {
         foo: "bar"
       }
     });
 
     expect(instance).toHaveBeenCalledWith("event", {
+      type: "thingHappened",
       data: {
         foo: "bar"
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added `type` field to Send Event action type. Right now I made it optional. We can switch it to required whenever we deem that it's required.

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/CORE-29012

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

`type` is supported by alloy

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Automation and manual visual inspection

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/210820/58824641-c92c8600-85f9-11e9-9d59-4a12f1299e9c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
