### PR TITLE
Added AEP Icon to the Extension

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,7 @@
 {
   "displayName": "AEP Web SDK",
   "name": "adobe-alloy",
+  "iconPath": "resources/images/icon.svg",
   "platform": "web",
   "version": "0.0.1",
   "description": "The Adobe Experience Platform Web SDK allows for streaming data into the platform, syncing identities, personalizing content, and more.",

--- a/resources/images/icon.svg
+++ b/resources/images/icon.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="logo" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 240 234" enable-background="new 0 0 240 234" xml:space="preserve">
+<g>
+	<path id="tile_6_" fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" d="M42.5,0h155C221,0,240,19,240,42.5v149
+		c0,23.5-19,42.5-42.5,42.5h-155C19,234,0,215,0,191.5v-149C0,19,19,0,42.5,0z"/>
+	<g>
+		<path fill="#F90025" d="M197,73.9v88.9l-35.7-20.6c-12.8-7.4-23.1-17.9-30.2-30.2L197,73.9z"/>
+		<path fill="#8D0017" d="M197,73.9l-65.9,38.1C123.9,99.6,120,85.4,120,70.7V29.4L197,73.9z"/>
+		<path fill="#C20020" d="M120,29.4v41.3c0,14.7-3.9,28.9-11.1,41.2L43,73.9L120,29.4z"/>
+		<path fill="#F90025" d="M108.9,111.9c-7.1,12.3-17.4,22.8-30.1,30.2c0,0,0,0-0.1,0L43,162.8V73.9L108.9,111.9z"/>
+		<g>
+			<path fill="#C20020" d="M197,162.8l-77,44.5v-76.1c14.3,0,28.5,3.7,41.3,11.1L197,162.8z"/>
+		</g>
+		<g>
+			<path fill="#8D0017" d="M120,131.1v76.1l-77-44.5l35.7-20.6C91.5,134.8,105.7,131.1,120,131.1z"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
## Description

Adding an Icon to the extension.

## Motivation and Context

We can change this later if we need a different one but put the latest AEP icon for now so demos and recordings don't show the placeholder.



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.


Test results:
"HeadlessChrome 75.0.3765 (Mac OS X 10.14.6): Executed 10 of 10 SUCCESS (0.141 secs / 0.025 secs)
TOTAL: 10 SUCCESS"
 44 passed (2m 07s)
