### PR TITLE
Add type and mergeId to sendEvent

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -112,6 +112,12 @@
           "xdm": {
             "type": "string",
             "pattern": "^%[^%]+%$"
+          },
+          "type": {
+            "type": "string"
+          },
+          "mergeId": {
+            "type": "string"
           }
         },
         "required": [

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -30,13 +30,17 @@ const getInitialValues = ({ initInfo }) => {
   const {
     instanceName = initInfo.extensionSettings.instances[0].name,
     viewStart = false,
-    xdm = ""
+    xdm = "",
+    type = "",
+    mergeId = ""
   } = initInfo.settings || {};
 
   return {
     instanceName,
     viewStart,
-    xdm
+    xdm,
+    type,
+    mergeId
   };
 };
 
@@ -47,6 +51,12 @@ const getSettings = ({ values }) => {
 
   if (values.xdm) {
     settings.xdm = values.xdm;
+  }
+  if (values.type) {
+    settings.type = values.type;
+  }
+  if (values.mergeId) {
+    settings.mergeId = values.mergeId;
   }
 
   // Only add viewStart if the value is different than the default (false).
@@ -103,6 +113,40 @@ const SendEvent = () => {
                 <WrappedField
                   id="xdmField"
                   name="xdm"
+                  component={Textfield}
+                  componentClassName="u-fieldLong"
+                  supportDataElement
+                />
+              </div>
+            </div>
+            <div className="u-gapTop">
+              <InfoTipLayout
+                tip="The type of the experience event.  This will be added to the
+                  XDM object as the field `eventType`."
+              >
+                <FieldLabel labelFor="typeField" label="Type (optional)" />
+              </InfoTipLayout>
+              <div>
+                <WrappedField
+                  id="typeField"
+                  name="type"
+                  component={Textfield}
+                  componentClassName="u-fieldLong"
+                  supportDataElement
+                />
+              </div>
+            </div>
+            <div className="u-gapTop">
+              <InfoTipLayout
+                tip="The merge ID of the experience event.  This will be added to
+                  the XDM object as the field `eventMergeId`."
+              >
+                <FieldLabel labelFor="mergeIdField" label="Merge ID (optional)" />
+              </InfoTipLayout>
+              <div>
+                <WrappedField
+                  id="mergeIdField"
+                  name="mergeId"
                   component={Textfield}
                   componentClassName="u-fieldLong"
                   supportDataElement

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -21,6 +21,8 @@ const extensionViewController = createExtensionViewController(
 const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
 const viewStartField = spectrum.checkbox(Selector("[name=viewStart]"));
 const xdmField = spectrum.textfield(Selector("[name=xdm]"));
+const typeField = spectrum.textfield(Selector("[name=type]"));
+const mergeIdField = spectrum.textfield(Selector("[name=mergeId]"));
 
 const mockExtensionSettings = {
   instances: [
@@ -47,12 +49,16 @@ test("initializes form fields with full settings", async t => {
     settings: {
       instanceName: "alloy2",
       viewStart: true,
-      xdm: "%myDataLayer%"
+      xdm: "%myDataLayer%",
+      type: "myType1",
+      mergeId: "%myMergeId%"
     }
   });
   await instanceNameField.expectValue(t, "alloy2");
   await viewStartField.expectChecked(t);
   await xdmField.expectValue(t, "%myDataLayer%");
+  await typeField.expectValue(t, "myType1");
+  await mergeIdField.expectValue(t, "%myMergeId%");
 });
 
 test("initializes form fields with minimal settings", async t => {
@@ -65,6 +71,8 @@ test("initializes form fields with minimal settings", async t => {
   await instanceNameField.expectValue(t, "alloy1");
   await viewStartField.expectUnchecked(t);
   await xdmField.expectValue(t, "");
+  await typeField.expectValue(t, "");
+  await mergeIdField.expectValue(t, "");
 });
 
 test("initializes form fields with no settings", async t => {
@@ -74,6 +82,8 @@ test("initializes form fields with no settings", async t => {
   await instanceNameField.expectValue(t, "alloy1");
   await viewStartField.expectUnchecked(t);
   await xdmField.expectValue(t, "");
+  await typeField.expectValue(t, "");
+  await mergeIdField.expectValue(t, "");
 });
 
 test("returns minimal valid settings", async t => {
@@ -94,11 +104,15 @@ test("returns full valid settings", async t => {
   await instanceNameField.selectOption(t, "alloy2");
   await viewStartField.click(t);
   await xdmField.typeText(t, "%myDataLayer%");
+  await typeField.typeText(t, "mytype1");
+  await mergeIdField.typeText(t, "%myMergeId%");
   await extensionViewController.expectIsValid(t);
   await extensionViewController.expectSettings(t, {
     instanceName: "alloy2",
     viewStart: true,
-    xdm: "%myDataLayer%"
+    xdm: "%myDataLayer%",
+    type: "mytype1",
+    mergeId: "%myMergeId%"
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add two new fields to the event command options.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-37378
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This allows customers to set the type and mergeId without having to modify the data element used for the xdm field.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
