### PR TITLE
Hiding the non-AEP related configs

### DIFF
--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -30,7 +30,7 @@ import "@react/react-spectrum/Form"; // needed for spectrum form styles
 import render from "../render";
 import WrappedField from "../components/wrappedField";
 import ExtensionView from "../components/extensionView";
-import EditorButton from "../components/editorButton";
+// import EditorButton from "../components/editorButton";
 import InfoTipLayout from "../components/infoTipLayout";
 import copyPropertiesIfNotDefault from "./utils/copyPropertiesIfNotDefault";
 import singleDataElementRegex from "../constants/singleDataElementRegex";
@@ -445,8 +445,8 @@ const Configuration = () => {
                           </div>
 
                           <h3>Identity</h3>
-
-                          <div className="u-gapTop">
+                          {/* TODO - Uncomment these when Konductor support is available  */}
+                          {/* <div className="u-gapTop">
                             <InfoTipLayout tip="Sends requests to third-party URLs to synchronize the Adobe unique user ID with the unique user ID of a third-party data source.">
                               <WrappedField
                                 name={`instances.${index}.idSyncEnabled`}
@@ -474,7 +474,7 @@ const Configuration = () => {
                                 />
                               </div>
                             </div>
-                          ) : null}
+                          ) : null} */}
 
                           <div className="u-gapTop">
                             <InfoTipLayout tip="Enables the AEP Web SDK to preserve the ECID by reading/writing the AMCV cookie. Use this config until users are fully migrated to the Alloy cookie and in situations where you have mixed pages on your website.">
@@ -485,8 +485,8 @@ const Configuration = () => {
                               />
                             </InfoTipLayout>
                           </div>
-
-                          <h3>Audiences</h3>
+                          {/* TODO - Uncomment these when Konductor support is available  */}
+                          {/* <h3>Audiences</h3>
 
                           <div className="u-gapTop">
                             <InfoTipLayout tip="Enables URL destinations, which allows the firing of URLs based on segment qualification.">
@@ -525,7 +525,7 @@ const Configuration = () => {
                                 language="css"
                               />
                             </div>
-                          </div>
+                          </div> */}
 
                           <h3>Context</h3>
 

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -148,11 +148,11 @@ test("initializes form fields with full settings", async t => {
   await instances[0].edgeDomainField.expectValue(t, "testedge.com");
   await instances[0].errorsEnabledField.expectUnchecked(t);
   await instances[0].optInEnabledField.expectChecked(t);
-  await instances[0].idSyncEnabledField.expectChecked(t);
-  await instances[0].idSyncContainerIdField.expectValue(t, "123");
+  // await instances[0].idSyncEnabledField.expectChecked(t);
+  // await instances[0].idSyncContainerIdField.expectValue(t, "123");
   await instances[0].idMigrationEnabled.expectChecked(t);
-  await instances[0].urlDestinationsEnabledField.expectChecked(t);
-  await instances[0].cookieDestinationsEnabledField.expectUnchecked(t);
+  // await instances[0].urlDestinationsEnabledField.expectChecked(t);
+  // await instances[0].cookieDestinationsEnabledField.expectUnchecked(t);
   await instances[0].contextGranularity.specificField.expectChecked(t);
   await instances[0].specificContext.webField.expectUnchecked(t);
   await instances[0].specificContext.deviceField.expectChecked(t);
@@ -167,11 +167,11 @@ test("initializes form fields with full settings", async t => {
   await instances[1].edgeDomainField.expectValue(t, defaultEdgeDomain);
   await instances[1].errorsEnabledField.expectChecked(t);
   await instances[1].optInEnabledField.expectUnchecked(t);
-  await instances[1].idSyncEnabledField.expectUnchecked(t);
-  await instances[1].idSyncContainerIdField.expectNotExists(t);
+  // await instances[1].idSyncEnabledField.expectUnchecked(t);
+  // await instances[1].idSyncContainerIdField.expectNotExists(t);
   await instances[1].idMigrationEnabled.expectUnchecked(t);
-  await instances[1].urlDestinationsEnabledField.expectChecked(t);
-  await instances[1].cookieDestinationsEnabledField.expectChecked(t);
+  // await instances[1].urlDestinationsEnabledField.expectChecked(t);
+  // await instances[1].cookieDestinationsEnabledField.expectChecked(t);
   await instances[1].contextGranularity.specificField.expectChecked(t);
   await instances[1].specificContext.webField.expectUnchecked(t);
   await instances[1].specificContext.deviceField.expectUnchecked(t);
@@ -200,11 +200,11 @@ test("initializes form fields with minimal settings", async t => {
   await instances[0].edgeDomainField.expectValue(t, defaultEdgeDomain);
   await instances[0].errorsEnabledField.expectChecked(t);
   await instances[0].optInEnabledField.expectUnchecked(t);
-  await instances[0].idSyncEnabledField.expectChecked(t);
-  await instances[0].idSyncContainerIdField.expectValue(t, "");
+  // await instances[0].idSyncEnabledField.expectChecked(t);
+  // await instances[0].idSyncContainerIdField.expectValue(t, "");
   await instances[0].idMigrationEnabled.expectChecked(t);
-  await instances[0].urlDestinationsEnabledField.expectChecked(t);
-  await instances[0].cookieDestinationsEnabledField.expectChecked(t);
+  // await instances[0].urlDestinationsEnabledField.expectChecked(t);
+  // await instances[0].cookieDestinationsEnabledField.expectChecked(t);
   await instances[0].contextGranularity.allField.expectChecked(t);
 });
 
@@ -217,11 +217,11 @@ test("initializes form fields with no settings", async t => {
   await instances[0].edgeDomainField.expectValue(t, defaultEdgeDomain);
   await instances[0].errorsEnabledField.expectChecked(t);
   await instances[0].optInEnabledField.expectUnchecked(t);
-  await instances[0].idSyncEnabledField.expectChecked(t);
-  await instances[0].idSyncContainerIdField.expectValue(t, "");
+  // await instances[0].idSyncEnabledField.expectChecked(t);
+  // await instances[0].idSyncContainerIdField.expectValue(t, "");
   await instances[0].idMigrationEnabled.expectChecked(t);
-  await instances[0].urlDestinationsEnabledField.expectChecked(t);
-  await instances[0].cookieDestinationsEnabledField.expectChecked(t);
+  // await instances[0].urlDestinationsEnabledField.expectChecked(t);
+  // await instances[0].cookieDestinationsEnabledField.expectChecked(t);
   await instances[0].contextGranularity.allField.expectChecked(t);
 });
 
@@ -257,11 +257,11 @@ test("returns full valid settings", async t => {
   await instances[0].edgeDomainField.typeText(t, "2");
   await instances[0].errorsEnabledField.click(t);
   await instances[0].optInEnabledField.click(t);
-  await instances[0].idSyncContainerIdField.typeText(t, "123");
+  // await instances[0].idSyncContainerIdField.typeText(t, "123");
   await instances[0].idMigrationEnabled.click(t);
-  await instances[0].urlDestinationsEnabledField.click(t);
-  await instances[0].cookieDestinationsEnabledField.click(t);
-  await instances[0].prehidingStyleField.click(t);
+  // await instances[0].urlDestinationsEnabledField.click(t);
+  // await instances[0].cookieDestinationsEnabledField.click(t);
+  // await instances[0].prehidingStyleField.click(t);
 
   await addInstanceButton.click(t);
 
@@ -269,7 +269,7 @@ test("returns full valid settings", async t => {
   await instances[1].configIdField.typeText(t, "PR456");
   await instances[1].imsOrgIdField.typeText(t, "2");
   await instances[1].optInEnabledField.click(t);
-  await instances[1].idSyncEnabledField.click(t);
+  // await instances[1].idSyncEnabledField.click(t);
   await instances[1].idMigrationEnabled.click(t);
   await instances[1].contextGranularity.specificField.click(t);
 
@@ -282,18 +282,18 @@ test("returns full valid settings", async t => {
         edgeDomain: `${defaultEdgeDomain}2`,
         errorsEnabled: false,
         optInEnabled: true,
-        idSyncContainerId: 123,
-        idMigrationEnabled: false,
-        urlDestinationsEnabled: false,
-        cookieDestinationsEnabled: false,
-        prehidingStyle: "#container { display: none } // css"
+        // idSyncContainerId: 123,
+        idMigrationEnabled: false
+        // urlDestinationsEnabled: false,
+        // cookieDestinationsEnabled: false,
+        // prehidingStyle: "#container { display: none } // css"
       },
       {
         name: "alloy2",
         configId: "PR456",
         imsOrgId: "ABC123@AdobeOrg2",
         optInEnabled: true,
-        idSyncEnabled: false,
+        // idSyncEnabled: false,
         idMigrationEnabled: false,
         context: ["web", "device", "environment", "placeContext"]
       }
@@ -409,61 +409,61 @@ test("restores default edge domain value when restore button is clicked", async 
   await instances[0].edgeDomainField.expectValue(t, defaultEdgeDomain);
 });
 
-test("shows error for ID sync container ID value that is a negative number", async t => {
-  await extensionViewController.init(t, defaultInitInfo);
-  await instances[0].configIdField.typeText(t, "PR123");
-  await instances[0].idSyncContainerIdField.typeText(t, "-1");
-  await extensionViewController.expectIsNotValid(t);
-  await instances[0].idSyncContainerIdField.expectError(t);
-});
+// test("shows error for ID sync container ID value that is a negative number", async t => {
+//   await extensionViewController.init(t, defaultInitInfo);
+//   await instances[0].configIdField.typeText(t, "PR123");
+//   await instances[0].idSyncContainerIdField.typeText(t, "-1");
+//   await extensionViewController.expectIsNotValid(t);
+//   await instances[0].idSyncContainerIdField.expectError(t);
+// });
 
-test("shows error for ID sync container ID value that is a float number", async t => {
-  await extensionViewController.init(t, defaultInitInfo);
-  await instances[0].configIdField.typeText(t, "PR123");
-  await instances[0].idSyncContainerIdField.typeText(t, "123.123");
-  await extensionViewController.expectIsNotValid(t);
-  await instances[0].idSyncContainerIdField.expectError(t);
-});
+// test("shows error for ID sync container ID value that is a float number", async t => {
+//   await extensionViewController.init(t, defaultInitInfo);
+//   await instances[0].configIdField.typeText(t, "PR123");
+//   await instances[0].idSyncContainerIdField.typeText(t, "123.123");
+//   await extensionViewController.expectIsNotValid(t);
+//   await instances[0].idSyncContainerIdField.expectError(t);
+// });
 
-test("shows error for ID sync container ID value that is an arbitrary string", async t => {
-  await extensionViewController.init(t, defaultInitInfo);
-  await instances[0].configIdField.typeText(t, "PR123");
-  await instances[0].idSyncContainerIdField.typeText(t, "123foo");
-  await extensionViewController.expectIsNotValid(t);
-  await instances[0].idSyncContainerIdField.expectError(t);
-});
+// test("shows error for ID sync container ID value that is an arbitrary string", async t => {
+//   await extensionViewController.init(t, defaultInitInfo);
+//   await instances[0].configIdField.typeText(t, "PR123");
+//   await instances[0].idSyncContainerIdField.typeText(t, "123foo");
+//   await extensionViewController.expectIsNotValid(t);
+//   await instances[0].idSyncContainerIdField.expectError(t);
+// });
 
-test("shows error for ID sync container ID value that is multiple data elements", async t => {
-  await extensionViewController.init(t, defaultInitInfo);
-  await instances[0].configIdField.typeText(t, "PR123");
-  await instances[0].idSyncContainerIdField.typeText(t, "%foo%%bar%");
-  await extensionViewController.expectIsNotValid(t);
-  await instances[0].idSyncContainerIdField.expectError(t);
-});
+// test("shows error for ID sync container ID value that is multiple data elements", async t => {
+//   await extensionViewController.init(t, defaultInitInfo);
+//   await instances[0].configIdField.typeText(t, "PR123");
+//   await instances[0].idSyncContainerIdField.typeText(t, "%foo%%bar%");
+//   await extensionViewController.expectIsNotValid(t);
+//   await instances[0].idSyncContainerIdField.expectError(t);
+// });
 
-test("does not show error for ID sync container ID value that is a single data element", async t => {
-  await extensionViewController.init(t, defaultInitInfo);
-  await instances[0].configIdField.typeText(t, "PR123");
-  await instances[0].idSyncContainerIdField.typeText(t, "%123foo%");
-  await extensionViewController.expectIsValid(t);
-});
+// test("does not show error for ID sync container ID value that is a single data element", async t => {
+//   await extensionViewController.init(t, defaultInitInfo);
+//   await instances[0].configIdField.typeText(t, "PR123");
+//   await instances[0].idSyncContainerIdField.typeText(t, "%123foo%");
+//   await extensionViewController.expectIsValid(t);
+// });
 
-test("ignores ID sync container ID value when ID sync is disabled", async t => {
-  await extensionViewController.init(t, defaultInitInfo);
-  await instances[0].configIdField.typeText(t, "PR123");
-  await instances[0].idSyncContainerIdField.typeText(t, "123foo");
-  await instances[0].idSyncEnabledField.click(t);
-  await extensionViewController.expectIsValid(t);
-  await extensionViewController.expectSettings(t, {
-    instances: [
-      {
-        name: "alloy",
-        configId: "PR123",
-        idSyncEnabled: false
-      }
-    ]
-  });
-});
+// test("ignores ID sync container ID value when ID sync is disabled", async t => {
+//   await extensionViewController.init(t, defaultInitInfo);
+//   await instances[0].configIdField.typeText(t, "PR123");
+//   await instances[0].idSyncContainerIdField.typeText(t, "123foo");
+//   await instances[0].idSyncEnabledField.click(t);
+//   await extensionViewController.expectIsValid(t);
+//   await extensionViewController.expectSettings(t, {
+//     instances: [
+//       {
+//         name: "alloy",
+//         configId: "PR123",
+//         idSyncEnabled: false
+//       }
+//     ]
+//   });
+// });
 
 test("deletes an instance", async t => {
   await extensionViewController.init(t, defaultInitInfo);


### PR DESCRIPTION
Hiding the non-AEP related configs

## Description
Konductor doesn't have support for `idSync` `destinationSync` and `personalization` today.
Hiding these from the extension for beta release

## Related Issue
https://jira.corp.adobe.com/browse/CORE-37167

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
<img width="685" alt="Screen Shot 2019-11-14 at 11 57 53 AM" src="https://user-images.githubusercontent.com/8774186/68891612-041d0480-06d6-11ea-8402-efac4c21c0df.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
