### PR TITLE
Removed upload npm script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Several npm scripts have been provided for assisting in development. Each script
 When you attempt to commit code changes, several of the above tasks will be run automatically to help ensure that your changes pass tests and are consistent with agreed-upon standards.
 
 Thank you for your interest in contributing! 
+
+## Uploading
+
+To upload the extension, you will first need to create an integration in [Adobe I/O](https://console.adobe.io). Once an integration has been created, use the [Launch Extension Uploader Tool](https://www.npmjs.com/package/@adobe/reactor-uploader) to upload the extension. For more information, please see the [Submissions documentation](https://developer.adobelaunch.com/extensions/submissions/) provided by Launch.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build": "./scripts/build.js",
     "build:prod": "NODE_ENV=production npm run build",
     "package": "npm run build:prod && npx @adobe/reactor-packager",
-    "upload": "npm run package && npx @adobe/reactor-uploader --org-id=97D1F3F459CE0AD80A495CBE@AdobeOrg --tech-account-id=4D7A358D5CF82F220A495FB1@techacct.adobe.com --api-key=e1d9c2679ab1428399bd2cbb3dd2668d",
     "dev": "./scripts/dev.js",
     "lint": "eslint \"*.js\" \"src/**/*.{js,jsx}\" \"test/**/*.{js,jsx}\"",
     "format": "prettier --write \"*.{js,jsx}\" \"{src,test}/**/*.{js,jsx}\"",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added the `upload` npm script so I could easily upload the extension, but it's specific to my own adobe.io integration. Each person uploading should technically create their own integration. As such, I'm removing it from package.json and I'll just have a local script I use for uploading.
<!--- Describe your changes in detail -->

## Related Issue
None
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Not taint public code with things specific to me.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
