### PR TITLE
Use name in accordion header instead of property ID.

### DIFF
--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -221,7 +221,7 @@ const Configuration = () => {
                       {values.instances.map((instance, index) => (
                         <AccordionItem
                           key={index}
-                          header={instance.propertyId || "untitled instance"}
+                          header={instance.name || "unnamed instance"}
                         >
                           <div>
                             <label

--- a/test/functional/configuration.spec.js
+++ b/test/functional/configuration.spec.js
@@ -123,7 +123,7 @@ test("initializes form fields with full settings", async t => {
   await instances[0].specificContext.environmentField.expectUnchecked(t);
   await instances[0].specificContext.placeContextField.expectChecked(t);
 
-  await accordion.clickHeader(t, "PR456");
+  await accordion.clickHeader(t, "ALLOY2");
 
   await instances[1].nameField.expectValue(t, "alloy2");
   await instances[1].propertyIdField.expectValue(t, "PR456");
@@ -257,10 +257,12 @@ test("shows errors for duplicate property IDs", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
   await addInstanceButton.click(t);
+  // Make accordion header label unique
+  await instances[1].nameField.typeText(t, "2");
   await instances[1].propertyIdField.typeText(t, "PR123");
   // We'll expand the first instance before we validate to test that
   // validation expands the invalid instance (in this case, the second one)
-  await accordion.clickHeader(t, "PR123");
+  await accordion.clickHeader(t, "ALLOY");
   await extensionViewController.expectIsNotValid(t);
   await instances[1].propertyIdField.expectError(t);
 });
@@ -272,7 +274,9 @@ test("shows errors for duplicate names", async t => {
   await instances[1].propertyIdField.typeText(t, "PR456");
   // We'll expand the first instance before we validate to test that
   // validation expands the invalid instance (in this case, the second one)
-  await accordion.clickHeader(t, "PR123");
+  // Even though both accordion header labels are "alloy", this
+  // will select the first one.
+  await accordion.clickHeader(t, "ALLOY");
   await extensionViewController.expectIsNotValid(t);
   await instances[1].nameField.expectError(t);
 });
@@ -299,8 +303,10 @@ test("deletes an instance", async t => {
   await t.expect(instances[0].deleteButton.exists).notOk();
   await addInstanceButton.click(t);
   await t.expect(instances[1].deleteButton.selector.exists).ok();
+  // Make accordion header label unique
+  await instances[1].nameField.typeText(t, "2");
   await instances[1].propertyIdField.typeText(t, "PR456");
-  await accordion.clickHeader(t, "PR123");
+  await accordion.clickHeader(t, "ALLOY");
   await instances[0].deleteButton.click(t);
   // Ensure that clicking cancel doesn't delete anything.
   await resourceUsageDialog.clickCancel(t);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I should have done this in a previous PR, but this change makes the accordion headers in the extension configuration reflect the instance name and not the property ID.

<!--- Describe your changes in detail -->

## Related Issue
None.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Since name is treated as the primary key for an instance now, it makes sense to use it for the accordion header label. Remember, in the Send Event action, users now select the instance by its name and not property ID.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
