### PR TITLE
CORE-34539 Fixed validation for ID sync container ID.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -42,8 +42,16 @@
                 "type": "boolean"
               },
               "idSyncContainerId": {
-                "type": "number",
-                "minimum": 0
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "^%([^%]+)%$"
+                  }
+                ]
               },
               "destinationsEnabled": {
                 "type": "boolean"

--- a/extension.json
+++ b/extension.json
@@ -49,7 +49,7 @@
                   },
                   {
                     "type": "string",
-                    "pattern": "^%([^%]+)%$"
+                    "pattern": "^%[^%]+%$"
                   }
                 ]
               },
@@ -100,7 +100,7 @@
           },
           "xdm": {
             "type": "string",
-            "pattern": "^%([^%]+)%$"
+            "pattern": "^%[^%]+%$"
           }
         },
         "required": [
@@ -133,7 +133,7 @@
               },
               {
                 "type": "string",
-                "pattern": "^%([^%]+)%$"
+                "pattern": "^%[^%]+%$"
               }
             ]
           }

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -22,6 +22,7 @@ import WrappedField from "../components/wrappedField";
 import ExtensionView from "../components/extensionView";
 import InfoTip from "../components/infoTip";
 import getInstanceOptions from "../utils/getInstanceOptions";
+import singleDataElementRegex from "../constants/singleDataElementRegex";
 import "./sendEvent.styl";
 
 const getInitialValues = initInfo => {
@@ -56,7 +57,7 @@ const getSettings = values => {
 };
 
 const validationSchema = object().shape({
-  xdm: string().matches(/^%([^%]+)%$/, "Please specify a data element")
+  xdm: string().matches(singleDataElementRegex, "Please specify a data element")
 });
 
 const SendEvent = () => {

--- a/src/view/actions/setOptInPreferences.jsx
+++ b/src/view/actions/setOptInPreferences.jsx
@@ -23,6 +23,7 @@ import render from "../render";
 import WrappedField from "../components/wrappedField";
 import ExtensionView from "../components/extensionView";
 import getInstanceOptions from "../utils/getInstanceOptions";
+import singleDataElementRegex from "../constants/singleDataElementRegex";
 import "./setOptInPreferences.styl";
 
 const purposesEnum = {
@@ -75,7 +76,7 @@ const validationSchema = object().shape({
     is: purposesEnum.DATA_ELEMENT,
     then: string()
       .required(invalidDataMessage)
-      .matches(/^%([^%]+)%$/, invalidDataMessage)
+      .matches(singleDataElementRegex, invalidDataMessage)
   })
 });
 

--- a/src/view/constants/singleDataElementRegex.js
+++ b/src/view/constants/singleDataElementRegex.js
@@ -10,4 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default /^%([^%]+)%$/;
+export default /^%[^%]+%$/;

--- a/src/view/constants/singleDataElementRegex.js
+++ b/src/view/constants/singleDataElementRegex.js
@@ -1,0 +1,13 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default /^%([^%]+)%$/;

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -287,7 +287,7 @@ test("shows errors for duplicate names", async t => {
   await instances[1].nameField.expectError(t);
 });
 
-test("shows error for non-negative number for ID sync container ID", async t => {
+test("shows error for ID sync container ID value that is a negative number", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
   await instances[0].idSyncContainerIdField.typeText(t, "-1");
@@ -295,7 +295,7 @@ test("shows error for non-negative number for ID sync container ID", async t => 
   await instances[0].idSyncContainerIdField.expectError(t);
 });
 
-test("shows error for a float number for ID sync container ID", async t => {
+test("shows error for ID sync container ID value that is a float number", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
   await instances[0].idSyncContainerIdField.typeText(t, "123.123");
@@ -303,7 +303,7 @@ test("shows error for a float number for ID sync container ID", async t => {
   await instances[0].idSyncContainerIdField.expectError(t);
 });
 
-test("shows error for an arbitrary string for ID sync container ID", async t => {
+test("shows error for ID sync container ID value that is an arbitrary string", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
   await instances[0].idSyncContainerIdField.typeText(t, "123foo");
@@ -311,14 +311,22 @@ test("shows error for an arbitrary string for ID sync container ID", async t => 
   await instances[0].idSyncContainerIdField.expectError(t);
 });
 
-test("does not show error for a data element for ID sync container ID", async t => {
+test("shows error for ID sync container ID value that is multiple data elements", async t => {
+  await extensionViewController.init(t, {});
+  await instances[0].propertyIdField.typeText(t, "PR123");
+  await instances[0].idSyncContainerIdField.typeText(t, "%foo%%bar%");
+  await extensionViewController.expectIsNotValid(t);
+  await instances[0].idSyncContainerIdField.expectError(t);
+});
+
+test("does not show error for ID sync container ID value that is a single data element", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
   await instances[0].idSyncContainerIdField.typeText(t, "%123foo%");
   await extensionViewController.expectIsValid(t);
 });
 
-test("ignores ID sync container ID when ID sync is disabled", async t => {
+test("ignores ID sync container ID value when ID sync is disabled", async t => {
   await extensionViewController.init(t, {});
   await instances[0].propertyIdField.typeText(t, "PR123");
   await instances[0].idSyncContainerIdField.typeText(t, "123foo");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed validation for ID sync container ID. Now the ID sync container ID field will only show up when the ID Synchronization Enabled checkbox is checked, since that really only when it matters. Acceptable values are an integer over 0, a single data element token, or an empty string. If the value is an empty string or the ID Synchronization Enabled checkbox is not checked, the ID sync container ID will not be added to the settings object.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-34539
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Proper validation
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
