### PR TITLE
Updating supportDatatElement to a string

### DIFF
--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -130,7 +130,7 @@ const SendEvent = () => {
                   name="type"
                   component={ComboBox}
                   componentClassName="u-fieldLong"
-                  supportDataElement
+                  supportDataElement="replace"
                   allowCreate
                   options={knownEventTypes}
                 />
@@ -150,7 +150,7 @@ const SendEvent = () => {
                   name="xdm"
                   component={Textfield}
                   componentClassName="u-fieldLong"
-                  supportDataElement
+                  supportDataElement="replace"
                 />
               </div>
             </div>
@@ -170,7 +170,7 @@ const SendEvent = () => {
                   name="mergeId"
                   component={Textfield}
                   componentClassName="u-fieldLong"
-                  supportDataElement
+                  supportDataElement="replace"
                 />
               </div>
             </div>

--- a/src/view/actions/setOptInPreferences.jsx
+++ b/src/view/actions/setOptInPreferences.jsx
@@ -148,7 +148,7 @@ const SetOptInPreferences = () => {
                     name="purposesDataElement"
                     component={Textfield}
                     componentClassName="u-fieldLong"
-                    supportDataElement
+                    supportDataElement="replace"
                   />
                 </div>
               </div>

--- a/src/view/components/customerIdWrapper.jsx
+++ b/src/view/components/customerIdWrapper.jsx
@@ -77,7 +77,7 @@ function CustomerIdWrapper({ values, initInfo }) {
                             name={`customerIds.${index}.id`}
                             component={Textfield}
                             componentClassName="u-fieldLong"
-                            supportDataElement
+                            supportDataElement="replace"
                           />
                         </div>
                       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I have updated the type of `supportDataElement` to `string` in `WrappedField` component.
Updating all the components using that prop to pass a string

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
