### PR TITLE
Fixed prehidingStyle button to open editor configured for CSS.

### DIFF
--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -344,6 +344,7 @@ const Configuration = () => {
                                 id="prehidingStyleField"
                                 name={`instances.${index}.prehidingStyle`}
                                 component={EditorButton}
+                                language="css"
                               />
                             </div>
                           </div>

--- a/test/functional/configuration.spec.js
+++ b/test/functional/configuration.spec.js
@@ -196,8 +196,13 @@ test("returns full valid settings", async t => {
     t,
     {},
     {
-      openCodeEditor() {
-        return Promise.resolve("#container { display: none }");
+      openCodeEditor(options) {
+        return Promise.resolve(
+          // We include options.language in the result
+          // just so we can assert that the code editor
+          // was properly configured for editing CSS
+          `#container { display: none } // ${options.language}`
+        );
       }
     }
   );
@@ -232,7 +237,7 @@ test("returns full valid settings", async t => {
         idSyncsEnabled: false,
         idSyncContainerId: 123,
         destinationsEnabled: false,
-        prehidingStyle: "#container { display: none }"
+        prehidingStyle: "#container { display: none } // css"
       },
       {
         name: "alloy2",
@@ -317,47 +322,4 @@ test("deletes an instance", async t => {
   await resourceUsageDialog.expectTitle(t, "Resource Usage");
   await resourceUsageDialog.clickConfirm(t);
   await instances[0].propertyIdField.expectValue(t, "PR456");
-});
-
-test("opens CSS code editor for editing prehiding style", async t => {
-  // The sandbox we use for testing doesn't have a real code editor
-  // that replicates what the Launch UI uses. As such, testing that
-  // the prehidingStyle editor button opens a code editor configured
-  // for editing CSS is not as trivial as it should be, so we're going
-  // to abuse the openCodeEditor API to just return the options that were
-  // passed in (instead of an actual string of code) and then abuse our
-  // form and settings system to validate that the object is as expected.
-  // Don't try this at home.
-  await extensionViewController.init(
-    t,
-    {
-      settings: {
-        instances: [
-          {
-            name: "alloy",
-            propertyId: "PR123",
-            prehidingStyle: "#container { display: none }"
-          }
-        ]
-      }
-    },
-    {
-      openCodeEditor(options) {
-        return Promise.resolve(options);
-      }
-    }
-  );
-  await instances[0].prehidingStyleField.click(t);
-  await extensionViewController.expectSettings(t, {
-    instances: [
-      {
-        name: "alloy",
-        propertyId: "PR123",
-        prehidingStyle: {
-          code: "#container { display: none }",
-          language: "css"
-        }
-      }
-    ]
-  });
 });

--- a/test/functional/configuration.spec.js
+++ b/test/functional/configuration.spec.js
@@ -318,3 +318,46 @@ test("deletes an instance", async t => {
   await resourceUsageDialog.clickConfirm(t);
   await instances[0].propertyIdField.expectValue(t, "PR456");
 });
+
+test("opens CSS code editor for editing prehiding style", async t => {
+  // The sandbox we use for testing doesn't have a real code editor
+  // that replicates what the Launch UI uses. As such, testing that
+  // the prehidingStyle editor button opens a code editor configured
+  // for editing CSS is not as trivial as it should be, so we're going
+  // to abuse the openCodeEditor API to just return the options that were
+  // passed in (instead of an actual string of code) and then abuse our
+  // form and settings system to validate that the object is as expected.
+  // Don't try this at home.
+  await extensionViewController.init(
+    t,
+    {
+      settings: {
+        instances: [
+          {
+            name: "alloy",
+            propertyId: "PR123",
+            prehidingStyle: "#container { display: none }"
+          }
+        ]
+      }
+    },
+    {
+      openCodeEditor(options) {
+        return Promise.resolve(options);
+      }
+    }
+  );
+  await instances[0].prehidingStyleField.click(t);
+  await extensionViewController.expectSettings(t, {
+    instances: [
+      {
+        name: "alloy",
+        propertyId: "PR123",
+        prehidingStyle: {
+          code: "#container { display: none }",
+          language: "css"
+        }
+      }
+    ]
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When opening the code editor for `prehidingStyle`, configure it for CSS editing.
<!--- Describe your changes in detail -->

## Related Issue
None. 😢 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Users are editing CSS so they should have CSS highlighting, linting, etc.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
