### PR TITLE
CORE-33720 Added Set Opt-In Preferences action type.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -107,6 +107,34 @@
       },
       "libPath": "dist/lib/actions/sendEvent/index.js",
       "viewPath": "actions/sendEvent.html"
+    },
+    {
+      "displayName": "Set Opt-In Preferences",
+      "name": "set-opt-in-preferences",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "instanceName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "purposes": {
+            "type": "string",
+            "enum": [
+              "all",
+              "none"
+            ]
+          }
+        },
+        "required": [
+          "instanceName",
+          "purposes"
+        ],
+        "additionalProperties": false
+      },
+      "libPath": "dist/lib/actions/setOptInPreferences/index.js",
+      "viewPath": "actions/setOptInPreferences.html"
     }
   ],
   "dataElements": [

--- a/src/lib/actions/setOptInPreferences/createSetOptInPreferences.js
+++ b/src/lib/actions/setOptInPreferences/createSetOptInPreferences.js
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = instanceManager => settings => {
+  const { instanceName, ...otherSettings } = settings;
+  const instanceAccessor = instanceManager.getAccessor(instanceName);
+
+  if (instanceAccessor) {
+    instanceAccessor.instance("optIn", otherSettings);
+  } else {
+    turbine.logger.error(
+      `Failed to set opt-in preferences for instance "${instanceName}". No matching instance was configured with this name.`
+    );
+  }
+};

--- a/src/lib/actions/setOptInPreferences/index.js
+++ b/src/lib/actions/setOptInPreferences/index.js
@@ -1,0 +1,16 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const createSetOptInPreferences = require("./createSetOptInPreferences");
+const instanceManager = require("../../instanceManager/index");
+
+module.exports = createSetOptInPreferences(instanceManager);

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -24,18 +24,13 @@ import InfoTip from "../components/infoTip";
 import getInstanceOptions from "../utils/getInstanceOptions";
 import "./sendEvent.styl";
 
-const getInitialValues = settings => {
-  // settings is null if the user is creating a new rule component
-  if (!settings) {
-    settings = {};
-  }
-
+const getInitialValues = initInfo => {
   const {
-    instanceName = "",
+    instanceName = initInfo.extensionSettings.instances[0].name,
     viewStart = false,
     data = "",
     eventMergeId = ""
-  } = settings;
+  } = initInfo.settings || {};
 
   return {
     instanceName,
@@ -65,7 +60,6 @@ const getSettings = values => {
 
 const invalidDataMessage = "Please specify a data element";
 const validationSchema = object().shape({
-  instanceName: string().required("Please specify an instance"),
   data: string()
     .required(invalidDataMessage)
     .matches(/^%([^%]+)%$/, invalidDataMessage)

--- a/src/view/actions/setOptInPreferences.html
+++ b/src/view/actions/setOptInPreferences.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Extension View</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
+    <script src="./setOptInPreferences.jsx"></script>
+  </body>
+</html>

--- a/src/view/actions/setOptInPreferences.jsx
+++ b/src/view/actions/setOptInPreferences.jsx
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import "regenerator-runtime"; // needed for some of react-spectrum
+import React from "react";
+import Alert from "@react/react-spectrum/Alert";
+import Select from "@react/react-spectrum/Select";
+import RadioGroup from "@react/react-spectrum/RadioGroup";
+import Radio from "@react/react-spectrum/Radio";
+import "@react/react-spectrum/Form"; // needed for spectrum form styles
+import render from "../render";
+import WrappedField from "../components/wrappedField";
+import ExtensionView from "../components/extensionView";
+import getInstanceOptions from "../utils/getInstanceOptions";
+import "./setOptInPreferences.styl";
+
+const purposesEnum = {
+  ALL: "all",
+  NONE: "none"
+};
+
+const getInitialValues = initInfo => {
+  const {
+    instanceName = initInfo.extensionSettings.instances[0].name,
+    purposes = purposesEnum.ALL
+  } = initInfo.settings || {};
+
+  return {
+    instanceName,
+    purposes
+  };
+};
+
+const getSettings = values => values;
+
+const isOptInEnabled = (initInfo, formikProps) => {
+  const matchingInstance = initInfo.extensionSettings.instances.find(
+    instance => instance.name === formikProps.values.instanceName
+  );
+  return matchingInstance ? matchingInstance.optInEnabled : false;
+};
+
+const SetOptInPreferences = () => {
+  return (
+    <ExtensionView
+      getInitialValues={getInitialValues}
+      getSettings={getSettings}
+      render={({ initInfo, formikProps }) => {
+        return (
+          <div>
+            {isOptInEnabled(initInfo, formikProps) ? null : (
+              <div>
+                <Alert header="Opt-In Not Enabled" variant="warning">
+                  Before Opt-In preferences can be set, Opt-In must be enabled
+                  for the instance within the extension configuration.
+                </Alert>
+              </div>
+            )}
+            <div>
+              <label
+                htmlFor="instanceNameField"
+                className="spectrum-Form-itemLabel"
+              >
+                Instance
+              </label>
+              <div>
+                <WrappedField
+                  id="instanceNameField"
+                  name="instanceName"
+                  component={Select}
+                  componentClassName="u-fieldLong"
+                  options={getInstanceOptions(initInfo)}
+                />
+              </div>
+            </div>
+            <div className="u-gapTop">
+              <label
+                htmlFor="purposesField"
+                className="spectrum-Form-itemLabel"
+              >
+                The user has opted into:
+              </label>
+              <WrappedField
+                id="purposesField"
+                name="purposes"
+                component={RadioGroup}
+                componentClassName="u-flexColumn"
+              >
+                <Radio value={purposesEnum.ALL} label="All purposes" />
+                <Radio value={purposesEnum.NONE} label="No purposes" />
+              </WrappedField>
+            </div>
+          </div>
+        );
+      }}
+    />
+  );
+};
+
+render(SetOptInPreferences);

--- a/src/view/actions/setOptInPreferences.styl
+++ b/src/view/actions/setOptInPreferences.styl
@@ -1,0 +1,13 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import "../global";

--- a/src/view/components/extensionView.jsx
+++ b/src/view/components/extensionView.jsx
@@ -37,7 +37,7 @@ const ExtensionView = ({
       init: _initInfo => {
         setState({
           initialized: true,
-          initialValues: getInitialValues(_initInfo.settings),
+          initialValues: getInitialValues(_initInfo),
           initInfo: _initInfo
         });
       },

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -32,7 +32,7 @@ import EditorButton from "../components/editorButton";
 import copyPropertiesIfNotDefault from "./utils/copyPropertiesIfNotDefault";
 import "./configuration.styl";
 
-const contextGranularity = {
+const contextGranularityEnum = {
   ALL: "all",
   SPECIFIC: "specific"
 };
@@ -48,25 +48,20 @@ const instanceDefaults = {
   idSyncContainerId: "",
   destinationsEnabled: true,
   prehidingStyle: "",
-  contextGranularity: contextGranularity.ALL,
+  contextGranularity: contextGranularityEnum.ALL,
   context: contextOptions
 };
 
 const createDefaultInstance = () =>
   JSON.parse(JSON.stringify(instanceDefaults));
 
-const getInitialValues = settings => {
-  // settings is null if the user is creating a new rule component
-  if (!settings) {
-    settings = {};
-  }
-
-  let { instances } = settings;
+const getInitialValues = initInfo => {
+  let { instances } = initInfo.settings || {};
 
   if (instances) {
     instances.forEach(instance => {
       if (instance.context) {
-        instance.contextGranularity = contextGranularity.SPECIFIC;
+        instance.contextGranularity = contextGranularityEnum.SPECIFIC;
       }
 
       // Copy default values to the instance if the properties
@@ -111,7 +106,7 @@ const getSettings = values => {
         );
       }
 
-      if (instance.contextGranularity === contextGranularity.SPECIFIC) {
+      if (instance.contextGranularity === contextGranularityEnum.SPECIFIC) {
         trimmedInstance.context = instance.context;
       }
 
@@ -353,28 +348,29 @@ const Configuration = () => {
 
                           <div className="u-gapTop">
                             <label
-                              htmlFor="contextGranularity"
+                              htmlFor="contextGranularityField"
                               className="spectrum-Form-itemLabel"
                             >
                               When sending event data, automatically include:
                             </label>
                             <WrappedField
+                              id="contextGranularityField"
                               name={`instances.${index}.contextGranularity`}
                               component={RadioGroup}
                               componentClassName="u-flexColumn"
                             >
                               <Radio
-                                value={contextGranularity.ALL}
+                                value={contextGranularityEnum.ALL}
                                 label="all context information"
                               />
                               <Radio
-                                value={contextGranularity.SPECIFIC}
+                                value={contextGranularityEnum.SPECIFIC}
                                 label="specific context information"
                               />
                             </WrappedField>
                           </div>
                           {values.instances[index].contextGranularity ===
-                          contextGranularity.SPECIFIC ? (
+                          contextGranularityEnum.SPECIFIC ? (
                             <div className="FieldSubset u-gapTop">
                               <WrappedField
                                 name={`instances.${index}.context`}

--- a/src/view/dataElements/instanceNameOnly.jsx
+++ b/src/view/dataElements/instanceNameOnly.jsx
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import "regenerator-runtime"; // needed for some of react-spectrum
 import React from "react";
-import { object, string } from "yup";
 import Select from "@react/react-spectrum/Select";
 import "@react/react-spectrum/Form"; // needed for spectrum form styles
 import render from "../render";
@@ -21,13 +20,9 @@ import ExtensionView from "../components/extensionView";
 import getInstanceOptions from "../utils/getInstanceOptions";
 import "./instanceNameOnly.styl";
 
-const getInitialValues = settings => {
-  // settings is null if the user is creating a new data element
-  if (!settings) {
-    settings = {};
-  }
-
-  const { instanceName = "" } = settings;
+const getInitialValues = initInfo => {
+  const { instanceName = initInfo.extensionSettings.instances[0].name } =
+    initInfo.settings || {};
 
   return {
     instanceName
@@ -40,16 +35,11 @@ const getSettings = values => {
   };
 };
 
-const validationSchema = object().shape({
-  instanceName: string().required("Please specify an instance")
-});
-
 const InstanceNameOnly = () => {
   return (
     <ExtensionView
       getInitialValues={getInitialValues}
       getSettings={getSettings}
-      validationSchema={validationSchema}
       render={({ initInfo }) => {
         return (
           <div>

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -28,6 +28,10 @@ const mockExtensionSettings = {
     {
       name: "alloy1",
       propertyId: "PR123"
+    },
+    {
+      name: "alloy2",
+      propertyId: "PR456"
     }
   ]
 };
@@ -42,13 +46,13 @@ test("initializes form fields with full settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings,
     settings: {
-      instanceName: "alloy1",
+      instanceName: "alloy2",
       viewStart: true,
       data: "%myDataLayer%",
       eventMergeId: "%myEventMergeId%"
     }
   });
-  await instanceNameField.expectValue(t, "alloy1");
+  await instanceNameField.expectValue(t, "alloy2");
   await viewStartField.expectChecked(t);
   await dataField.expectValue(t, "%myDataLayer%");
   await eventMergeIdField.expectValue(t, "%myEventMergeId%");
@@ -72,7 +76,7 @@ test("initializes form fields with no settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings
   });
-  await instanceNameField.expectValue(t, "");
+  await instanceNameField.expectValue(t, "alloy1");
   await viewStartField.expectUnchecked(t);
   await dataField.expectValue(t, "");
   await eventMergeIdField.expectValue(t, "");
@@ -83,7 +87,6 @@ test("returns minimal valid settings", async t => {
     extensionSettings: mockExtensionSettings
   });
 
-  await instanceNameField.selectOption(t, "alloy1");
   await dataField.typeText(t, "%myDataLayer%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
@@ -96,13 +99,13 @@ test("returns full valid settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings
   });
-  await instanceNameField.selectOption(t, "alloy1");
+  await instanceNameField.selectOption(t, "alloy2");
   await viewStartField.click(t);
   await dataField.typeText(t, "%myDataLayer%");
   await eventMergeIdField.typeText(t, "%myEventMergeId%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
-    instanceName: "alloy1",
+    instanceName: "alloy2",
     viewStart: true,
     data: "%myDataLayer%",
     eventMergeId: "%myEventMergeId%"
@@ -114,16 +117,12 @@ test("shows errors for empty required values", async t => {
     extensionSettings: mockExtensionSettings
   });
   await extensionViewController.expectIsNotValid(t);
-  await instanceNameField.expectError(t);
   await dataField.expectError(t);
 });
 
 test("shows error for data value that is not a data element", async t => {
   await extensionViewController.init(t, {
-    extensionSettings: mockExtensionSettings,
-    settings: {
-      instanceName: "alloy1"
-    }
+    extensionSettings: mockExtensionSettings
   });
   await dataField.typeText(t, "myDataLayer");
   await extensionViewController.expectIsNotValid(t);
@@ -132,10 +131,7 @@ test("shows error for data value that is not a data element", async t => {
 
 test("shows error for data value that is more than one data element", async t => {
   await extensionViewController.init(t, {
-    extensionSettings: mockExtensionSettings,
-    settings: {
-      instanceName: "alloy1"
-    }
+    extensionSettings: mockExtensionSettings
   });
   await dataField.typeText(t, "%a%%b%");
   await extensionViewController.expectIsNotValid(t);

--- a/test/functional/actions/setOptInPreferences.js
+++ b/test/functional/actions/setOptInPreferences.js
@@ -1,0 +1,108 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Selector } from "testcafe";
+import createExtensionViewController from "../helpers/createExtensionViewController";
+import spectrum from "../helpers/spectrum";
+import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
+
+const extensionViewController = createExtensionViewController(
+  "actions/setOptInPreferences.html"
+);
+const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
+const purposesFields = {
+  allField: spectrum.radio(Selector(`[name='purposes'][value=all]`)),
+  noneField: spectrum.radio(Selector(`[name='purposes'][value=none]`))
+};
+const warning = spectrum.alert(Selector(`.spectrum-Alert`));
+
+const mockExtensionSettings = {
+  instances: [
+    {
+      name: "alloy1",
+      propertyId: "PR123"
+    },
+    {
+      name: "alloy2",
+      propertyId: "PR456",
+      optInEnabled: true
+    }
+  ]
+};
+
+// disablePageReloads is not a publicized feature, but it sure helps speed up tests.
+// https://github.com/DevExpress/testcafe/issues/1770
+fixture("Set Opt-In Preferences View").disablePageReloads.page(
+  "http://localhost:3000/viewSandbox.html"
+);
+
+test("initializes form fields with settings", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy2",
+      purposes: "none"
+    }
+  });
+  await instanceNameField.expectValue(t, "alloy2");
+  await purposesFields.allField.expectUnchecked(t);
+  await purposesFields.noneField.expectChecked(t);
+});
+
+test("initializes form fields with no settings", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+  await instanceNameField.expectValue(t, "alloy1");
+  await purposesFields.allField.expectChecked(t);
+  await purposesFields.noneField.expectUnchecked(t);
+});
+
+test("returns valid settings", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+
+  await instanceNameField.selectOption(t, "alloy2");
+  await purposesFields.noneField.click(t);
+  await extensionViewController.expectIsValid(t);
+  await extensionViewController.expectSettings(t, {
+    instanceName: "alloy2",
+    purposes: "none"
+  });
+});
+
+test("shows warning if opt-in is not enabled", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy1",
+      purposes: "all"
+    }
+  });
+
+  await warning.expectTitle(t, "Opt-In Not Enabled");
+});
+
+test("does not show warning if opt-in is enabled", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy2",
+      purposes: "all"
+    }
+  });
+
+  await warning.expectNotExists(t);
+});
+
+testInstanceNameOptions(extensionViewController, instanceNameField);

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -305,9 +305,9 @@ test("shows error for non-integer ID sync container ID", async t => {
 test("deletes an instance", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
-  await t.expect(instances[0].deleteButton.exists).notOk();
+  await instances[0].deleteButton.expectNotExists(t);
   await addInstanceButton.click(t);
-  await t.expect(instances[1].deleteButton.selector.exists).ok();
+  await instances[1].deleteButton.expectExists(t);
   // Make accordion header label unique
   await instances[1].nameField.typeText(t, "2");
   await instances[1].propertyIdField.typeText(t, "PR456");
@@ -315,7 +315,7 @@ test("deletes an instance", async t => {
   await instances[0].deleteButton.click(t);
   // Ensure that clicking cancel doesn't delete anything.
   await resourceUsageDialog.clickCancel(t);
-  await t.expect(resourceUsageDialog.selector.exists).notOk();
+  await resourceUsageDialog.expectNotExists(t);
   await instances[0].propertyIdField.expectValue(t, "PR123");
   // Alright, delete for real.
   await instances[0].deleteButton.click(t);

--- a/test/functional/helpers/spectrum.js
+++ b/test/functional/helpers/spectrum.js
@@ -186,6 +186,7 @@ const componentWrappers = {
   }
 };
 
+// This adds certain properties to all component wrappers.
 Object.keys(componentWrappers).forEach(componentName => {
   const componentWrapper = componentWrappers[componentName];
   componentWrappers[componentName] = selector => {

--- a/test/functional/helpers/testInstanceNameOnlyView.js
+++ b/test/functional/helpers/testInstanceNameOnlyView.js
@@ -9,6 +9,10 @@ const mockExtensionSettings = {
     {
       name: "alloy1",
       propertyId: "PR123"
+    },
+    {
+      name: "alloy2",
+      propertyId: "PR456"
     }
   ]
 };
@@ -18,36 +22,28 @@ export default extensionViewController => {
     await extensionViewController.init(t, {
       extensionSettings: mockExtensionSettings,
       settings: {
-        instanceName: "alloy1"
+        instanceName: "alloy2"
       }
     });
-    await instanceNameField.expectValue(t, "alloy1");
+    await instanceNameField.expectValue(t, "alloy2");
   });
 
   test("initializes form fields with no settings", async t => {
     await extensionViewController.init(t, {
       extensionSettings: mockExtensionSettings
     });
-    await instanceNameField.expectValue(t, "");
+    await instanceNameField.expectValue(t, "alloy1");
   });
 
   test("returns full valid settings", async t => {
     await extensionViewController.init(t, {
       extensionSettings: mockExtensionSettings
     });
-    await instanceNameField.selectOption(t, "alloy1");
+    await instanceNameField.selectOption(t, "alloy2");
     await extensionViewController.expectIsValid(t);
     await extensionViewController.expectSettings(t, {
-      instanceName: "alloy1"
+      instanceName: "alloy2"
     });
-  });
-
-  test("shows errors for empty required values", async t => {
-    await extensionViewController.init(t, {
-      extensionSettings: mockExtensionSettings
-    });
-    await extensionViewController.expectIsNotValid(t);
-    await instanceNameField.expectError(t);
   });
 
   testInstanceNameOptions(extensionViewController, instanceNameField);

--- a/test/unit/lib/actions/setOptInPreferences/createSetOptInPreferences.js
+++ b/test/unit/lib/actions/setOptInPreferences/createSetOptInPreferences.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createSetOptInPreferences from "../../../../../src/lib/actions/setOptInPreferences/createSetOptInPreferences";
+import turbineVariable from "../../../helpers/turbineVariable";
+
+describe("Set Opt-In Preferences", () => {
+  let mockLogger;
+
+  beforeEach(() => {
+    mockLogger = {
+      error: jasmine.createSpy()
+    };
+    turbineVariable.mock({
+      logger: mockLogger
+    });
+  });
+
+  afterEach(() => {
+    turbineVariable.reset();
+  });
+
+  ["all", "none"].forEach(purposes => {
+    it(`executes optIn command with "${purposes}" purposes`, () => {
+      const instance = jasmine.createSpy();
+      const instanceManager = {
+        getAccessor: jasmine.createSpy().and.returnValue({
+          instance
+        })
+      };
+      const action = createSetOptInPreferences(instanceManager);
+
+      action({
+        instanceName: "myinstance",
+        purposes
+      });
+
+      expect(instanceManager.getAccessor).toHaveBeenCalledWith("myinstance");
+      expect(instance).toHaveBeenCalledWith("optIn", {
+        purposes
+      });
+    });
+  });
+
+  it("logs an error when no matching instance found", () => {
+    const instanceManager = {
+      getAccessor() {
+        return undefined;
+      }
+    };
+    const action = createSetOptInPreferences(instanceManager);
+
+    action({
+      instanceName: "myinstance",
+      purposes: "none"
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed to send event for instance "myinstance". No matching instance was configured with this name.'
+    );
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds Set Opt-In Preferences action type. I also made a change across several of the views where, if a user is creating an action or data element (instead of editing an existing one), we now auto-select the first configured instance on their behalf. This makes for fewer user clicks and also ensures that an instance will always be selected, which simplifies validation.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-33720
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Customers need to convey user opt-in preferences to Alloy.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
