### PR TITLE
CORE-33720 Added Set Opt-In Preferences action type.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -102,6 +102,42 @@
       },
       "libPath": "dist/lib/actions/sendEvent/index.js",
       "viewPath": "actions/sendEvent.html"
+    },
+    {
+      "displayName": "Set Opt-In Preferences",
+      "name": "set-opt-in-preferences",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "instanceName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "purposes": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "none"
+                ]
+              },
+              {
+                "type": "string",
+                "pattern": "^%([^%]+)%$"
+              }
+            ]
+          }
+        },
+        "required": [
+          "instanceName",
+          "purposes"
+        ],
+        "additionalProperties": false
+      },
+      "libPath": "dist/lib/actions/setOptInPreferences/index.js",
+      "viewPath": "actions/setOptInPreferences.html"
     }
   ],
   "dataElements": [

--- a/src/lib/actions/setOptInPreferences/createSetOptInPreferences.js
+++ b/src/lib/actions/setOptInPreferences/createSetOptInPreferences.js
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = instanceManager => settings => {
+  const { instanceName, ...otherSettings } = settings;
+  const instanceAccessor = instanceManager.getAccessor(instanceName);
+
+  if (instanceAccessor) {
+    instanceAccessor.instance("optIn", otherSettings);
+  } else {
+    turbine.logger.error(
+      `Failed to set opt-in preferences for instance "${instanceName}". No matching instance was configured with this name.`
+    );
+  }
+};

--- a/src/lib/actions/setOptInPreferences/index.js
+++ b/src/lib/actions/setOptInPreferences/index.js
@@ -1,0 +1,16 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const createSetOptInPreferences = require("./createSetOptInPreferences");
+const instanceManager = require("../../instanceManager/index");
+
+module.exports = createSetOptInPreferences(instanceManager);

--- a/src/view/actions/setOptInPreferences.html
+++ b/src/view/actions/setOptInPreferences.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Extension View</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
+    <script src="./setOptInPreferences.jsx"></script>
+  </body>
+</html>

--- a/src/view/actions/setOptInPreferences.jsx
+++ b/src/view/actions/setOptInPreferences.jsx
@@ -1,0 +1,163 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import "regenerator-runtime"; // needed for some of react-spectrum
+import React from "react";
+import Alert from "@react/react-spectrum/Alert";
+import Select from "@react/react-spectrum/Select";
+import RadioGroup from "@react/react-spectrum/RadioGroup";
+import Radio from "@react/react-spectrum/Radio";
+import Textfield from "@react/react-spectrum/Textfield";
+import "@react/react-spectrum/Form"; // needed for spectrum form styles
+import { object, string } from "yup";
+import render from "../render";
+import WrappedField from "../components/wrappedField";
+import ExtensionView from "../components/extensionView";
+import getInstanceOptions from "../utils/getInstanceOptions";
+import "./setOptInPreferences.styl";
+
+const purposesEnum = {
+  ALL: "all",
+  NONE: "none",
+  DATA_ELEMENT: "dataElement"
+};
+
+const getInitialValues = initInfo => {
+  const {
+    instanceName = initInfo.extensionSettings.instances[0].name,
+    purposes = purposesEnum.ALL
+  } = initInfo.settings || {};
+
+  const initialValues = {
+    instanceName
+  };
+
+  if (purposes === purposesEnum.ALL || purposes === purposesEnum.NONE) {
+    initialValues.purposes = purposes;
+    initialValues.purposesDataElement = "";
+  } else {
+    initialValues.purposes = purposesEnum.DATA_ELEMENT;
+    initialValues.purposesDataElement = purposes;
+  }
+
+  return initialValues;
+};
+
+const getSettings = values => {
+  const { instanceName, purposes, purposesDataElement } = values;
+
+  return {
+    instanceName,
+    purposes:
+      purposes === purposesEnum.DATA_ELEMENT ? purposesDataElement : purposes
+  };
+};
+
+const isOptInEnabled = (initInfo, formikProps) => {
+  const matchingInstance = initInfo.extensionSettings.instances.find(
+    instance => instance.name === formikProps.values.instanceName
+  );
+  return matchingInstance ? matchingInstance.optInEnabled : false;
+};
+
+const invalidDataMessage = "Please specify a data element";
+const validationSchema = object().shape({
+  purposesDataElement: string().when("purposes", {
+    is: purposesEnum.DATA_ELEMENT,
+    then: string()
+      .required(invalidDataMessage)
+      .matches(/^%([^%]+)%$/, invalidDataMessage)
+  })
+});
+
+const SetOptInPreferences = () => {
+  return (
+    <ExtensionView
+      getInitialValues={getInitialValues}
+      getSettings={getSettings}
+      validationSchema={validationSchema}
+      render={({ initInfo, formikProps }) => {
+        return (
+          <div>
+            {isOptInEnabled(initInfo, formikProps) ? null : (
+              <div>
+                <Alert header="Opt-In Not Enabled" variant="warning">
+                  Before Opt-In preferences can be set, Opt-In must be enabled
+                  for the instance within the extension configuration.
+                </Alert>
+              </div>
+            )}
+            <div>
+              <label
+                htmlFor="instanceNameField"
+                className="spectrum-Form-itemLabel"
+              >
+                Instance
+              </label>
+              <div>
+                <WrappedField
+                  id="instanceNameField"
+                  name="instanceName"
+                  component={Select}
+                  componentClassName="u-fieldLong"
+                  options={getInstanceOptions(initInfo)}
+                />
+              </div>
+            </div>
+            <div className="u-gapTop">
+              <label
+                htmlFor="purposesField"
+                className="spectrum-Form-itemLabel"
+              >
+                The user has opted into:
+              </label>
+              <WrappedField
+                id="purposesField"
+                name="purposes"
+                component={RadioGroup}
+                componentClassName="u-flexColumn"
+              >
+                <Radio value={purposesEnum.ALL} label="All purposes" />
+                <Radio value={purposesEnum.NONE} label="No purposes" />
+                <Radio
+                  value={purposesEnum.DATA_ELEMENT}
+                  label="Purposes provided by data element"
+                />
+              </WrappedField>
+            </div>
+            {formikProps.values.purposes === purposesEnum.DATA_ELEMENT ? (
+              <div className="FieldSubset u-gapTop">
+                <label
+                  htmlFor="purposesDataElementField"
+                  className="spectrum-Form-itemLabel"
+                >
+                  Data Element
+                </label>
+                <div>
+                  <WrappedField
+                    id="purposesDataElementField"
+                    name="purposesDataElement"
+                    component={Textfield}
+                    componentClassName="u-fieldLong"
+                    supportDataElement
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+        );
+      }}
+    />
+  );
+};
+
+render(SetOptInPreferences);

--- a/src/view/actions/setOptInPreferences.styl
+++ b/src/view/actions/setOptInPreferences.styl
@@ -1,0 +1,13 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import "../global";

--- a/test/functional/actions/setOptInPreferences.spec.js
+++ b/test/functional/actions/setOptInPreferences.spec.js
@@ -1,0 +1,166 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Selector } from "testcafe";
+import createExtensionViewController from "../helpers/createExtensionViewController";
+import spectrum from "../helpers/spectrum";
+import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
+
+const extensionViewController = createExtensionViewController(
+  "actions/setOptInPreferences.html"
+);
+const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
+const purposesRadioGroup = {
+  allField: spectrum.radio(Selector(`[name='purposes'][value=all]`)),
+  noneField: spectrum.radio(Selector(`[name='purposes'][value=none]`)),
+  dataElementField: spectrum.radio(
+    Selector(`[name='purposes'][value=dataElement]`)
+  )
+};
+const purposesDataElementField = spectrum.textfield(
+  Selector("[name=purposesDataElement]")
+);
+const warning = spectrum.alert(Selector(`.spectrum-Alert`));
+
+const mockExtensionSettings = {
+  instances: [
+    {
+      name: "alloy1",
+      propertyId: "PR123"
+    },
+    {
+      name: "alloy2",
+      propertyId: "PR456",
+      optInEnabled: true
+    }
+  ]
+};
+
+// disablePageReloads is not a publicized feature, but it sure helps speed up tests.
+// https://github.com/DevExpress/testcafe/issues/1770
+fixture("Set Opt-In Preferences View").disablePageReloads.page(
+  "http://localhost:3000/viewSandbox.html"
+);
+
+test("initializes form fields with settings containing static purposes", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy2",
+      purposes: "none"
+    }
+  });
+  await instanceNameField.expectValue(t, "alloy2");
+  await purposesRadioGroup.allField.expectUnchecked(t);
+  await purposesRadioGroup.noneField.expectChecked(t);
+  await purposesRadioGroup.dataElementField.expectUnchecked(t);
+});
+
+test("initializes form fields with settings containing data element for purposes", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy2",
+      purposes: "%foo%"
+    }
+  });
+  await instanceNameField.expectValue(t, "alloy2");
+  await purposesRadioGroup.allField.expectUnchecked(t);
+  await purposesRadioGroup.noneField.expectUnchecked(t);
+  await purposesRadioGroup.dataElementField.expectChecked(t);
+  await purposesDataElementField.expectValue(t, "%foo%");
+});
+
+test("initializes form fields with no settings", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+  await instanceNameField.expectValue(t, "alloy1");
+  await purposesRadioGroup.allField.expectChecked(t);
+  await purposesRadioGroup.noneField.expectUnchecked(t);
+  await purposesRadioGroup.dataElementField.expectUnchecked(t);
+});
+
+test("returns valid settings containing static purposes", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+
+  await instanceNameField.selectOption(t, "alloy2");
+  await purposesRadioGroup.noneField.click(t);
+  await extensionViewController.expectIsValid(t);
+  await extensionViewController.expectSettings(t, {
+    instanceName: "alloy2",
+    purposes: "none"
+  });
+});
+
+test("returns valid settings containing data element for purposes", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+
+  await instanceNameField.selectOption(t, "alloy2");
+  await purposesRadioGroup.dataElementField.click(t);
+  await purposesDataElementField.typeText(t, "%foo%");
+  await extensionViewController.expectIsValid(t);
+  await extensionViewController.expectSettings(t, {
+    instanceName: "alloy2",
+    purposes: "%foo%"
+  });
+});
+
+test("shows error for purposes data element value that is not a data element", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+  await purposesRadioGroup.dataElementField.click(t);
+  await purposesDataElementField.typeText(t, "foo");
+  await extensionViewController.expectIsNotValid(t);
+  await purposesDataElementField.expectError(t);
+});
+
+test("shows error for purposes data element value that is more than one data element", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings
+  });
+  await purposesRadioGroup.dataElementField.click(t);
+  await purposesDataElementField.typeText(t, "%foo%%bar%");
+  await extensionViewController.expectIsNotValid(t);
+  await purposesDataElementField.expectError(t);
+});
+
+test("shows warning if opt-in is not enabled", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy1",
+      purposes: "all"
+    }
+  });
+
+  await warning.expectTitle(t, "Opt-In Not Enabled");
+});
+
+test("does not show warning if opt-in is enabled", async t => {
+  await extensionViewController.init(t, {
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy2",
+      purposes: "all"
+    }
+  });
+
+  await warning.expectNotExists(t);
+});
+
+testInstanceNameOptions(extensionViewController, instanceNameField);

--- a/test/unit/lib/actions/setOptInPreferences/createSetOptInPreferences.js
+++ b/test/unit/lib/actions/setOptInPreferences/createSetOptInPreferences.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createSetOptInPreferences from "../../../../../src/lib/actions/setOptInPreferences/createSetOptInPreferences";
+import turbineVariable from "../../../helpers/turbineVariable";
+
+describe("Set Opt-In Preferences", () => {
+  let mockLogger;
+
+  beforeEach(() => {
+    mockLogger = {
+      error: jasmine.createSpy()
+    };
+    turbineVariable.mock({
+      logger: mockLogger
+    });
+  });
+
+  afterEach(() => {
+    turbineVariable.reset();
+  });
+
+  ["all", "none"].forEach(purposes => {
+    it(`executes optIn command with "${purposes}" purposes`, () => {
+      const instance = jasmine.createSpy();
+      const instanceManager = {
+        getAccessor: jasmine.createSpy().and.returnValue({
+          instance
+        })
+      };
+      const action = createSetOptInPreferences(instanceManager);
+
+      action({
+        instanceName: "myinstance",
+        purposes
+      });
+
+      expect(instanceManager.getAccessor).toHaveBeenCalledWith("myinstance");
+      expect(instance).toHaveBeenCalledWith("optIn", {
+        purposes
+      });
+    });
+  });
+
+  it("logs an error when no matching instance found", () => {
+    const instanceManager = {
+      getAccessor() {
+        return undefined;
+      }
+    };
+    const action = createSetOptInPreferences(instanceManager);
+
+    action({
+      instanceName: "myinstance",
+      purposes: "none"
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed to send event for instance "myinstance". No matching instance was configured with this name.'
+    );
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After talking with Alpha customers, it does sounds like a Set Opt-In Preferences action type is useful, but they would like to be able to set opt-in preferences both statically (e.g., "all" and "none" checkboxes) as well as via a data element. This PR provides for both.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-33720
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/210820/64988669-38687600-d889-11e9-9715-b31350e4eb8e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
