### PR TITLE
CORE-41768 Changed onBeforeEventSend field to code editor.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -73,7 +73,7 @@
               },
               "onBeforeEventSend": {
                 "type": "string",
-                "pattern": "^%[^%]+%$"
+                "minLength": 1
               }
             },
             "required": ["configId", "name"],
@@ -83,7 +83,14 @@
       },
       "required": ["instances"],
       "additionalProperties": false
-    }
+    },
+    "transforms": [
+      {
+        "type": "function",
+        "propertyPath": "instances[].onBeforeEventSend",
+        "parameters": ["content"]
+      }
+    ]
   },
   "actions": [
     {

--- a/src/view/components/editorButton.jsx
+++ b/src/view/components/editorButton.jsx
@@ -23,17 +23,32 @@ import PropTypes from "prop-types";
  */
 class EditorButton extends React.Component {
   onClick = () => {
-    const { onChange, value, language } = this.props;
+    const { onChange, value, language, placeholder } = this.props;
 
     const options = {
-      code: value
+      code: value || placeholder || ""
     };
 
     if (language) {
       options.language = language;
     }
 
-    window.extensionBridge.openCodeEditor(options).then(onChange);
+    window.extensionBridge.openCodeEditor(options).then(updatedCode => {
+      // A bug exists in the Launch UI where the promise is resolved
+      // with undefined if the user hits Cancel. In this case, the promise
+      // should never be resolved or rejected.
+      // https://jira.corp.adobe.com/browse/DTM-14454
+      if (updatedCode === undefined) {
+        return;
+      }
+
+      // If the user never changed placeholder code, don't save the placeholder code.
+      if (placeholder && updatedCode === placeholder) {
+        updatedCode = "";
+      }
+
+      onChange(updatedCode);
+    });
   };
 
   render() {
@@ -58,7 +73,12 @@ EditorButton.propTypes = {
   value: PropTypes.string.isRequired,
   className: PropTypes.string,
   invalid: PropTypes.bool,
-  language: PropTypes.oneOf(["javascript", "html", "css", "json", "plaintext"])
+  language: PropTypes.oneOf(["javascript", "html", "css", "json", "plaintext"]),
+  /**
+   * Provides initial code to display in the editor if value is empty.
+   * If the user does not modify the placeholder code, an empty value will be saved.
+   */
+  placeholder: PropTypes.string
 };
 
 export default EditorButton;

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -535,7 +535,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                           component={EditorButton}
                           language="javascript"
                           placeholder={
-                            '// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.product = "shirt";'
+                            '// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.web.webPageDetails.name = "Checkout";'
                           }
                         />
                       </div>

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -535,7 +535,7 @@ const Configuration = ({ formikProps, initInfo }) => {
                           component={EditorButton}
                           language="javascript"
                           placeholder={
-                            '// Modify content.xdm as necessary. For example:\n// content.xdm.product = "shirt";'
+                            '// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.product = "shirt";'
                           }
                         />
                       </div>

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -297,7 +297,7 @@ test("returns full valid settings", async () => {
         idMigrationEnabled: false,
         thirdPartyCookiesEnabled: false,
         onBeforeEventSend:
-          'language=javascript;code=// Modify content.xdm as necessary. For example:\n// content.xdm.product = "shirt";',
+          'language=javascript;code=// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.product = "shirt";',
         context: ["web", "device", "environment", "placeContext"],
         downloadLinkQualifier: "[]"
       }
@@ -492,7 +492,7 @@ test("does not save onBeforeEventSend code if it matches placeholder", async () 
   await extensionViewController.init(defaultInitInfo, {
     openCodeEditor() {
       return Promise.resolve(
-        '// Modify content.xdm as necessary. For example:\n// content.xdm.product = "shirt";'
+        '// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.product = "shirt";'
       );
     }
   });

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -297,7 +297,7 @@ test("returns full valid settings", async () => {
         idMigrationEnabled: false,
         thirdPartyCookiesEnabled: false,
         onBeforeEventSend:
-          'language=javascript;code=// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.product = "shirt";',
+          'language=javascript;code=// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.web.webPageDetails.name = "Checkout";',
         context: ["web", "device", "environment", "placeContext"],
         downloadLinkQualifier: "[]"
       }
@@ -492,7 +492,7 @@ test("does not save onBeforeEventSend code if it matches placeholder", async () 
   await extensionViewController.init(defaultInitInfo, {
     openCodeEditor() {
       return Promise.resolve(
-        '// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.product = "shirt";'
+        '// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.web.webPageDetails.name = "Checkout";'
       );
     }
   });

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -62,7 +62,9 @@ for (let i = 0; i < 2; i += 1) {
     downloadLinkQualifierTestButton: spectrum.button(
       "downloadLinkQualifierTestButton"
     ),
-    onBeforeEventSendField: spectrum.textfield("onBeforeEventSendField"),
+    onBeforeEventSendEditorButton: spectrum.button(
+      "onBeforeEventSendEditorButton"
+    ),
     contextGranularity: {
       allField: spectrum.radio("contextGranularityAllField"),
       specificField: spectrum.radio("contextGranularitySpecificField")
@@ -202,7 +204,6 @@ test("initializes form fields with minimal settings", async () => {
     defaultDownloadLinkQualifier
   );
   await instances[0].contextGranularity.allField.expectChecked();
-  await instances[0].onBeforeEventSendField.expectValue("");
 });
 
 test("initializes form fields with no settings", async () => {
@@ -223,7 +224,6 @@ test("initializes form fields with no settings", async () => {
     defaultDownloadLinkQualifier
   );
   await instances[0].contextGranularity.allField.expectChecked();
-  await instances[0].onBeforeEventSendField.expectValue("");
 });
 
 test("returns minimal valid settings", async () => {
@@ -245,10 +245,9 @@ test("returns full valid settings", async () => {
   await extensionViewController.init(defaultInitInfo, {
     openCodeEditor(options) {
       return Promise.resolve(
-        // We include options.language in the result
-        // just so we can assert that the code editor
-        // was properly configured for editing CSS
-        `#container { display: none } // ${options.language}`
+        // We include options.language and options.code in the result
+        // just so we can assert that the code editor was properly configured
+        `language=${options.language};code=${options.code}`
       );
     }
   });
@@ -262,7 +261,6 @@ test("returns full valid settings", async () => {
   await instances[0].idMigrationEnabled.click();
   await instances[0].thirdPartyCookiesEnabled.click();
   await instances[0].prehidingStyleEditorButton.click();
-  await instances[0].onBeforeEventSendField.typeText("%foo%");
   await addInstanceButton.click();
 
   await instances[1].nameField.typeText("2");
@@ -271,6 +269,7 @@ test("returns full valid settings", async () => {
   await instances[1].defaultConsent.pendingField.click();
   await instances[1].idMigrationEnabled.click();
   await instances[1].thirdPartyCookiesEnabled.click();
+  await instances[1].onBeforeEventSendEditorButton.click();
   await instances[1].downloadLinkQualifierField.clear();
   await instances[1].downloadLinkQualifierField.typeText("[]");
   await instances[1].contextGranularity.specificField.click();
@@ -287,8 +286,8 @@ test("returns full valid settings", async () => {
         defaultConsent: { general: "pending" },
         idMigrationEnabled: false,
         thirdPartyCookiesEnabled: false,
-        prehidingStyle: "#container { display: none } // css",
-        onBeforeEventSend: "%foo%"
+        prehidingStyle:
+          "language=css;code=/*\nHide elements as necessary. For example:\n#container { opacity: 0 !important }\n*/"
       },
       {
         name: "alloy2",
@@ -297,6 +296,8 @@ test("returns full valid settings", async () => {
         defaultConsent: { general: "pending" },
         idMigrationEnabled: false,
         thirdPartyCookiesEnabled: false,
+        onBeforeEventSend:
+          'language=javascript;code=// Modify content.xdm as necessary. For example:\n// content.xdm.product = "shirt";',
         context: ["web", "device", "environment", "placeContext"],
         downloadLinkQualifier: "[]"
       }
@@ -444,29 +445,6 @@ test("sets download link qualifier when test button is clicked", async () => {
   await instances[0].downloadLinkQualifierField.expectMatch(/^Edited Regex/);
 });
 
-test("shows error for onBeforeEventSend value that is an arbitrary string", async () => {
-  await extensionViewController.init(defaultInitInfo);
-  await instances[0].configIdField.typeText("PR123");
-  await instances[0].onBeforeEventSendField.typeText("123foo");
-  await extensionViewController.expectIsNotValid();
-  await instances[0].onBeforeEventSendField.expectError();
-});
-
-test("shows error for onBeforeEventSend value that is multiple data elements", async () => {
-  await extensionViewController.init(defaultInitInfo);
-  await instances[0].configIdField.typeText("PR123");
-  await instances[0].onBeforeEventSendField.typeText("%foo%%bar%");
-  await extensionViewController.expectIsNotValid();
-  await instances[0].onBeforeEventSendField.expectError();
-});
-
-test("does not show error for onBeforeEventSend value that is a single data element", async () => {
-  await extensionViewController.init(defaultInitInfo);
-  await instances[0].configIdField.typeText("PR123");
-  await instances[0].onBeforeEventSendField.typeText("%123foo%");
-  await extensionViewController.expectIsValid();
-});
-
 test("deletes an instance", async () => {
   await extensionViewController.init(defaultInitInfo);
   await instances[0].configIdField.typeText("PR123");
@@ -486,4 +464,48 @@ test("deletes an instance", async () => {
   await instances[0].deleteButton.click();
   await resourceUsageDialog.clickConfirm();
   await instances[0].configIdField.expectValue("PR456");
+});
+
+test("does not save prehidingStyle code if it matches placeholder", async () => {
+  await extensionViewController.init(defaultInitInfo, {
+    openCodeEditor() {
+      return Promise.resolve(
+        "/*\nHide elements as necessary. For example:\n#container { opacity: 0 !important }\n*/"
+      );
+    }
+  });
+
+  await instances[0].configIdField.typeText("PR123");
+  await instances[0].prehidingStyleEditorButton.click();
+  await extensionViewController.expectIsValid();
+  await extensionViewController.expectSettings({
+    instances: [
+      {
+        name: "alloy",
+        configId: "PR123"
+      }
+    ]
+  });
+});
+
+test("does not save onBeforeEventSend code if it matches placeholder", async () => {
+  await extensionViewController.init(defaultInitInfo, {
+    openCodeEditor() {
+      return Promise.resolve(
+        '// Modify content.xdm as necessary. For example:\n// content.xdm.product = "shirt";'
+      );
+    }
+  });
+
+  await instances[0].configIdField.typeText("PR123");
+  await instances[0].onBeforeEventSendEditorButton.click();
+  await extensionViewController.expectIsValid();
+  await extensionViewController.expectSettings({
+    instances: [
+      {
+        name: "alloy",
+        configId: "PR123"
+      }
+    ]
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed onBeforeEventSend field to code editor. Previously, it was a textfield that accepted a data element.

Notice I added a "placeholder" prop to EditorButton which we're now using for both `prehidingStyle` and `onBeforeEventSend`. If the user does not modify the placeholder, no code will be saved. I'm curious to know how you feel about this.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-41768
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
It's simper for a user to provide code "inline" instead of having to go create a custom code data element.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] (probably?) My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
