### PR TITLE
CORE-33751 Made name the primary identifier for each instance.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -74,7 +74,7 @@
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "properties": {
-          "propertyId": {
+          "name": {
             "type": "string",
             "minLength": 1
           },
@@ -88,7 +88,7 @@
           }
         },
         "required": [
-          "propertyId",
+          "name",
           "data"
         ],
         "additionalProperties": false

--- a/extension.json
+++ b/extension.json
@@ -54,7 +54,7 @@
             },
             "required": [
               "propertyId",
-              "instanceName"
+              "name"
             ],
             "additionalProperties": false
           }
@@ -74,7 +74,7 @@
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "properties": {
-          "name": {
+          "instanceName": {
             "type": "string",
             "minLength": 1
           },
@@ -88,7 +88,7 @@
           }
         },
         "required": [
-          "name",
+          "instanceName",
           "data"
         ],
         "additionalProperties": false

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -3,5 +3,8 @@ module.exports = {
     // The eslintrc in the base directory turns this rule off.
     // We want to turn it back on for the src directory.
     "import/no-extraneous-dependencies": "error"
+  },
+  globals: {
+    _satellite: "readonly"
   }
 };

--- a/src/lib/actions/createSendEvent.js
+++ b/src/lib/actions/createSendEvent.js
@@ -11,14 +11,14 @@ governing permissions and limitations under the License.
 */
 
 module.exports = instanceManager => settings => {
-  const { propertyId, ...otherSettings } = settings;
-  const instance = instanceManager.getInstance(propertyId);
+  const { instanceName, ...otherSettings } = settings;
+  const instance = instanceManager.getInstance(instanceName);
 
   if (instance) {
     instance("event", otherSettings);
   } else {
     turbine.logger.error(
-      `Failed to send event for property ID "${propertyId}". No matching instance was configured with this ID.`
+      `Failed to send event for instance "${instanceName}". No matching instance was configured with this name.`
     );
   }
 };

--- a/src/lib/createInstanceManager.js
+++ b/src/lib/createInstanceManager.js
@@ -10,31 +10,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const getNameByPropertyId = (instances, propertyId) => {
-  let matchingName;
-  for (let i = 0; i < instances.length; i += 1) {
-    const instance = instances[i];
-    if (instance.propertyId === propertyId) {
-      matchingName = instance.name;
-      break;
-    }
-  }
-  return matchingName;
-};
-
-module.exports = (window, runAlloy) => {
+module.exports = (window, runAlloy, imsOrgId) => {
   const { instances } = turbine.getExtensionSettings();
   const names = instances.map(instance => instance.name);
 
   runAlloy(names);
 
   instances.forEach(({ name, ...options }) => {
-    window[name]("configure", options);
+    window[name]("configure", {
+      ...options,
+      imsOrgId
+    });
   });
 
   return {
-    getInstance(propertyId) {
-      const name = getNameByPropertyId(instances, propertyId);
+    getInstance(name) {
       return name ? window[name] : undefined;
     }
   };

--- a/src/lib/instanceManager.js
+++ b/src/lib/instanceManager.js
@@ -13,4 +13,8 @@ governing permissions and limitations under the License.
 const runAlloy = require("./runAlloy");
 const createInstanceManager = require("./createInstanceManager");
 
-module.exports = createInstanceManager(window, runAlloy);
+module.exports = createInstanceManager(
+  window,
+  runAlloy,
+  _satellite.company.orgId
+);

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -29,10 +29,10 @@ const getInitialValues = settings => {
     settings = {};
   }
 
-  const { propertyId = "", viewStart = false, data = "" } = settings;
+  const { instanceName = "", viewStart = false, data = "" } = settings;
 
   return {
-    propertyId,
+    instanceName,
     viewStart,
     data
   };
@@ -40,7 +40,7 @@ const getInitialValues = settings => {
 
 const getSettings = values => {
   const settings = {
-    propertyId: values.propertyId,
+    instanceName: values.instanceName,
     data: values.data
   };
 
@@ -54,7 +54,7 @@ const getSettings = values => {
 
 const invalidDataMessage = "Please specify a data element";
 const validationSchema = object().shape({
-  propertyId: string().required("Please specify an instance"),
+  instanceName: string().required("Please specify an instance"),
   data: string()
     .required(invalidDataMessage)
     .matches(/^%([^%]+)%$/, invalidDataMessage)
@@ -69,22 +69,22 @@ const SendEvent = () => {
       render={({ initInfo }) => {
         const instanceOptions = initInfo.extensionSettings.instances.map(
           instance => ({
-            value: instance.propertyId,
-            label: instance.propertyId
+            value: instance.name,
+            label: instance.name
           })
         );
 
         if (initInfo.settings) {
-          const previouslySavedPropertyId = initInfo.settings.propertyId;
+          const previouslySavedInstanceName = initInfo.settings.instanceName;
           if (
             !instanceOptions.some(
               instanceOption =>
-                instanceOption.value === initInfo.settings.propertyId
+                instanceOption.value === initInfo.settings.instanceName
             )
           ) {
             instanceOptions.unshift({
-              value: previouslySavedPropertyId,
-              label: `${previouslySavedPropertyId} (Deleted)`,
+              value: previouslySavedInstanceName,
+              label: `${previouslySavedInstanceName} (Deleted)`,
               disabled: true
             });
           }
@@ -94,15 +94,15 @@ const SendEvent = () => {
           <div>
             <div>
               <label
-                htmlFor="propertyIdField"
+                htmlFor="instanceNameField"
                 className="spectrum-Form-itemLabel"
               >
                 Instance
               </label>
               <div>
                 <WrappedField
-                  id="propertyIdField"
-                  name="propertyId"
+                  id="instanceNameField"
+                  name="instanceName"
                   component={Select}
                   componentClassName="u-fieldLong"
                   options={instanceOptions}

--- a/test/functional/sendEvent.spec.js
+++ b/test/functional/sendEvent.spec.js
@@ -17,15 +17,15 @@ import spectrum from "./helpers/spectrum";
 const extensionViewController = createExtensionViewController(
   "actions/sendEvent.html"
 );
-const propertyIdField = spectrum.select(Selector("[name=propertyId]"));
+const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
 const dataField = spectrum.textfield(Selector("[name=data]"));
 const viewStartField = spectrum.checkbox(Selector("[name=viewStart]"));
 
 const mockExtensionSettings = {
   instances: [
     {
-      propertyId: "PR123",
-      name: "alloy1"
+      name: "alloy1",
+      propertyId: "PR123"
     }
   ]
 };
@@ -40,12 +40,12 @@ test("initializes form fields with full settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings,
     settings: {
-      propertyId: "PR123",
+      instanceName: "alloy1",
       viewStart: true,
       data: "%myDataLayer%"
     }
   });
-  await propertyIdField.expectValue(t, "PR123");
+  await instanceNameField.expectValue(t, "alloy1");
   await viewStartField.expectChecked(t);
   await dataField.expectValue(t, "%myDataLayer%");
 });
@@ -54,11 +54,11 @@ test("initializes form fields with minimal settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings,
     settings: {
-      propertyId: "PR123",
+      instanceName: "alloy1",
       data: "%myDataLayer%"
     }
   });
-  await propertyIdField.expectValue(t, "PR123");
+  await instanceNameField.expectValue(t, "alloy1");
   await viewStartField.expectUnchecked(t);
   await dataField.expectValue(t, "%myDataLayer%");
 });
@@ -67,7 +67,7 @@ test("initializes form fields with no settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings
   });
-  await propertyIdField.expectValue(t, "");
+  await instanceNameField.expectValue(t, "");
   await viewStartField.expectUnchecked(t);
   await dataField.expectValue(t, "");
 });
@@ -77,11 +77,11 @@ test("returns minimal valid settings", async t => {
     extensionSettings: mockExtensionSettings
   });
 
-  await propertyIdField.selectOption(t, "PR123");
+  await instanceNameField.selectOption(t, "alloy1");
   await dataField.typeText(t, "%myDataLayer%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
-    propertyId: "PR123",
+    instanceName: "alloy1",
     data: "%myDataLayer%"
   });
 });
@@ -90,12 +90,12 @@ test("returns full valid settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings
   });
-  await propertyIdField.selectOption(t, "PR123");
+  await instanceNameField.selectOption(t, "alloy1");
   await viewStartField.click(t);
   await dataField.typeText(t, "%myDataLayer%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
-    propertyId: "PR123",
+    instanceName: "alloy1",
     viewStart: true,
     data: "%myDataLayer%"
   });
@@ -106,7 +106,7 @@ test("shows errors for empty required values", async t => {
     extensionSettings: mockExtensionSettings
   });
   await extensionViewController.expectIsNotValid(t);
-  await propertyIdField.expectError(t);
+  await instanceNameField.expectError(t);
   await dataField.expectError(t);
 });
 
@@ -114,7 +114,7 @@ test("shows error for data value that is not a data element", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings,
     settings: {
-      propertyId: "PR123"
+      instanceName: "alloy1"
     }
   });
   await dataField.typeText(t, "myDataLayer");
@@ -126,7 +126,7 @@ test("shows error for data value that is more than one data element", async t =>
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings,
     settings: {
-      propertyId: "PR123"
+      instanceName: "alloy1"
     }
   });
   await dataField.typeText(t, "%a%%b%");

--- a/test/unit/lib/actions/sendEvent.spec.js
+++ b/test/unit/lib/actions/sendEvent.spec.js
@@ -37,14 +37,14 @@ describe("Send Event", () => {
     const action = createSendEvent(instanceManager);
 
     action({
-      propertyId: "PR123",
+      instanceName: "myinstance",
       viewStart: true,
       data: {
         foo: "bar"
       }
     });
 
-    expect(instanceManager.getInstance).toHaveBeenCalledWith("PR123");
+    expect(instanceManager.getInstance).toHaveBeenCalledWith("myinstance");
     expect(instance).toHaveBeenCalledWith("event", {
       viewStart: true,
       data: {
@@ -60,7 +60,7 @@ describe("Send Event", () => {
     const action = createSendEvent(instanceManager);
 
     action({
-      propertyId: "PR123",
+      instanceName: "myinstance",
       viewStart: true,
       data: {
         foo: "bar"
@@ -68,7 +68,7 @@ describe("Send Event", () => {
     });
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'Failed to send event for property ID "PR123". No matching instance was configured with this ID.'
+      'Failed to send event for instance "myinstance". No matching instance was configured with this name.'
     );
   });
 });

--- a/test/unit/lib/createInstanceManager.spec.js
+++ b/test/unit/lib/createInstanceManager.spec.js
@@ -41,7 +41,11 @@ describe("Instance Manager", () => {
         mockWindow[name] = jasmine.createSpy();
       });
     });
-    instanceManager = createInstanceManager(mockWindow, runAlloy);
+    instanceManager = createInstanceManager(
+      mockWindow,
+      runAlloy,
+      "ABC@AdobeOrg"
+    );
   });
 
   afterEach(() => {
@@ -59,14 +63,16 @@ describe("Instance Manager", () => {
 
   it("configures an SDK instance for each instance", () => {
     expect(mockWindow.alloy1).toHaveBeenCalledWith("configure", {
-      propertyId: "PR123"
+      propertyId: "PR123",
+      imsOrgId: "ABC@AdobeOrg"
     });
     expect(mockWindow.alloy2).toHaveBeenCalledWith("configure", {
-      propertyId: "PR456"
+      propertyId: "PR456",
+      imsOrgId: "ABC@AdobeOrg"
     });
   });
 
-  it("returns instance by property ID", () => {
-    expect(instanceManager.getInstance("PR456")).toBe(mockWindow.alloy2);
+  it("returns instance by name", () => {
+    expect(instanceManager.getInstance("alloy2")).toBe(mockWindow.alloy2);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I talked to Justin Grover about using name as the primary identifier for the instance rather than propertyId. In other words, if a user were to go to the Send Event action view, they would select an instance name from a dropdown to select the instance, whereas right now they're selecting a property ID. Selecting by name seems to make more sense to me. He agreed.

Also, I set up the passing of org ID into the `configure` command. I was doing some locally hardcoded stuff to make it work previously. I probably should have done this in a different PR, but alas, I got carried away.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-33751
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The name, which is used for the global method on window, seems much more like a primary identifier of an instance that the property ID we pass through configuration.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Automated and manual
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
