### PR TITLE
Removed turbine variable helper.

### DIFF
--- a/src/lib/actions/sendEvent/createSendEvent.js
+++ b/src/lib/actions/sendEvent/createSendEvent.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = instanceManager => settings => {
+module.exports = ({ instanceManager, turbine }) => settings => {
   const { instanceName, ...otherSettings } = settings;
   const instanceAccessor = instanceManager.getAccessor(instanceName);
 

--- a/src/lib/actions/sendEvent/index.js
+++ b/src/lib/actions/sendEvent/index.js
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 const createSendEvent = require("./createSendEvent");
 const instanceManager = require("../../instanceManager/index");
 
-module.exports = createSendEvent(instanceManager);
+module.exports = createSendEvent({ instanceManager, turbine });

--- a/src/lib/actions/setConsent/createSetConsent.js
+++ b/src/lib/actions/setConsent/createSetConsent.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = instanceManager => settings => {
+module.exports = ({ instanceManager, turbine }) => settings => {
   const { instanceName, consent } = settings;
   const instanceAccessor = instanceManager.getAccessor(instanceName);
 

--- a/src/lib/actions/setConsent/index.js
+++ b/src/lib/actions/setConsent/index.js
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 const createSetConsent = require("./createSetConsent");
 const instanceManager = require("../../instanceManager/index");
 
-module.exports = createSetConsent(instanceManager);
+module.exports = createSetConsent({ instanceManager, turbine });

--- a/src/lib/actions/setCustomerIds/createSetCustomerIds.js
+++ b/src/lib/actions/setCustomerIds/createSetCustomerIds.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = instanceManager => settings => {
+module.exports = ({ instanceManager, turbine }) => settings => {
   const { instanceName, customerIds } = settings;
   const instanceAccessor = instanceManager.getAccessor(instanceName);
 

--- a/src/lib/actions/setCustomerIds/index.js
+++ b/src/lib/actions/setCustomerIds/index.js
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 const createSetCustomerIds = require("./createSetCustomerIds");
 const instanceManager = require("../../instanceManager/index");
 
-module.exports = createSetCustomerIds(instanceManager);
+module.exports = createSetCustomerIds({ instanceManager, turbine });

--- a/src/lib/dataElements/ecid/createEcid.js
+++ b/src/lib/dataElements/ecid/createEcid.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = instanceManager => settings => {
+module.exports = ({ instanceManager, turbine }) => settings => {
   const { instanceName } = settings;
   const instanceAccessor = instanceManager.getAccessor(instanceName);
   let ecid;

--- a/src/lib/dataElements/ecid/index.js
+++ b/src/lib/dataElements/ecid/index.js
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 const createEcid = require("./createEcid");
 const instanceManager = require("../../instanceManager/index");
 
-module.exports = createEcid(instanceManager);
+module.exports = createEcid({ instanceManager, turbine });

--- a/src/lib/dataElements/eventMergeId/createEventMergeId.js
+++ b/src/lib/dataElements/eventMergeId/createEventMergeId.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = instanceManager => settings => {
+module.exports = ({ instanceManager, turbine }) => settings => {
   const { instanceName } = settings;
   const instanceAccessor = instanceManager.getAccessor(instanceName);
   let eventMergeId;

--- a/src/lib/dataElements/eventMergeId/index.js
+++ b/src/lib/dataElements/eventMergeId/index.js
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 const createEventMergeId = require("./createEventMergeId");
 const instanceManager = require("../../instanceManager/index");
 
-module.exports = createEventMergeId(instanceManager);
+module.exports = createEventMergeId({ instanceManager, turbine });

--- a/src/lib/instanceManager/createInstanceManager.js
+++ b/src/lib/instanceManager/createInstanceManager.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = (window, runAlloy, orgId) => {
+module.exports = ({ turbine, window, runAlloy, orgId }) => {
   const accessorByInstanceName = {};
   const { instances } = turbine.getExtensionSettings();
   const names = instances.map(instance => instance.name);

--- a/src/lib/instanceManager/index.js
+++ b/src/lib/instanceManager/index.js
@@ -13,8 +13,9 @@ governing permissions and limitations under the License.
 const runAlloy = require("../runAlloy");
 const createInstanceManager = require("./createInstanceManager");
 
-module.exports = createInstanceManager(
+module.exports = createInstanceManager({
+  turbine,
   window,
   runAlloy,
-  _satellite.company.orgId
-);
+  orgId: _satellite.company.orgId
+});

--- a/test/unit/helpers/turbineVariable.js
+++ b/test/unit/helpers/turbineVariable.js
@@ -1,8 +1,0 @@
-module.exports = {
-  mock(turbine) {
-    window.turbine = turbine;
-  },
-  reset() {
-    delete window.turbine;
-  }
-};

--- a/test/unit/lib/actions/sendEvent/createSendEvent.spec.js
+++ b/test/unit/lib/actions/sendEvent/createSendEvent.spec.js
@@ -11,22 +11,14 @@ governing permissions and limitations under the License.
 */
 
 import createSendEvent from "../../../../../src/lib/actions/sendEvent/createSendEvent";
-import turbineVariable from "../../../helpers/turbineVariable";
 
 describe("Send Event", () => {
-  let mockLogger;
+  let turbine;
 
   beforeEach(() => {
-    mockLogger = {
-      error: jasmine.createSpy()
+    turbine = {
+      logger: jasmine.createSpyObj("logger", ["error"])
     };
-    turbineVariable.mock({
-      logger: mockLogger
-    });
-  });
-
-  afterEach(() => {
-    turbineVariable.reset();
   });
 
   it("executes event command", () => {
@@ -36,7 +28,7 @@ describe("Send Event", () => {
         instance
       })
     };
-    const action = createSendEvent(instanceManager);
+    const action = createSendEvent({ instanceManager, turbine });
 
     action({
       instanceName: "myinstance",
@@ -61,7 +53,7 @@ describe("Send Event", () => {
         return undefined;
       }
     };
-    const action = createSendEvent(instanceManager);
+    const action = createSendEvent({ instanceManager, turbine });
 
     action({
       instanceName: "myinstance",
@@ -71,7 +63,7 @@ describe("Send Event", () => {
       }
     });
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(turbine.logger.error).toHaveBeenCalledWith(
       'Failed to send event for instance "myinstance". No matching instance was configured with this name.'
     );
   });

--- a/test/unit/lib/actions/setConsent/createSetConsent.spec.js
+++ b/test/unit/lib/actions/setConsent/createSetConsent.spec.js
@@ -11,22 +11,14 @@ governing permissions and limitations under the License.
 */
 
 import createSetConsent from "../../../../../src/lib/actions/setConsent/createSetConsent";
-import turbineVariable from "../../../helpers/turbineVariable";
 
 describe("Set Consent", () => {
-  let mockLogger;
+  let turbine;
 
   beforeEach(() => {
-    mockLogger = {
-      error: jasmine.createSpy()
+    turbine = {
+      logger: jasmine.createSpyObj("logger", ["error"])
     };
-    turbineVariable.mock({
-      logger: mockLogger
-    });
-  });
-
-  afterEach(() => {
-    turbineVariable.reset();
   });
 
   ["in", "out"].forEach(generalConsent => {
@@ -37,7 +29,7 @@ describe("Set Consent", () => {
           instance
         })
       };
-      const action = createSetConsent(instanceManager);
+      const action = createSetConsent({ instanceManager, turbine });
 
       action({
         instanceName: "myinstance",
@@ -57,14 +49,14 @@ describe("Set Consent", () => {
         return undefined;
       }
     };
-    const action = createSetConsent(instanceManager);
+    const action = createSetConsent({ instanceManager, turbine });
 
     action({
       instanceName: "myinstance",
       purposes: "none"
     });
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(turbine.logger.error).toHaveBeenCalledWith(
       'Failed to set consent for instance "myinstance". No matching instance was configured with this name.'
     );
   });

--- a/test/unit/lib/actions/setCustomerIds/createSetCustumerIds.spec.js
+++ b/test/unit/lib/actions/setCustomerIds/createSetCustumerIds.spec.js
@@ -11,22 +11,14 @@ governing permissions and limitations under the License.
 */
 
 import createSetCustomerIds from "../../../../../src/lib/actions/setCustomerIds/createSetCustomerIds";
-import turbineVariable from "../../../helpers/turbineVariable";
 
 describe("Set Customer IDs", () => {
-  let mockLogger;
+  let turbine;
 
   beforeEach(() => {
-    mockLogger = {
-      error: jasmine.createSpy()
+    turbine = {
+      logger: jasmine.createSpyObj("logger", ["error"])
     };
-    turbineVariable.mock({
-      logger: mockLogger
-    });
-  });
-
-  afterEach(() => {
-    turbineVariable.reset();
   });
 
   it("executes setCustomerIds command", () => {
@@ -36,7 +28,7 @@ describe("Set Customer IDs", () => {
         instance
       })
     };
-    const action = createSetCustomerIds(instanceManager);
+    const action = createSetCustomerIds({ instanceManager, turbine });
 
     action({
       instanceName: "instance1",
@@ -69,7 +61,7 @@ describe("Set Customer IDs", () => {
         return undefined;
       }
     };
-    const action = createSetCustomerIds(instanceManager);
+    const action = createSetCustomerIds({ instanceManager, turbine });
 
     action({
       instanceName: "instance1",
@@ -84,7 +76,7 @@ describe("Set Customer IDs", () => {
       ]
     });
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(turbine.logger.error).toHaveBeenCalledWith(
       'Failed to set customer IDs for instance "instance1". No matching instance was configured with this name.'
     );
   });

--- a/test/unit/lib/dataElements/ecid/createEcid.spec.js
+++ b/test/unit/lib/dataElements/ecid/createEcid.spec.js
@@ -11,22 +11,14 @@ governing permissions and limitations under the License.
 */
 
 import createEcid from "../../../../../src/lib/dataElements/ecid/createEcid";
-import turbineVariable from "../../../helpers/turbineVariable";
 
 describe("ECID", () => {
-  let mockLogger;
+  let turbine;
 
   beforeEach(() => {
-    mockLogger = {
-      error: jasmine.createSpy()
+    turbine = {
+      logger: jasmine.createSpyObj("logger", ["error"])
     };
-    turbineVariable.mock({
-      logger: mockLogger
-    });
-  });
-
-  afterEach(() => {
-    turbineVariable.reset();
   });
 
   it("returns ECID", () => {
@@ -37,7 +29,7 @@ describe("ECID", () => {
         }
       })
     };
-    const dataElement = createEcid(instanceManager);
+    const dataElement = createEcid({ instanceManager, turbine });
 
     const value = dataElement({
       instanceName: "myinstance"
@@ -51,13 +43,13 @@ describe("ECID", () => {
     const instanceManager = {
       getAccessor: () => undefined
     };
-    const dataElement = createEcid(instanceManager);
+    const dataElement = createEcid({ instanceManager, turbine });
 
     dataElement({
       instanceName: "myinstance"
     });
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(turbine.logger.error).toHaveBeenCalledWith(
       'Failed to retrieve ECID for instance "myinstance". No matching instance was configured with this name.'
     );
   });

--- a/test/unit/lib/dataElements/eventMergeId/createEventMergeId.spec.js
+++ b/test/unit/lib/dataElements/eventMergeId/createEventMergeId.spec.js
@@ -11,22 +11,14 @@ governing permissions and limitations under the License.
 */
 
 import createEventMergeId from "../../../../../src/lib/dataElements/eventMergeId/createEventMergeId";
-import turbineVariable from "../../../helpers/turbineVariable";
 
 describe("Event Merge ID", () => {
-  let mockLogger;
+  let turbine;
 
   beforeEach(() => {
-    mockLogger = {
-      error: jasmine.createSpy()
+    turbine = {
+      logger: jasmine.createSpyObj("logger", ["error"])
     };
-    turbineVariable.mock({
-      logger: mockLogger
-    });
-  });
-
-  afterEach(() => {
-    turbineVariable.reset();
   });
 
   it("returns event merge ID", () => {
@@ -37,7 +29,7 @@ describe("Event Merge ID", () => {
         }
       })
     };
-    const dataElement = createEventMergeId(instanceManager);
+    const dataElement = createEventMergeId({ instanceManager, turbine });
 
     const value = dataElement({
       instanceName: "myinstance"
@@ -51,13 +43,13 @@ describe("Event Merge ID", () => {
     const instanceManager = {
       getAccessor: () => undefined
     };
-    const dataElement = createEventMergeId(instanceManager);
+    const dataElement = createEventMergeId({ instanceManager, turbine });
 
     dataElement({
       instanceName: "myinstance"
     });
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(turbine.logger.error).toHaveBeenCalledWith(
       'Failed to create event merge ID for instance "myinstance". No matching instance was configured with this name.'
     );
   });

--- a/test/unit/lib/instanceManager/createInstanceManager.spec.js
+++ b/test/unit/lib/instanceManager/createInstanceManager.spec.js
@@ -11,15 +11,15 @@ governing permissions and limitations under the License.
 */
 
 import createInstanceManager from "../../../../src/lib/instanceManager/createInstanceManager";
-import turbineVariable from "../../helpers/turbineVariable";
 
 describe("Instance Manager", () => {
+  let turbine;
   let runAlloy;
   let instanceManager;
   let mockWindow;
 
   beforeEach(() => {
-    turbineVariable.mock({
+    turbine = {
       getExtensionSettings() {
         return {
           instances: [
@@ -35,7 +35,7 @@ describe("Instance Manager", () => {
           ]
         };
       }
-    });
+    };
     mockWindow = {};
     runAlloy = jasmine.createSpy().and.callFake(names => {
       names.forEach(name => {
@@ -51,15 +51,12 @@ describe("Instance Manager", () => {
           });
       });
     });
-    instanceManager = createInstanceManager(
-      mockWindow,
+    instanceManager = createInstanceManager({
+      turbine,
+      window: mockWindow,
       runAlloy,
-      "ABC@AdobeOrg"
-    );
-  });
-
-  afterEach(() => {
-    turbineVariable.reset();
+      orgId: "ABC@AdobeOrg"
+    });
   });
 
   it("runs alloy", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We had a `turbineVariable` helper that was used to mock the "turbine free variable" that Launch provides our extension. It really wasn't necessary though if we inject turbine from our index files. Removing its usage cleans up our tests some as well.
<!--- Describe your changes in detail -->

## Related Issue
None.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Cleaner tests.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
