### PR TITLE
Auto-select first instance name.

### DIFF
--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -24,18 +24,13 @@ import InfoTip from "../components/infoTip";
 import getInstanceOptions from "../utils/getInstanceOptions";
 import "./sendEvent.styl";
 
-const getInitialValues = settings => {
-  // settings is null if the user is creating a new rule component
-  if (!settings) {
-    settings = {};
-  }
-
+const getInitialValues = initInfo => {
   const {
-    instanceName = "",
+    instanceName = initInfo.extensionSettings.instances[0].name,
     viewStart = false,
     data = "",
     eventMergeId = ""
-  } = settings;
+  } = initInfo.settings || {};
 
   return {
     instanceName,
@@ -65,7 +60,6 @@ const getSettings = values => {
 
 const invalidDataMessage = "Please specify a data element";
 const validationSchema = object().shape({
-  instanceName: string().required("Please specify an instance"),
   data: string()
     .required(invalidDataMessage)
     .matches(/^%([^%]+)%$/, invalidDataMessage)

--- a/src/view/components/extensionView.jsx
+++ b/src/view/components/extensionView.jsx
@@ -37,7 +37,7 @@ const ExtensionView = ({
       init: _initInfo => {
         setState({
           initialized: true,
-          initialValues: getInitialValues(_initInfo.settings),
+          initialValues: getInitialValues(_initInfo),
           initInfo: _initInfo
         });
       },

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -32,7 +32,7 @@ import EditorButton from "../components/editorButton";
 import copyPropertiesIfNotDefault from "./utils/copyPropertiesIfNotDefault";
 import "./configuration.styl";
 
-const contextGranularity = {
+const contextGranularityEnum = {
   ALL: "all",
   SPECIFIC: "specific"
 };
@@ -48,25 +48,20 @@ const instanceDefaults = {
   idSyncContainerId: "",
   destinationsEnabled: true,
   prehidingStyle: "",
-  contextGranularity: contextGranularity.ALL,
+  contextGranularity: contextGranularityEnum.ALL,
   context: contextOptions
 };
 
 const createDefaultInstance = () =>
   JSON.parse(JSON.stringify(instanceDefaults));
 
-const getInitialValues = settings => {
-  // settings is null if the user is creating a new rule component
-  if (!settings) {
-    settings = {};
-  }
-
-  let { instances } = settings;
+const getInitialValues = initInfo => {
+  let { instances } = initInfo.settings || {};
 
   if (instances) {
     instances.forEach(instance => {
       if (instance.context) {
-        instance.contextGranularity = contextGranularity.SPECIFIC;
+        instance.contextGranularity = contextGranularityEnum.SPECIFIC;
       }
 
       // Copy default values to the instance if the properties
@@ -111,7 +106,7 @@ const getSettings = values => {
         );
       }
 
-      if (instance.contextGranularity === contextGranularity.SPECIFIC) {
+      if (instance.contextGranularity === contextGranularityEnum.SPECIFIC) {
         trimmedInstance.context = instance.context;
       }
 
@@ -353,28 +348,29 @@ const Configuration = () => {
 
                           <div className="u-gapTop">
                             <label
-                              htmlFor="contextGranularity"
+                              htmlFor="contextGranularityField"
                               className="spectrum-Form-itemLabel"
                             >
                               When sending event data, automatically include:
                             </label>
                             <WrappedField
+                              id="contextGranularityField"
                               name={`instances.${index}.contextGranularity`}
                               component={RadioGroup}
                               componentClassName="u-flexColumn"
                             >
                               <Radio
-                                value={contextGranularity.ALL}
+                                value={contextGranularityEnum.ALL}
                                 label="all context information"
                               />
                               <Radio
-                                value={contextGranularity.SPECIFIC}
+                                value={contextGranularityEnum.SPECIFIC}
                                 label="specific context information"
                               />
                             </WrappedField>
                           </div>
                           {values.instances[index].contextGranularity ===
-                          contextGranularity.SPECIFIC ? (
+                          contextGranularityEnum.SPECIFIC ? (
                             <div className="FieldSubset u-gapTop">
                               <WrappedField
                                 name={`instances.${index}.context`}

--- a/src/view/dataElements/instanceNameOnly.jsx
+++ b/src/view/dataElements/instanceNameOnly.jsx
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import "regenerator-runtime"; // needed for some of react-spectrum
 import React from "react";
-import { object, string } from "yup";
 import Select from "@react/react-spectrum/Select";
 import "@react/react-spectrum/Form"; // needed for spectrum form styles
 import render from "../render";
@@ -21,13 +20,9 @@ import ExtensionView from "../components/extensionView";
 import getInstanceOptions from "../utils/getInstanceOptions";
 import "./instanceNameOnly.styl";
 
-const getInitialValues = settings => {
-  // settings is null if the user is creating a new data element
-  if (!settings) {
-    settings = {};
-  }
-
-  const { instanceName = "" } = settings;
+const getInitialValues = initInfo => {
+  const { instanceName = initInfo.extensionSettings.instances[0].name } =
+    initInfo.settings || {};
 
   return {
     instanceName
@@ -40,16 +35,11 @@ const getSettings = values => {
   };
 };
 
-const validationSchema = object().shape({
-  instanceName: string().required("Please specify an instance")
-});
-
 const InstanceNameOnly = () => {
   return (
     <ExtensionView
       getInitialValues={getInitialValues}
       getSettings={getSettings}
-      validationSchema={validationSchema}
       render={({ initInfo }) => {
         return (
           <div>

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -28,6 +28,10 @@ const mockExtensionSettings = {
     {
       name: "alloy1",
       propertyId: "PR123"
+    },
+    {
+      name: "alloy2",
+      propertyId: "PR456"
     }
   ]
 };
@@ -42,13 +46,13 @@ test("initializes form fields with full settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings,
     settings: {
-      instanceName: "alloy1",
+      instanceName: "alloy2",
       viewStart: true,
       data: "%myDataLayer%",
       eventMergeId: "%myEventMergeId%"
     }
   });
-  await instanceNameField.expectValue(t, "alloy1");
+  await instanceNameField.expectValue(t, "alloy2");
   await viewStartField.expectChecked(t);
   await dataField.expectValue(t, "%myDataLayer%");
   await eventMergeIdField.expectValue(t, "%myEventMergeId%");
@@ -72,7 +76,7 @@ test("initializes form fields with no settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings
   });
-  await instanceNameField.expectValue(t, "");
+  await instanceNameField.expectValue(t, "alloy1");
   await viewStartField.expectUnchecked(t);
   await dataField.expectValue(t, "");
   await eventMergeIdField.expectValue(t, "");
@@ -83,7 +87,6 @@ test("returns minimal valid settings", async t => {
     extensionSettings: mockExtensionSettings
   });
 
-  await instanceNameField.selectOption(t, "alloy1");
   await dataField.typeText(t, "%myDataLayer%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
@@ -96,13 +99,13 @@ test("returns full valid settings", async t => {
   await extensionViewController.init(t, {
     extensionSettings: mockExtensionSettings
   });
-  await instanceNameField.selectOption(t, "alloy1");
+  await instanceNameField.selectOption(t, "alloy2");
   await viewStartField.click(t);
   await dataField.typeText(t, "%myDataLayer%");
   await eventMergeIdField.typeText(t, "%myEventMergeId%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
-    instanceName: "alloy1",
+    instanceName: "alloy2",
     viewStart: true,
     data: "%myDataLayer%",
     eventMergeId: "%myEventMergeId%"
@@ -114,16 +117,12 @@ test("shows errors for empty required values", async t => {
     extensionSettings: mockExtensionSettings
   });
   await extensionViewController.expectIsNotValid(t);
-  await instanceNameField.expectError(t);
   await dataField.expectError(t);
 });
 
 test("shows error for data value that is not a data element", async t => {
   await extensionViewController.init(t, {
-    extensionSettings: mockExtensionSettings,
-    settings: {
-      instanceName: "alloy1"
-    }
+    extensionSettings: mockExtensionSettings
   });
   await dataField.typeText(t, "myDataLayer");
   await extensionViewController.expectIsNotValid(t);
@@ -132,10 +131,7 @@ test("shows error for data value that is not a data element", async t => {
 
 test("shows error for data value that is more than one data element", async t => {
   await extensionViewController.init(t, {
-    extensionSettings: mockExtensionSettings,
-    settings: {
-      instanceName: "alloy1"
-    }
+    extensionSettings: mockExtensionSettings
   });
   await dataField.typeText(t, "%a%%b%");
   await extensionViewController.expectIsNotValid(t);

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -305,9 +305,9 @@ test("shows error for non-integer ID sync container ID", async t => {
 test("deletes an instance", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
-  await t.expect(instances[0].deleteButton.exists).notOk();
+  await instances[0].deleteButton.expectNotExists(t);
   await addInstanceButton.click(t);
-  await t.expect(instances[1].deleteButton.selector.exists).ok();
+  await instances[1].deleteButton.expectExists(t);
   // Make accordion header label unique
   await instances[1].nameField.typeText(t, "2");
   await instances[1].propertyIdField.typeText(t, "PR456");
@@ -315,7 +315,7 @@ test("deletes an instance", async t => {
   await instances[0].deleteButton.click(t);
   // Ensure that clicking cancel doesn't delete anything.
   await resourceUsageDialog.clickCancel(t);
-  await t.expect(resourceUsageDialog.selector.exists).notOk();
+  await resourceUsageDialog.expectNotExists(t);
   await instances[0].propertyIdField.expectValue(t, "PR123");
   // Alright, delete for real.
   await instances[0].deleteButton.click(t);

--- a/test/functional/helpers/spectrum.js
+++ b/test/functional/helpers/spectrum.js
@@ -63,6 +63,16 @@ const createExpectUnchecked = selector => async t => {
   await t.expect(selector.checked).notOk();
 };
 
+const createExpectExists = selector => async t => {
+  await switchToIframe(t);
+  await t.expect(selector.exists).ok();
+};
+
+const createExpectNotExists = selector => async t => {
+  await switchToIframe(t);
+  await t.expect(selector.exists).notOk();
+};
+
 // This provides an abstraction layer on top of react-spectrum
 // in order to keep react-spectrum specifics outside of tests.
 // This abstraction is more valuable for some components (Select, Accordion)
@@ -75,10 +85,9 @@ const createExpectUnchecked = selector => async t => {
 // selector on the returned object, so if we need to do something
 // a bit more custom inside the test, the test can use the selector
 // and TestCafe APIs directly.
-module.exports = {
+const componentWrappers = {
   select(selector) {
     return {
-      selector,
       expectError: createExpectError(selector),
       expectValue: createExpectValue(selector),
       async expectSelectedOptionLabel(t, label) {
@@ -106,7 +115,6 @@ module.exports = {
   },
   textfield(selector) {
     return {
-      selector,
       expectError: createExpectError(selector),
       expectValue: createExpectValue(selector),
       async typeText(t, text) {
@@ -121,7 +129,6 @@ module.exports = {
   },
   checkbox(selector) {
     return {
-      selector,
       expectChecked: createExpectChecked(selector),
       expectUnchecked: createExpectUnchecked(selector),
       click: createClick(selector)
@@ -129,7 +136,6 @@ module.exports = {
   },
   radio(selector) {
     return {
-      selector,
       expectChecked: createExpectChecked(selector),
       expectUnchecked: createExpectUnchecked(selector),
       click: createClick(selector)
@@ -137,7 +143,6 @@ module.exports = {
   },
   accordion(selector) {
     return {
-      selector,
       async clickHeader(t, label) {
         await switchToIframe(t);
         await t.click(
@@ -148,13 +153,11 @@ module.exports = {
   },
   button(selector) {
     return {
-      selector,
       click: createClick(selector)
     };
   },
   dialog(selector) {
     return {
-      selector,
       async expectTitle(t, title) {
         await switchToIframe(t);
         await selector.find(".spectrum-Dialog-header").withText(title);
@@ -172,5 +175,28 @@ module.exports = {
         );
       }
     };
+  },
+  alert(selector) {
+    return {
+      async expectTitle(t, title) {
+        await switchToIframe(t);
+        await selector.find(".spectrum-Alert-header").withText(title);
+      }
+    };
   }
 };
+
+// This adds certain properties to all component wrappers.
+Object.keys(componentWrappers).forEach(componentName => {
+  const componentWrapper = componentWrappers[componentName];
+  componentWrappers[componentName] = selector => {
+    return {
+      ...componentWrapper(selector),
+      selector,
+      expectExists: createExpectExists(selector),
+      expectNotExists: createExpectNotExists(selector)
+    };
+  };
+});
+
+module.exports = componentWrappers;

--- a/test/functional/helpers/testInstanceNameOnlyView.js
+++ b/test/functional/helpers/testInstanceNameOnlyView.js
@@ -9,6 +9,10 @@ const mockExtensionSettings = {
     {
       name: "alloy1",
       propertyId: "PR123"
+    },
+    {
+      name: "alloy2",
+      propertyId: "PR456"
     }
   ]
 };
@@ -18,36 +22,28 @@ export default extensionViewController => {
     await extensionViewController.init(t, {
       extensionSettings: mockExtensionSettings,
       settings: {
-        instanceName: "alloy1"
+        instanceName: "alloy2"
       }
     });
-    await instanceNameField.expectValue(t, "alloy1");
+    await instanceNameField.expectValue(t, "alloy2");
   });
 
   test("initializes form fields with no settings", async t => {
     await extensionViewController.init(t, {
       extensionSettings: mockExtensionSettings
     });
-    await instanceNameField.expectValue(t, "");
+    await instanceNameField.expectValue(t, "alloy1");
   });
 
   test("returns full valid settings", async t => {
     await extensionViewController.init(t, {
       extensionSettings: mockExtensionSettings
     });
-    await instanceNameField.selectOption(t, "alloy1");
+    await instanceNameField.selectOption(t, "alloy2");
     await extensionViewController.expectIsValid(t);
     await extensionViewController.expectSettings(t, {
-      instanceName: "alloy1"
+      instanceName: "alloy2"
     });
-  });
-
-  test("shows errors for empty required values", async t => {
-    await extensionViewController.init(t, {
-      extensionSettings: mockExtensionSettings
-    });
-    await extensionViewController.expectIsNotValid(t);
-    await instanceNameField.expectError(t);
   });
 
   testInstanceNameOptions(extensionViewController, instanceNameField);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This takes code from https://github.com/adobe/reactor-extension-alloy/pull/20 that's still relevant (that PR was closed rather than merged). Specifically, it auto-selects the first instance name from the instance dropdown in the extension views.

In the other PR, @jonsnyder mentioned "Can you add instructions in the readme for how to run the actions in the sandbox? (what to copy and paste and where to put it). Or maybe you can change the default settings that get loaded in the action view of the sandbox." I'll handle that in a separate PR.
<!--- Describe your changes in detail -->

## Related Issue
None.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fewer user clicks, less need for validation.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
