### PR TITLE
Convert to using test IDs in tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,9 @@
 {
   "plugins": ["@babel/plugin-proposal-class-properties"],
-  "presets": [
-    ["@babel/preset-env"]
-  ]
+  "presets": [["@babel/preset-env"]],
+  "env": {
+    "production": {
+      "plugins": ["babel-plugin-jsx-remove-data-test-id"]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2337,6 +2337,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-jsx-remove-data-test-id": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-2.1.3.tgz",
+      "integrity": "sha512-FTpcmzr3avLVStllCT4BceTTZNEb+1mJVtLpsicvXDqjojEkyrga1GGOxWj768Ra3tev6KWgNOhZ/Lrucb+MuQ==",
+      "dev": true
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "babel-eslint": "^10.0.1",
+    "babel-plugin-jsx-remove-data-test-id": "^2.1.3",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "chalk": "^3.0.0",
     "eslint": "^5.16.0",

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -109,6 +109,7 @@ const SendEvent = () => {
               <FieldLabel labelFor="instanceNameField" label="Instance" />
               <div>
                 <WrappedField
+                  data-test-id="instanceNameField"
                   id="instanceNameField"
                   name="instanceName"
                   component={Select}
@@ -126,6 +127,7 @@ const SendEvent = () => {
               </InfoTipLayout>
               <div>
                 <WrappedField
+                  data-test-id="typeField"
                   id="typeField"
                   name="type"
                   component={ComboBox}
@@ -146,6 +148,7 @@ const SendEvent = () => {
               </InfoTipLayout>
               <div>
                 <WrappedField
+                  data-test-id="xdmField"
                   id="xdmField"
                   name="xdm"
                   component={Textfield}
@@ -166,6 +169,7 @@ const SendEvent = () => {
               </InfoTipLayout>
               <div>
                 <WrappedField
+                  data-test-id="mergeIdField"
                   id="mergeIdField"
                   name="mergeId"
                   component={Textfield}
@@ -177,6 +181,7 @@ const SendEvent = () => {
             <div className="u-gapTop">
               <InfoTipLayout tip="Influences whether the SDK should retrieve and render personalization content, among other things.">
                 <WrappedField
+                  data-test-id="viewStartField"
                   name="viewStart"
                   component={Checkbox}
                   label="Occurs at the start of a view"

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -124,6 +124,7 @@ const SetConsent = () => {
               <FieldLabel labelFor="instanceNameField" label="Instance" />
               <div>
                 <WrappedField
+                  data-test-id="instanceNameField"
                   id="instanceNameField"
                   name="instanceName"
                   component={Select}
@@ -143,9 +144,18 @@ const SetConsent = () => {
                 component={RadioGroup}
                 componentClassName="u-flexColumn"
               >
-                <Radio value={purposesEnum.IN} label="In" />
-                <Radio value={purposesEnum.OUT} label="Out" />
                 <Radio
+                  data-test-id="inOptionField"
+                  value={purposesEnum.IN}
+                  label="In"
+                />
+                <Radio
+                  data-test-id="outOptionField"
+                  value={purposesEnum.OUT}
+                  label="Out"
+                />
+                <Radio
+                  data-test-id="dataElementOptionField"
                   value={purposesEnum.DATA_ELEMENT}
                   label="Consent provided by data element"
                 />
@@ -161,6 +171,7 @@ const SetConsent = () => {
                 </InfoTipLayout>
                 <div>
                   <WrappedField
+                    data-test-id="dataElementField"
                     id="dataElementField"
                     name="dataElement"
                     component={Textfield}

--- a/src/view/components/checkboxList.jsx
+++ b/src/view/components/checkboxList.jsx
@@ -38,20 +38,16 @@ class CheckboxList extends React.Component {
   render() {
     const { options, value, className } = this.props;
     const listItems = options.map(option => {
-      let optionValue;
-      let optionLabel;
-
-      if (typeof option === "string") {
-        optionValue = option;
-        optionLabel = option;
-      } else {
-        optionValue = option.value;
-        optionLabel = option.label;
-      }
+      const {
+        value: optionValue,
+        label: optionLabel,
+        testId: optionTestId
+      } = option;
 
       return (
         <li key={optionValue}>
           <Checkbox
+            data-test-id={optionTestId}
             value={optionValue}
             checked={value && value.includes(optionValue)}
             onChange={this.onChange}

--- a/src/view/components/customerIdWrapper.jsx
+++ b/src/view/components/customerIdWrapper.jsx
@@ -20,10 +20,11 @@ import getInstanceOptions from "../utils/getInstanceOptions";
 function CustomerIdWrapper({ values, initInfo }) {
   return (
     <React.Fragment>
-      <FieldLabel labelFor="instanceName" label="Instance" />
+      <FieldLabel labelFor="instanceNameField" label="Instance" />
       <div>
         <WrappedField
-          id="instanceName"
+          data-test-id="instanceNameField"
+          id="instanceNameField"
           name="instanceName"
           component={Select}
           componentClassName="u-fieldLong"
@@ -37,7 +38,7 @@ function CustomerIdWrapper({ values, initInfo }) {
             <React.Fragment>
               <div className="u-gapTop u-alignRight">
                 <Button
-                  id="addCustomerId"
+                  data-test-id="addCustomerIdButton"
                   label="Add Customer ID"
                   onClick={() => {
                     arrayHelpers.push(getDefaultCustomerId());
@@ -55,12 +56,13 @@ function CustomerIdWrapper({ values, initInfo }) {
                     <Well key={index}>
                       <div>
                         <FieldLabel
-                          labelFor={`namespaceField${index}`}
+                          labelFor={`namespace${index}Field`}
                           label="Namespace"
                         />
                         <div>
                           <WrappedField
-                            id={`namespaceField${index}`}
+                            data-test-id={`namespace${index}Field`}
+                            id={`namespace${index}Field`}
                             name={`customerIds.${index}.namespace`}
                             // component={Select}
                             component={Textfield}
@@ -70,10 +72,11 @@ function CustomerIdWrapper({ values, initInfo }) {
                         </div>
                       </div>
                       <div className="u-gapTop">
-                        <FieldLabel labelFor={`idField${index}`} label="ID" />
+                        <FieldLabel labelFor={`id${index}Field`} label="ID" />
                         <div>
                           <WrappedField
-                            id={`idField${index}`}
+                            data-test-id={`id${index}Field`}
+                            id={`id${index}Field`}
                             name={`customerIds.${index}.id`}
                             component={Textfield}
                             componentClassName="u-fieldLong"
@@ -84,6 +87,7 @@ function CustomerIdWrapper({ values, initInfo }) {
                       <div className="u-gapTop">
                         <InfoTipLayout tip="Uses the SHA-256 hashing algorithm that allows you to pass in customer IDs or email addresses, and pass out hashed IDs. This is an optional Javascript method for sending hashed identifiers. You can continue to use your own methods of hashing prior to sending customer IDs. Note: if this is set to true for a customer ID and the page is HTTP, the customer ID will be removed from the call because hashing cannot be completed in this case.">
                           <WrappedField
+                            data-test-id={`hashEnabled${index}Field`}
                             name={`customerIds.${index}.hashEnabled`}
                             component={Checkbox}
                             label="Convert ID to sha256 hash"
@@ -92,12 +96,13 @@ function CustomerIdWrapper({ values, initInfo }) {
                       </div>
                       <div className="u-gapTop">
                         <FieldLabel
-                          labelFor={`authenticatedStateField${index}`}
+                          labelFor={`authenticatedState${index}Field`}
                           label="Authenticated State"
                         />
                         <div>
                           <WrappedField
-                            id={`authenticatedStateField${index}`}
+                            data-test-id={`authenticatedState${index}Field`}
+                            id={`authenticatedState${index}Field`}
                             name={`customerIds.${index}.authenticatedState`}
                             component={Select}
                             componentClassName="u-fieldLong"
@@ -108,6 +113,7 @@ function CustomerIdWrapper({ values, initInfo }) {
                       <div className="u-gapTop">
                         <InfoTipLayout tip="Adobe Experience Platform will use the customer ID as an identifier to help stitch together more information about that individual. If left unchecked, the identifier within this namespace will still be collected but the ECID will be used as the primary identifier for stitching.">
                           <WrappedField
+                            data-test-id={`primary${index}Field`}
                             name={`customerIds.${index}.primary`}
                             component={Checkbox}
                             label="Primary"
@@ -116,7 +122,7 @@ function CustomerIdWrapper({ values, initInfo }) {
                       </div>
                       <div className="u-gapTop">
                         <Button
-                          id={`deleteButton${index}`}
+                          data-test-id={`delete${index}Button`}
                           label="Delete Customer ID"
                           icon={<Delete />}
                           disabled={values.customerIds.length === 1}

--- a/src/view/components/editorButton.jsx
+++ b/src/view/components/editorButton.jsx
@@ -37,10 +37,11 @@ class EditorButton extends React.Component {
   };
 
   render() {
-    const { className, invalid } = this.props;
+    const { className, invalid, ...otherProps } = this.props;
 
     return (
       <Button
+        {...otherProps}
         icon={<Code />}
         className={className}
         onClick={this.onClick}

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -46,7 +46,28 @@ const consentLevels = {
   IN: "in",
   PENDING: "pending"
 };
-const contextOptions = ["web", "device", "environment", "placeContext"];
+const contextOptions = [
+  {
+    label: "Web",
+    value: "web",
+    testId: "contextWebField"
+  },
+  {
+    label: "Device",
+    value: "device",
+    testId: "contextDeviceField"
+  },
+  {
+    label: "Environment",
+    value: "environment",
+    testId: "contextEnvironmentField"
+  },
+  {
+    label: "Place Context",
+    value: "placeContext",
+    testId: "contextPlaceContextField"
+  }
+];
 
 const getInstanceDefaults = initInfo => ({
   name: "alloy",
@@ -58,7 +79,7 @@ const getInstanceDefaults = initInfo => ({
   defaultConsent: { general: consentLevels.IN },
   prehidingStyle: "",
   contextGranularity: contextGranularityEnum.ALL,
-  context: contextOptions,
+  context: contextOptions.map(contextOption => contextOption.value),
   idMigrationEnabled: true,
   thirdPartyCookiesEnabled: true,
   clickCollectionEnabled: true,
@@ -279,6 +300,7 @@ const Configuration = ({ formikProps, initInfo }) => {
             <div>
               <div className="u-alignRight">
                 <Button
+                  data-test-id="addInstanceButton"
                   label="Add Instance"
                   onClick={() => {
                     arrayHelpers.push(createDefaultInstance(initInfo));
@@ -287,6 +309,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                 />
               </div>
               <Accordion
+                data-test-id="instancesAccordion"
                 selectedIndex={selectedAccordionIndex}
                 className="u-gapTop2x"
                 onChange={setSelectedAccordionIndex}
@@ -302,6 +325,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="nameField"
                           id="nameField"
                           name={`instances.${index}.name`}
                           component={Textfield}
@@ -314,6 +338,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       initialValues.instances[0].name !==
                         values.instances[0].name ? (
                         <Alert
+                          data-test-id="nameChangeAlert"
                           id="nameChangeAlert"
                           className="ConstrainedAlert"
                           header="Potential Problems Due to Name Change"
@@ -337,6 +362,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="configIdField"
                           id="configIdField"
                           name={`instances.${index}.configId`}
                           component={Textfield}
@@ -354,6 +380,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="orgIdField"
                           id="orgIdField"
                           name={`instances.${index}.orgId`}
                           component={Textfield}
@@ -361,7 +388,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                           supportDataElement="replace"
                         />
                         <Button
-                          id="orgIdRestoreButton"
+                          data-test-id="orgIdRestoreButton"
                           label="Restore to default"
                           onClick={() => {
                             const instanceDefaults = getInstanceDefaults(
@@ -390,6 +417,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="edgeDomainField"
                           id="edgeDomainField"
                           name={`instances.${index}.edgeDomain`}
                           component={Textfield}
@@ -397,7 +425,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                           supportDataElement="replace"
                         />
                         <Button
-                          id="edgeDomainRestoreButton"
+                          data-test-id="edgeDomainRestoreButton"
                           label="Restore to default"
                           onClick={() => {
                             const instanceDefaults = getInstanceDefaults(
@@ -415,6 +443,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                     <div className="u-gapTop">
                       <InfoTipLayout tip="Allows uncaught errors to be displayed in the console.">
                         <WrappedField
+                          data-test-id="errorsEnabledField"
                           name={`instances.${index}.errorsEnabled`}
                           component={Checkbox}
                           label="Enable errors"
@@ -438,10 +467,12 @@ const Configuration = ({ formikProps, initInfo }) => {
                         componentClassName="u-flexColumn"
                       >
                         <Radio
+                          data-test-id="defaultConsentInField"
                           value={consentLevels.IN}
                           label="In - Do not wait for explicit consent."
                         />
                         <Radio
+                          data-test-id="defaultConsentOutField"
                           value={consentLevels.PENDING}
                           label="Pending - Queue privacy-sensitive work until the user gives consent."
                         />
@@ -453,6 +484,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                     <div className="u-gapTop">
                       <InfoTipLayout tip="Enables the AEP Web SDK to preserve the ECID by reading/writing the AMCV cookie. Use this config until users are fully migrated to the Alloy cookie and in situations where you have mixed pages on your website.">
                         <WrappedField
+                          data-test-id="idMigrationEnabledField"
                           name={`instances.${index}.idMigrationEnabled`}
                           component={Checkbox}
                           label="Migrate ECID from VisitorAPI to Alloy to prevent visitor cliffing"
@@ -463,6 +495,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                     <div className="u-gapTop">
                       <InfoTipLayout tip="Enables the setting of Adobe third-party cookies. The SDK has the ability to persist the visitor ID in a third-party context to enable the same visitor ID to be used across site. This is useful if you have multiple sites or you want to share data with partners; however, sometimes this is not desired for privacy reasons.">
                         <WrappedField
+                          data-test-id="thirdPartyCookiesEnabledField"
                           name={`instances.${index}.thirdPartyCookiesEnabled`}
                           component={Checkbox}
                           label="Use third-party cookies"
@@ -481,6 +514,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="prehidingStyleEditorButton"
                           id="prehidingStyleField"
                           name={`instances.${index}.prehidingStyle`}
                           component={EditorButton}
@@ -499,6 +533,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="onBeforeEventSendField"
                           id="onBeforeEventSendField"
                           name={`instances.${index}.onBeforeEventSend`}
                           component={Textfield}
@@ -510,6 +545,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                     <div className="u-gapTop">
                       <InfoTipLayout tip="Indicates whether data associated with clicks on navigational links, download links, or personalized content should be automatically collected.">
                         <WrappedField
+                          data-test-id="clickCollectionEnabledField"
                           name={`instances.${index}.clickCollectionEnabled`}
                           component={Checkbox}
                           label="Enable click data collection"
@@ -526,13 +562,14 @@ const Configuration = ({ formikProps, initInfo }) => {
                         </InfoTipLayout>
                         <div>
                           <WrappedField
+                            data-test-id="downloadLinkQualifierField"
                             id="downloadLinkQualifierField"
                             name={`instances.${index}.downloadLinkQualifier`}
                             component={Textfield}
                             componentClassName="u-fieldLong"
                           />
                           <Button
-                            id="downloadLinkQualifierTestButton"
+                            data-test-id="downloadLinkQualifierTestButton"
                             className="u-gapLeft"
                             label="Test"
                             onClick={() => {
@@ -555,7 +592,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                             quiet
                           />
                           <Button
-                            id="downloadLinkQualifierRestoreButton"
+                            data-test-id="downloadLinkQualifierRestoreButton"
                             label="Restore to default"
                             onClick={() => {
                               const instanceDefaults = getInstanceDefaults(
@@ -585,10 +622,12 @@ const Configuration = ({ formikProps, initInfo }) => {
                         componentClassName="u-flexColumn"
                       >
                         <Radio
+                          data-test-id="contextGranularityAllField"
                           value={contextGranularityEnum.ALL}
                           label="all context information"
                         />
                         <Radio
+                          data-test-id="contextGranularitySpecificField"
                           value={contextGranularityEnum.SPECIFIC}
                           label="specific context information"
                         />
@@ -621,6 +660,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                       </InfoTipLayout>
                       <div>
                         <WrappedField
+                          data-test-id="edgeBasePathField"
                           id="edgeBasePathField"
                           name={`instances.${index}.edgeBasePath`}
                           component={Textfield}
@@ -628,7 +668,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                           supportDataElement="replace"
                         />
                         <Button
-                          id="edgeBasePathRestoreButton"
+                          data-test-id="edgeBasePathRestoreButton"
                           label="Restore to default"
                           onClick={() => {
                             const instanceDefaults = getInstanceDefaults(
@@ -647,7 +687,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                     <div className="u-gapTop2x">
                       <ModalTrigger>
                         <Button
-                          id="deleteButton"
+                          data-test-id="deleteInstanceButton"
                           label="Delete Instance"
                           icon={<Delete />}
                           variant="action"
@@ -660,6 +700,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                           </span>
                         ) : null}
                         <Dialog
+                          id="resourceUsageDialog"
                           onConfirm={() => {
                             arrayHelpers.remove(index);
                             setSelectedAccordionIndex(0);

--- a/src/view/dataElements/instanceNameOnly.jsx
+++ b/src/view/dataElements/instanceNameOnly.jsx
@@ -44,9 +44,10 @@ const InstanceNameOnly = () => {
       render={({ initInfo }) => {
         return (
           <div>
-            <FieldLabel labelFor="configIdField" label="Instance" />
+            <FieldLabel labelFor="instanceNameField" label="Instance" />
             <div>
               <WrappedField
+                data-test-id="instanceNameField"
                 id="instanceNameField"
                 name="instanceName"
                 component={Select}

--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -52,3 +52,16 @@ For Adobe employees, please reach out to the `alloy-engineering` Slack channel a
 * `EDGE_E2E_CLIENT_SECRET` - The value of this variable should be the client secret.
 
 Once the environment variables are configured, tests that require authentication should run successfully.
+
+### Selecting DOM Elements
+
+When writing automated tests, it's likely you'll need to select a DOM element so the test can interact with the element. Where possible, add a `data-test-id` attribute to the element, even if the element already has an `id` attribute that may seem adequate. Then, select the element using an attribute CSS selector (see our helpful [data test ID selectors](../functional/helpers/dataTestIdSelectors.js)).
+
+If the DOM element you are attempting to interact with is a [React-Spectrum](https://react-spectrum.corp.adobe.com/) component or part of a React-Spectrum component, you may find our [spectrum helpers](../functional/helpers/spectrum.js) useful. When using the spectrum helpers, you can pass the element's "test ID" (the value of the element's `data-test-id` attribute) directly into the helper and it will automatically select the element using the `data-test-id` attribute.
+
+Values of `data-test-id` attributes should follow these standards:
+
+* Should be camelCased. Example: `resourceUsageDialog`
+* Should end in `Field` if the element in some component intended for user input (textfield, select, radio, checkbox, etc.). Example: `instanceNameField`
+* Should end in `Button` if the element is as button that allows the user to take some action. Example: `addCustomerIdButton`
+* Should integrate the index before the `Field` or `Button` suffix if an element is repeated multiple times. Example: `hashEnabled1Field`, `hashEnabled2Field`, `hashEnabled3Field`

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -13,20 +13,15 @@ governing permissions and limitations under the License.
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
 import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
-import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "actions/sendEvent.html"
 );
-const instanceNameField = spectrum.select(
-  createTestIdSelector("instanceNameField")
-);
-const viewStartField = spectrum.checkbox(
-  createTestIdSelector("viewStartField")
-);
-const xdmField = spectrum.textfield(createTestIdSelector("xdmField"));
-const typeField = spectrum.textfield(createTestIdSelector("typeField"));
-const mergeIdField = spectrum.textfield(createTestIdSelector("mergeIdField"));
+const instanceNameField = spectrum.select("instanceNameField");
+const viewStartField = spectrum.checkbox("viewStartField");
+const xdmField = spectrum.textfield("xdmField");
+const typeField = spectrum.textfield("typeField");
+const mergeIdField = spectrum.textfield("mergeIdField");
 
 const mockExtensionSettings = {
   instances: [

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -10,19 +10,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Selector } from "testcafe";
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
 import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
+import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "actions/sendEvent.html"
 );
-const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
-const viewStartField = spectrum.checkbox(Selector("[name=viewStart]"));
-const xdmField = spectrum.textfield(Selector("[name=xdm]"));
-const typeField = spectrum.textfield(Selector("[name=type]"));
-const mergeIdField = spectrum.textfield(Selector("[name=mergeId]"));
+const instanceNameField = spectrum.select(
+  createTestIdSelector("instanceNameField")
+);
+const viewStartField = spectrum.checkbox(
+  createTestIdSelector("viewStartField")
+);
+const xdmField = spectrum.textfield(createTestIdSelector("xdmField"));
+const typeField = spectrum.textfield(createTestIdSelector("typeField"));
+const mergeIdField = spectrum.textfield(createTestIdSelector("mergeIdField"));
 
 const mockExtensionSettings = {
   instances: [

--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -13,24 +13,17 @@ governing permissions and limitations under the License.
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
 import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
-import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "actions/setConsent.html"
 );
-const instanceNameField = spectrum.select(
-  createTestIdSelector("instanceNameField")
-);
+const instanceNameField = spectrum.select("instanceNameField");
 const radioGroup = {
-  inField: spectrum.radio(createTestIdSelector("inOptionField")),
-  outField: spectrum.radio(createTestIdSelector("outOptionField")),
-  dataElementField: spectrum.radio(
-    createTestIdSelector("dataElementOptionField")
-  )
+  inField: spectrum.radio("inOptionField"),
+  outField: spectrum.radio("outOptionField"),
+  dataElementField: spectrum.radio("dataElementOptionField")
 };
-const dataElementField = spectrum.textfield(
-  createTestIdSelector("dataElementField")
-);
+const dataElementField = spectrum.textfield("dataElementField");
 
 const mockExtensionSettings = {
   instances: [

--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -10,23 +10,27 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Selector } from "testcafe";
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
 import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
+import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "actions/setConsent.html"
 );
-const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
+const instanceNameField = spectrum.select(
+  createTestIdSelector("instanceNameField")
+);
 const radioGroup = {
-  inField: spectrum.radio(Selector(`[name='option'][value=in]`)),
-  outField: spectrum.radio(Selector(`[name='option'][value=out]`)),
+  inField: spectrum.radio(createTestIdSelector("inOptionField")),
+  outField: spectrum.radio(createTestIdSelector("outOptionField")),
   dataElementField: spectrum.radio(
-    Selector(`[name='option'][value=dataElement]`)
+    createTestIdSelector("dataElementOptionField")
   )
 };
-const dataElementField = spectrum.textfield(Selector("[name=dataElement]"));
+const dataElementField = spectrum.textfield(
+  createTestIdSelector("dataElementField")
+);
 
 const mockExtensionSettings = {
   instances: [

--- a/test/functional/actions/setCustomerIds.spec.js
+++ b/test/functional/actions/setCustomerIds.spec.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
-import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "actions/setCustomerIds.html"
@@ -31,28 +30,18 @@ const mockExtensionSettings = {
   ]
 };
 
-const instanceNameField = spectrum.select(
-  createTestIdSelector("instanceNameField")
-);
-const addCustomerIdButton = spectrum.button(
-  createTestIdSelector("addCustomerIdButton")
-);
+const instanceNameField = spectrum.select("instanceNameField");
+const addCustomerIdButton = spectrum.button("addCustomerIdButton");
 const customerIds = [];
 
 for (let i = 0; i < 2; i += 1) {
   customerIds.push({
-    namespaceField: spectrum.textfield(
-      createTestIdSelector(`namespace${i}Field`)
-    ),
-    idField: spectrum.textfield(createTestIdSelector(`id${i}Field`)),
-    hashEnabledField: spectrum.checkbox(
-      createTestIdSelector(`hashEnabled${i}Field`)
-    ),
-    authenticatedStateField: spectrum.select(
-      createTestIdSelector(`authenticatedState${i}Field`)
-    ),
-    primaryField: spectrum.checkbox(createTestIdSelector(`primary${i}Field`)),
-    deleteButton: spectrum.button(createTestIdSelector(`delete${i}Button`))
+    namespaceField: spectrum.textfield(`namespace${i}Field`),
+    idField: spectrum.textfield(`id${i}Field`),
+    hashEnabledField: spectrum.checkbox(`hashEnabled${i}Field`),
+    authenticatedStateField: spectrum.select(`authenticatedState${i}Field`),
+    primaryField: spectrum.checkbox(`primary${i}Field`),
+    deleteButton: spectrum.button(`delete${i}Button`)
   });
 }
 

--- a/test/functional/actions/setCustomerIds.spec.js
+++ b/test/functional/actions/setCustomerIds.spec.js
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Selector } from "testcafe";
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
+import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "actions/setCustomerIds.html"
@@ -31,27 +31,28 @@ const mockExtensionSettings = {
   ]
 };
 
-const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
-const addCustomerIdButton = spectrum.button(Selector("#addCustomerId"));
+const instanceNameField = spectrum.select(
+  createTestIdSelector("instanceNameField")
+);
+const addCustomerIdButton = spectrum.button(
+  createTestIdSelector("addCustomerIdButton")
+);
 const customerIds = [];
 
 for (let i = 0; i < 2; i += 1) {
   customerIds.push({
     namespaceField: spectrum.textfield(
-      Selector(`[name='customerIds.${i}.namespace']`)
+      createTestIdSelector(`namespace${i}Field`)
     ),
-    idField: spectrum.textfield(Selector(`[name='customerIds.${i}.id']`)),
+    idField: spectrum.textfield(createTestIdSelector(`id${i}Field`)),
     hashEnabledField: spectrum.checkbox(
-      Selector(`[name='customerIds.${i}.hashEnabled']`)
+      createTestIdSelector(`hashEnabled${i}Field`)
     ),
     authenticatedStateField: spectrum.select(
-      Selector(`[name='customerIds.${i}.authenticatedState']`)
+      createTestIdSelector(`authenticatedState${i}Field`)
     ),
-    primaryField: spectrum.checkbox(
-      Selector(`[name='customerIds.${i}.primary']`)
-    ),
-    deleteButton: spectrum.button(Selector(`#deleteButton${i}`)),
-    deleteDialog: spectrum.dialog(Selector(`#deleteCustomerId${i}`))
+    primaryField: spectrum.checkbox(createTestIdSelector(`primary${i}Field`)),
+    deleteButton: spectrum.button(createTestIdSelector(`delete${i}Button`))
   });
 }
 

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -13,18 +13,13 @@ governing permissions and limitations under the License.
 import { Selector } from "testcafe";
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
-import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "configuration/configuration.html"
 );
 
-const addInstanceButton = spectrum.button(
-  createTestIdSelector("addInstanceButton")
-);
-const accordion = spectrum.accordion(
-  createTestIdSelector("instancesAccordion")
-);
+const addInstanceButton = spectrum.button("addInstanceButton");
+const accordion = spectrum.accordion("instancesAccordion");
 
 // We can't use data-test-id on Dialog because of a Spectrum bug.
 // https://git.corp.adobe.com/React/react-spectrum-v2/issues/501
@@ -34,81 +29,51 @@ const instances = [];
 
 for (let i = 0; i < 2; i += 1) {
   instances.push({
-    nameField: spectrum.textfield(createTestIdSelector("nameField")),
-    nameChangeAlert: spectrum.alert(createTestIdSelector("nameChangeAlert")),
-    configIdField: spectrum.textfield(createTestIdSelector("configIdField")),
-    orgIdField: spectrum.textfield(createTestIdSelector("orgIdField")),
-    orgIdRestoreButton: spectrum.button(
-      createTestIdSelector("orgIdRestoreButton")
-    ),
-    edgeDomainField: spectrum.textfield(
-      createTestIdSelector("edgeDomainField")
-    ),
-    edgeDomainRestoreButton: spectrum.button(
-      createTestIdSelector("edgeDomainRestoreButton")
-    ),
-    edgeBasePathField: spectrum.textfield(
-      createTestIdSelector("edgeBasePathField")
-    ),
-    edgeBasePathRestoreButton: spectrum.button(
-      createTestIdSelector("edgeBasePathRestoreButton")
-    ),
-    errorsEnabledField: spectrum.checkbox(
-      createTestIdSelector("errorsEnabledField")
-    ),
+    nameField: spectrum.textfield("nameField"),
+    nameChangeAlert: spectrum.alert("nameChangeAlert"),
+    configIdField: spectrum.textfield("configIdField"),
+    orgIdField: spectrum.textfield("orgIdField"),
+    orgIdRestoreButton: spectrum.button("orgIdRestoreButton"),
+    edgeDomainField: spectrum.textfield("edgeDomainField"),
+    edgeDomainRestoreButton: spectrum.button("edgeDomainRestoreButton"),
+    edgeBasePathField: spectrum.textfield("edgeBasePathField"),
+    edgeBasePathRestoreButton: spectrum.button("edgeBasePathRestoreButton"),
+    errorsEnabledField: spectrum.checkbox("errorsEnabledField"),
     defaultConsent: {
-      inField: spectrum.radio(createTestIdSelector("defaultConsentInField")),
-      pendingField: spectrum.radio(
-        createTestIdSelector("defaultConsentOutField")
-      )
+      inField: spectrum.radio("defaultConsentInField"),
+      pendingField: spectrum.radio("defaultConsentOutField")
     },
-    idMigrationEnabled: spectrum.checkbox(
-      createTestIdSelector("idMigrationEnabledField")
-    ),
+    idMigrationEnabled: spectrum.checkbox("idMigrationEnabledField"),
     thirdPartyCookiesEnabled: spectrum.checkbox(
-      createTestIdSelector("thirdPartyCookiesEnabledField")
+      "thirdPartyCookiesEnabledField"
     ),
     // Due to limitations of the sandbox where tests are run,
     // testing prehiding style viewing/editing is limited.
-    prehidingStyleEditorButton: spectrum.button(
-      createTestIdSelector("prehidingStyleEditorButton")
-    ),
+    prehidingStyleEditorButton: spectrum.button("prehidingStyleEditorButton"),
     clickCollectionEnabledField: spectrum.checkbox(
-      createTestIdSelector("clickCollectionEnabledField")
+      "clickCollectionEnabledField"
     ),
     downloadLinkQualifierField: spectrum.textfield(
-      createTestIdSelector("downloadLinkQualifierField")
+      "downloadLinkQualifierField"
     ),
     downloadLinkQualifierRestoreButton: spectrum.button(
-      createTestIdSelector("downloadLinkQualifierRestoreButton")
+      "downloadLinkQualifierRestoreButton"
     ),
     downloadLinkQualifierTestButton: spectrum.button(
-      createTestIdSelector("downloadLinkQualifierTestButton")
+      "downloadLinkQualifierTestButton"
     ),
-    onBeforeEventSendField: spectrum.textfield(
-      createTestIdSelector("onBeforeEventSendField")
-    ),
+    onBeforeEventSendField: spectrum.textfield("onBeforeEventSendField"),
     contextGranularity: {
-      allField: spectrum.radio(
-        createTestIdSelector("contextGranularityAllField")
-      ),
-      specificField: spectrum.radio(
-        createTestIdSelector("contextGranularitySpecificField")
-      )
+      allField: spectrum.radio("contextGranularityAllField"),
+      specificField: spectrum.radio("contextGranularitySpecificField")
     },
     specificContext: {
-      webField: spectrum.checkbox(createTestIdSelector("contextWebField")),
-      deviceField: spectrum.checkbox(
-        createTestIdSelector("contextDeviceField")
-      ),
-      environmentField: spectrum.checkbox(
-        createTestIdSelector("contextEnvironmentField")
-      ),
-      placeContextField: spectrum.checkbox(
-        createTestIdSelector("contextPlaceContextField")
-      )
+      webField: spectrum.checkbox("contextWebField"),
+      deviceField: spectrum.checkbox("contextDeviceField"),
+      environmentField: spectrum.checkbox("contextEnvironmentField"),
+      placeContextField: spectrum.checkbox("contextPlaceContextField")
     },
-    deleteButton: spectrum.button(createTestIdSelector("deleteInstanceButton"))
+    deleteButton: spectrum.button("deleteInstanceButton")
   });
 }
 

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -13,94 +13,102 @@ governing permissions and limitations under the License.
 import { Selector } from "testcafe";
 import createExtensionViewController from "../helpers/createExtensionViewController";
 import spectrum from "../helpers/spectrum";
+import { createTestIdSelector } from "../helpers/dataTestIdSelectors";
 
 const extensionViewController = createExtensionViewController(
   "configuration/configuration.html"
 );
 
 const addInstanceButton = spectrum.button(
-  Selector(".spectrum-Button").withText("Add Instance")
+  createTestIdSelector("addInstanceButton")
 );
-const accordion = spectrum.accordion(Selector(".spectrum-Accordion"));
-const resourceUsageDialog = spectrum.dialog(Selector(".spectrum-Dialog"));
+const accordion = spectrum.accordion(
+  createTestIdSelector("instancesAccordion")
+);
+
+// We can't use data-test-id on Dialog because of a Spectrum bug.
+// https://git.corp.adobe.com/React/react-spectrum-v2/issues/501
+const resourceUsageDialog = spectrum.dialog(Selector("#resourceUsageDialog"));
 
 const instances = [];
 
 for (let i = 0; i < 2; i += 1) {
   instances.push({
-    nameField: spectrum.textfield(Selector(`[name='instances.${i}.name']`)),
-    nameChangeAlert: spectrum.alert(Selector("#nameChangeAlert")),
-    configIdField: spectrum.textfield(
-      Selector(`[name='instances.${i}.configId']`)
+    nameField: spectrum.textfield(createTestIdSelector("nameField")),
+    nameChangeAlert: spectrum.alert(createTestIdSelector("nameChangeAlert")),
+    configIdField: spectrum.textfield(createTestIdSelector("configIdField")),
+    orgIdField: spectrum.textfield(createTestIdSelector("orgIdField")),
+    orgIdRestoreButton: spectrum.button(
+      createTestIdSelector("orgIdRestoreButton")
     ),
-    orgIdField: spectrum.textfield(Selector(`[name='instances.${i}.orgId']`)),
-    orgIdRestoreButton: spectrum.button(Selector("#orgIdRestoreButton")),
     edgeDomainField: spectrum.textfield(
-      Selector(`[name='instances.${i}.edgeDomain']`)
+      createTestIdSelector("edgeDomainField")
     ),
     edgeDomainRestoreButton: spectrum.button(
-      Selector(`#edgeDomainRestoreButton`)
+      createTestIdSelector("edgeDomainRestoreButton")
     ),
     edgeBasePathField: spectrum.textfield(
-      Selector(`[name='instances.${i}.edgeBasePath']`)
+      createTestIdSelector("edgeBasePathField")
     ),
     edgeBasePathRestoreButton: spectrum.button(
-      Selector(`#edgeBasePathRestoreButton`)
+      createTestIdSelector("edgeBasePathRestoreButton")
     ),
     errorsEnabledField: spectrum.checkbox(
-      Selector(`[name='instances.${i}.errorsEnabled']`)
+      createTestIdSelector("errorsEnabledField")
     ),
     defaultConsent: {
-      inField: spectrum.radio(
-        Selector(`[name='instances.${i}.defaultConsent.general'][value=in]`)
-      ),
+      inField: spectrum.radio(createTestIdSelector("defaultConsentInField")),
       pendingField: spectrum.radio(
-        Selector(
-          `[name='instances.${i}.defaultConsent.general'][value=pending]`
-        )
+        createTestIdSelector("defaultConsentOutField")
       )
     },
     idMigrationEnabled: spectrum.checkbox(
-      Selector(`[name='instances.${i}.idMigrationEnabled']`)
+      createTestIdSelector("idMigrationEnabledField")
     ),
     thirdPartyCookiesEnabled: spectrum.checkbox(
-      Selector(`[name='instances.${i}.thirdPartyCookiesEnabled']`)
+      createTestIdSelector("thirdPartyCookiesEnabledField")
     ),
     // Due to limitations of the sandbox where tests are run,
-    // testing prehding style viewing/editing is limited.
-    prehidingStyleField: spectrum.button(
-      Selector(`button`).withText("Open Editor")
+    // testing prehiding style viewing/editing is limited.
+    prehidingStyleEditorButton: spectrum.button(
+      createTestIdSelector("prehidingStyleEditorButton")
     ),
     clickCollectionEnabledField: spectrum.checkbox(
-      Selector(`[name='instances.${i}.clickCollectionEnabled']`)
+      createTestIdSelector("clickCollectionEnabledField")
     ),
     downloadLinkQualifierField: spectrum.textfield(
-      Selector(`[name='instances.${i}.downloadLinkQualifier']`)
+      createTestIdSelector("downloadLinkQualifierField")
     ),
     downloadLinkQualifierRestoreButton: spectrum.button(
-      Selector(`#downloadLinkQualifierRestoreButton`)
+      createTestIdSelector("downloadLinkQualifierRestoreButton")
     ),
     downloadLinkQualifierTestButton: spectrum.button(
-      Selector(`#downloadLinkQualifierTestButton`)
+      createTestIdSelector("downloadLinkQualifierTestButton")
     ),
     onBeforeEventSendField: spectrum.textfield(
-      Selector(`[name='instances.${i}.onBeforeEventSend']`)
+      createTestIdSelector("onBeforeEventSendField")
     ),
     contextGranularity: {
       allField: spectrum.radio(
-        Selector(`[name='instances.${i}.contextGranularity'][value=all]`)
+        createTestIdSelector("contextGranularityAllField")
       ),
       specificField: spectrum.radio(
-        Selector(`[name='instances.${i}.contextGranularity'][value=specific]`)
+        createTestIdSelector("contextGranularitySpecificField")
       )
     },
     specificContext: {
-      webField: spectrum.checkbox(Selector("[value=web]")),
-      deviceField: spectrum.checkbox(Selector("[value=device]")),
-      environmentField: spectrum.checkbox(Selector("[value=environment]")),
-      placeContextField: spectrum.checkbox(Selector("[value=placeContext]"))
+      webField: spectrum.checkbox(createTestIdSelector("contextWebField")),
+      deviceField: spectrum.checkbox(
+        createTestIdSelector("contextDeviceField")
+      ),
+      environmentField: spectrum.checkbox(
+        createTestIdSelector("contextEnvironmentField")
+      ),
+      placeContextField: spectrum.checkbox(
+        createTestIdSelector("contextPlaceContextField")
+      )
     },
-    deleteButton: spectrum.button(Selector("#deleteButton"))
+    deleteButton: spectrum.button(createTestIdSelector("deleteInstanceButton"))
   });
 }
 
@@ -288,7 +296,7 @@ test("returns full valid settings", async () => {
   await instances[0].defaultConsent.pendingField.click();
   await instances[0].idMigrationEnabled.click();
   await instances[0].thirdPartyCookiesEnabled.click();
-  await instances[0].prehidingStyleField.click();
+  await instances[0].prehidingStyleEditorButton.click();
   await instances[0].onBeforeEventSendField.typeText("%foo%");
   await addInstanceButton.click();
 
@@ -511,7 +519,6 @@ test("deletes an instance", async () => {
   await instances[0].configIdField.expectValue("PR123");
   // Alright, delete for real.
   await instances[0].deleteButton.click();
-  await resourceUsageDialog.expectTitle("Resource Usage");
   await resourceUsageDialog.clickConfirm();
   await instances[0].configIdField.expectValue("PR456");
 });

--- a/test/functional/dataElements/xdmObject/helpers/arrayItemsEdit.js
+++ b/test/functional/dataElements/xdmObject/helpers/arrayItemsEdit.js
@@ -11,23 +11,18 @@ governing permissions and limitations under the License.
 */
 
 import spectrum from "../../../helpers/spectrum";
-import { createTestIdSelector } from "../../../helpers/dataTestIdSelectors";
 
 /**
  * Provides methods for managing an array's items when on the array's edit view.
  */
 export default {
   addItem: async () => {
-    await spectrum.button(createTestIdSelector("addItemButton")).click();
+    await spectrum.button("addItemButton").click();
   },
   removeItem: async index => {
-    await spectrum
-      .button(createTestIdSelector(`item${index}RemoveButton`))
-      .click();
+    await spectrum.button(`item${index}RemoveButton`).click();
   },
   clickItem: async index => {
-    await spectrum
-      .button(createTestIdSelector(`item${index}SelectButton`))
-      .click();
+    await spectrum.button(`item${index}SelectButton`).click();
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/arrayItemsEdit.js
+++ b/test/functional/dataElements/xdmObject/helpers/arrayItemsEdit.js
@@ -11,23 +11,23 @@ governing permissions and limitations under the License.
 */
 
 import spectrum from "../../../helpers/spectrum";
-import { createDataTestIdSelector } from "../../../helpers/dataTestIdSelectors";
+import { createTestIdSelector } from "../../../helpers/dataTestIdSelectors";
 
 /**
  * Provides methods for managing an array's items when on the array's edit view.
  */
 export default {
   addItem: async () => {
-    await spectrum.button(createDataTestIdSelector("addItemButton")).click();
+    await spectrum.button(createTestIdSelector("addItemButton")).click();
   },
   removeItem: async index => {
     await spectrum
-      .button(createDataTestIdSelector(`item${index}RemoveButton`))
+      .button(createTestIdSelector(`item${index}RemoveButton`))
       .click();
   },
   clickItem: async index => {
     await spectrum
-      .button(createDataTestIdSelector(`item${index}SelectButton`))
+      .button(createTestIdSelector(`item${index}SelectButton`))
       .click();
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/nodeEdit.js
+++ b/test/functional/dataElements/xdmObject/helpers/nodeEdit.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import spectrum from "../../../helpers/spectrum";
-import { createDataTestIdSelector } from "../../../helpers/dataTestIdSelectors";
+import { createTestIdSelector } from "../../../helpers/dataTestIdSelectors";
 
 /**
  * Provides methods for managing form fields when editing a node.
@@ -19,22 +19,22 @@ import { createDataTestIdSelector } from "../../../helpers/dataTestIdSelectors";
 export default {
   selectPartsPopulationStrategy: async () => {
     await spectrum
-      .radio(createDataTestIdSelector("partsPopulationStrategyField"))
+      .radio(createTestIdSelector("partsPopulationStrategyField"))
       .click();
   },
   selectWholePopulationStrategy: async () => {
     await spectrum
-      .radio(createDataTestIdSelector("wholePopulationStrategyField"))
+      .radio(createTestIdSelector("wholePopulationStrategyField"))
       .click();
   },
   enterWholeValue: async text => {
     await spectrum
-      .textfield(createDataTestIdSelector("wholeValueField"))
+      .textfield(createTestIdSelector("wholeValueField"))
       .typeText(text);
   },
   expectWholeValue: async text => {
     await spectrum
-      .textfield(createDataTestIdSelector("wholeValueField"))
+      .textfield(createTestIdSelector("wholeValueField"))
       .expectValue(text);
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/nodeEdit.js
+++ b/test/functional/dataElements/xdmObject/helpers/nodeEdit.js
@@ -11,30 +11,21 @@ governing permissions and limitations under the License.
 */
 
 import spectrum from "../../../helpers/spectrum";
-import { createTestIdSelector } from "../../../helpers/dataTestIdSelectors";
 
 /**
  * Provides methods for managing form fields when editing a node.
  */
 export default {
   selectPartsPopulationStrategy: async () => {
-    await spectrum
-      .radio(createTestIdSelector("partsPopulationStrategyField"))
-      .click();
+    await spectrum.radio("partsPopulationStrategyField").click();
   },
   selectWholePopulationStrategy: async () => {
-    await spectrum
-      .radio(createTestIdSelector("wholePopulationStrategyField"))
-      .click();
+    await spectrum.radio("wholePopulationStrategyField").click();
   },
   enterWholeValue: async text => {
-    await spectrum
-      .textfield(createTestIdSelector("wholeValueField"))
-      .typeText(text);
+    await spectrum.textfield("wholeValueField").typeText(text);
   },
   expectWholeValue: async text => {
-    await spectrum
-      .textfield(createTestIdSelector("wholeValueField"))
-      .expectValue(text);
+    await spectrum.textfield("wholeValueField").expectValue(text);
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/xdmTree.js
+++ b/test/functional/dataElements/xdmObject/helpers/xdmTree.js
@@ -13,18 +13,18 @@ governing permissions and limitations under the License.
 import { t } from "testcafe";
 import switchToIframe from "../../../helpers/switchToIframe";
 import {
-  createDataTestIdSelector,
-  createDataTestIdSelectorString
+  createTestIdSelector,
+  createTestIdSelectorString
 } from "../../../helpers/dataTestIdSelectors";
 
-const xdmTree = createDataTestIdSelector("xdmTree");
+const xdmTree = createTestIdSelector("xdmTree");
 
 const getNode = async title => {
   await switchToIframe();
   return xdmTree
-    .find(createDataTestIdSelectorString("xdmTreeNodeTitleDisplayName"))
+    .find(createTestIdSelectorString("xdmTreeNodeTitleDisplayName"))
     .withText(title)
-    .parent(createDataTestIdSelectorString("xdmTreeNodeTitle"))
+    .parent(createTestIdSelectorString("xdmTreeNodeTitle"))
     .nth(0);
 };
 

--- a/test/functional/helpers/dataTestIdSelectors.js
+++ b/test/functional/helpers/dataTestIdSelectors.js
@@ -18,7 +18,7 @@ import { Selector } from "testcafe";
  * @param {string} dataTestId The value of the data-test-id attribute.
  * @returns {string}
  */
-export const createDataTestIdSelectorString = dataTestId =>
+export const createTestIdSelectorString = dataTestId =>
   `[data-test-id='${dataTestId}']`;
 
 /**
@@ -27,5 +27,5 @@ export const createDataTestIdSelectorString = dataTestId =>
  * @param {string} dataTestId The value of the data-test-id attribute.
  * @returns {Selector}
  */
-export const createDataTestIdSelector = dataTestId =>
-  Selector(createDataTestIdSelectorString(dataTestId));
+export const createTestIdSelector = dataTestId =>
+  Selector(createTestIdSelectorString(dataTestId));

--- a/test/functional/helpers/spectrum.js
+++ b/test/functional/helpers/spectrum.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import { Selector, t } from "testcafe";
 import switchToIframe from "./switchToIframe";
+import { createTestIdSelector } from "./dataTestIdSelectors";
 
 const popoverSelector = Selector(".spectrum-Popover");
 const menuItemLabelCssSelector = ".spectrum-Menu-itemLabel";
@@ -98,7 +99,8 @@ const createExpectDisabled = selector => async () => {
 // additional components and methods. We always include the original
 // selector on the returned object, so if we need to do something
 // a bit more custom inside the test, the test can use the selector
-// and TestCafe APIs directly.
+// and TestCafe APIs directly. A test ID string or a Selector can
+// be passed into each component wrapper.
 const componentWrappers = {
   select(selector) {
     return {
@@ -202,10 +204,22 @@ const componentWrappers = {
   }
 };
 
+/**
+ * Given a test ID string or a selector, it returns a selector.
+ * @param {string|Selector} testIdOrSelector
+ * @returns {Selector}
+ */
+const selectorize = testIdOrSelector => {
+  return typeof testIdOrSelector === "string"
+    ? createTestIdSelector(testIdOrSelector)
+    : testIdOrSelector;
+};
+
 // This adds certain properties to all component wrappers.
 Object.keys(componentWrappers).forEach(componentName => {
   const componentWrapper = componentWrappers[componentName];
-  componentWrappers[componentName] = selector => {
+  componentWrappers[componentName] = testIdOrSelector => {
+    const selector = selectorize(testIdOrSelector);
     return {
       ...componentWrapper(selector),
       selector,

--- a/test/functional/helpers/testInstanceNameOnlyView.js
+++ b/test/functional/helpers/testInstanceNameOnlyView.js
@@ -1,10 +1,7 @@
 import spectrum from "./spectrum";
 import testInstanceNameOptions from "./testInstanceNameOptions";
-import { createTestIdSelector } from "./dataTestIdSelectors";
 
-const instanceNameField = spectrum.select(
-  createTestIdSelector("instanceNameField")
-);
+const instanceNameField = spectrum.select("instanceNameField");
 
 const mockExtensionSettings = {
   instances: [

--- a/test/functional/helpers/testInstanceNameOnlyView.js
+++ b/test/functional/helpers/testInstanceNameOnlyView.js
@@ -1,8 +1,10 @@
-import { Selector } from "testcafe";
 import spectrum from "./spectrum";
 import testInstanceNameOptions from "./testInstanceNameOptions";
+import { createTestIdSelector } from "./dataTestIdSelectors";
 
-const instanceNameField = spectrum.select(Selector("[name=instanceName]"));
+const instanceNameField = spectrum.select(
+  createTestIdSelector("instanceNameField")
+);
 
 const mockExtensionSettings = {
   instances: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Convert to using test IDs in tests. This is so we have a consistent way of referencing DOM elements that is less fragile than other options.

In full disclosure, for a proper e2e test, it's usually recommended to reference elements by what the user sees (the label, field placeholder, etc.). This is because, in an end-to-end test, one "end" is the user, and the user looks for the button that says "Add", for example, rather than looking for the button with some attribute or class name (that's what developers do). This is a relevant explanation: https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change

However, there are downsides to this. It's often more costly to maintain and in many cases it's very difficult to achieve this for certain elements, which means we have inconsistencies in how we select elements. As we discussed this as a team, it was decided we would use `data-test-id` attributes for selecting DOM elements.

I have three commits: One where I switch everything over to `data-test-id` attributes. One where I add built-in-support for test IDs inside our `spectrum` helper module, which allows us to just pass in a test ID (or a `Selector` if necessary). The last commit removes `data-test-id` attributes from production builds since they're only needed for e2e tests.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-42303
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Consistency and simplicity.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
