### PR TITLE
CORE-42552 Add data element support back to property form.

### DIFF
--- a/src/view/components/wrappedField.jsx
+++ b/src/view/components/wrappedField.jsx
@@ -146,7 +146,7 @@ DecoratedInput.propTypes = {
   field: PropTypes.object.isRequired,
   form: PropTypes.object.isRequired,
   children: PropTypes.node,
-  supportDataElement: PropTypes.string,
+  supportDataElement: PropTypes.oneOf(["replace", "append"]),
   errorTooltipPlacement: PropTypes.oneOf(["top", "right", "bottom", "left"]),
   onChange: PropTypes.func,
   onBlur: PropTypes.func

--- a/src/view/dataElements/xdmObject/components/xdmPropertyForm.jsx
+++ b/src/view/dataElements/xdmObject/components/xdmPropertyForm.jsx
@@ -33,6 +33,7 @@ const XdmPropertyForm = props => {
           name={`${fieldName}.wholeValue`}
           component={Textfield}
           componentClassName="u-fieldLong"
+          supportDataElement="append"
         />
       </div>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a data element selector that appends data element tokens to the value field when editing an XDM object property in the XDM Object data element.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-42552

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I mistakenly removed it previously.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/210820/76897491-73a82980-6859-11ea-899f-6c70db7911ac.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
