### PR TITLE
CORE-43465 Return promise from actions. Throw error instead of logging.

### DIFF
--- a/src/lib/actions/sendEvent/createSendEvent.js
+++ b/src/lib/actions/sendEvent/createSendEvent.js
@@ -10,15 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = ({ instanceManager, turbine }) => settings => {
+module.exports = ({ instanceManager }) => settings => {
   const { instanceName, ...otherSettings } = settings;
   const instance = instanceManager.getInstance(instanceName);
 
-  if (instance) {
-    instance("event", otherSettings);
-  } else {
-    turbine.logger.error(
+  if (!instance) {
+    throw new Error(
       `Failed to send event for instance "${instanceName}". No matching instance was configured with this name.`
     );
   }
+
+  return instance("event", otherSettings);
 };

--- a/src/lib/actions/setConsent/createSetConsent.js
+++ b/src/lib/actions/setConsent/createSetConsent.js
@@ -10,15 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = ({ instanceManager, turbine }) => settings => {
+module.exports = ({ instanceManager }) => settings => {
   const { instanceName, consent } = settings;
   const instance = instanceManager.getInstance(instanceName);
 
-  if (instance) {
-    instance("setConsent", consent);
-  } else {
-    turbine.logger.error(
+  if (!instance) {
+    throw new Error(
       `Failed to set consent for instance "${instanceName}". No matching instance was configured with this name.`
     );
   }
+
+  return instance("setConsent", consent);
 };

--- a/src/lib/actions/setCustomerIds/createSetCustomerIds.js
+++ b/src/lib/actions/setCustomerIds/createSetCustomerIds.js
@@ -10,21 +10,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = ({ instanceManager, turbine }) => settings => {
+module.exports = ({ instanceManager }) => settings => {
   const { instanceName, customerIds } = settings;
   const instance = instanceManager.getInstance(instanceName);
 
-  if (instance) {
-    const customerIdsConfig = customerIds.reduce((config, customerIdObject) => {
-      config[customerIdObject.namespace] = customerIdObject;
-
-      return config;
-    }, {});
-
-    instance("setCustomerIds", customerIdsConfig);
-  } else {
-    turbine.logger.error(
+  if (!instance) {
+    throw new Error(
       `Failed to set customer IDs for instance "${instanceName}". No matching instance was configured with this name.`
     );
   }
+
+  const customerIdsConfig = customerIds.reduce((config, customerIdObject) => {
+    config[customerIdObject.namespace] = customerIdObject;
+
+    return config;
+  }, {});
+
+  return instance("setCustomerIds", customerIdsConfig);
 };

--- a/test/unit/lib/actions/sendEvent/createSendEvent.spec.js
+++ b/test/unit/lib/actions/sendEvent/createSendEvent.spec.js
@@ -13,22 +13,16 @@ governing permissions and limitations under the License.
 import createSendEvent from "../../../../../src/lib/actions/sendEvent/createSendEvent";
 
 describe("Send Event", () => {
-  let turbine;
-
-  beforeEach(() => {
-    turbine = {
-      logger: jasmine.createSpyObj("logger", ["error"])
-    };
-  });
-
   it("executes event command", () => {
-    const instance = jasmine.createSpy();
+    const promiseReturnedFromInstance = Promise.resolve();
+    const instance = jasmine
+      .createSpy()
+      .and.returnValue(promiseReturnedFromInstance);
     const instanceManager = jasmine.createSpyObj("instanceManager", {
       getInstance: instance
     });
-    const action = createSendEvent({ instanceManager, turbine });
-
-    action({
+    const action = createSendEvent({ instanceManager });
+    const promiseReturnedFromAction = action({
       instanceName: "myinstance",
       viewStart: true,
       xdm: {
@@ -36,6 +30,7 @@ describe("Send Event", () => {
       }
     });
 
+    expect(promiseReturnedFromAction).toBe(promiseReturnedFromInstance);
     expect(instanceManager.getInstance).toHaveBeenCalledWith("myinstance");
     expect(instance).toHaveBeenCalledWith("event", {
       viewStart: true,
@@ -45,22 +40,24 @@ describe("Send Event", () => {
     });
   });
 
-  it("logs an error when no matching instance found", () => {
+  it("throws an error when no matching instance found", () => {
     const instanceManager = jasmine.createSpyObj("instanceManager", {
       getInstance: undefined
     });
-    const action = createSendEvent({ instanceManager, turbine });
+    const action = createSendEvent({ instanceManager });
 
-    action({
-      instanceName: "myinstance",
-      viewStart: true,
-      xdm: {
-        foo: "bar"
-      }
-    });
-
-    expect(turbine.logger.error).toHaveBeenCalledWith(
-      'Failed to send event for instance "myinstance". No matching instance was configured with this name.'
+    expect(() => {
+      action({
+        instanceName: "myinstance",
+        viewStart: true,
+        xdm: {
+          foo: "bar"
+        }
+      });
+    }).toThrow(
+      new Error(
+        'Failed to send event for instance "myinstance". No matching instance was configured with this name.'
+      )
     );
   });
 });

--- a/test/unit/lib/actions/setConsent/createSetConsent.spec.js
+++ b/test/unit/lib/actions/setConsent/createSetConsent.spec.js
@@ -13,27 +13,22 @@ governing permissions and limitations under the License.
 import createSetConsent from "../../../../../src/lib/actions/setConsent/createSetConsent";
 
 describe("Set Consent", () => {
-  let turbine;
-
-  beforeEach(() => {
-    turbine = {
-      logger: jasmine.createSpyObj("logger", ["error"])
-    };
-  });
-
   ["in", "out"].forEach(generalConsent => {
     it(`executes setConsent command with "${generalConsent}" general consent`, () => {
-      const instance = jasmine.createSpy();
+      const promiseReturnedFromInstance = Promise.resolve();
+      const instance = jasmine
+        .createSpy()
+        .and.returnValue(promiseReturnedFromInstance);
       const instanceManager = jasmine.createSpyObj("instanceManager", {
         getInstance: instance
       });
-      const action = createSetConsent({ instanceManager, turbine });
-
-      action({
+      const action = createSetConsent({ instanceManager });
+      const promiseReturnedFromAction = action({
         instanceName: "myinstance",
         consent: { general: generalConsent }
       });
 
+      expect(promiseReturnedFromAction).toBe(promiseReturnedFromInstance);
       expect(instanceManager.getInstance).toHaveBeenCalledWith("myinstance");
       expect(instance).toHaveBeenCalledWith("setConsent", {
         general: generalConsent
@@ -41,19 +36,21 @@ describe("Set Consent", () => {
     });
   });
 
-  it("logs an error when no matching instance found", () => {
+  it("throws an error when no matching instance found", () => {
     const instanceManager = jasmine.createSpyObj("instanceManager", {
       getInstance: undefined
     });
-    const action = createSetConsent({ instanceManager, turbine });
+    const action = createSetConsent({ instanceManager });
 
-    action({
-      instanceName: "myinstance",
-      purposes: "none"
-    });
-
-    expect(turbine.logger.error).toHaveBeenCalledWith(
-      'Failed to set consent for instance "myinstance". No matching instance was configured with this name.'
+    expect(() => {
+      action({
+        instanceName: "myinstance",
+        purposes: "none"
+      });
+    }).toThrow(
+      new Error(
+        'Failed to set consent for instance "myinstance". No matching instance was configured with this name.'
+      )
     );
   });
 });

--- a/test/unit/lib/actions/setCustomerIds/createSetCustumerIds.spec.js
+++ b/test/unit/lib/actions/setCustomerIds/createSetCustumerIds.spec.js
@@ -13,22 +13,16 @@ governing permissions and limitations under the License.
 import createSetCustomerIds from "../../../../../src/lib/actions/setCustomerIds/createSetCustomerIds";
 
 describe("Set Customer IDs", () => {
-  let turbine;
-
-  beforeEach(() => {
-    turbine = {
-      logger: jasmine.createSpyObj("logger", ["error"])
-    };
-  });
-
   it("executes setCustomerIds command", () => {
-    const instance = jasmine.createSpy();
+    const promiseReturnedFromInstance = Promise.resolve();
+    const instance = jasmine
+      .createSpy()
+      .and.returnValue(promiseReturnedFromInstance);
     const instanceManager = jasmine.createSpyObj("instanceManager", {
       getInstance: instance
     });
-    const action = createSetCustomerIds({ instanceManager, turbine });
-
-    action({
+    const action = createSetCustomerIds({ instanceManager });
+    const promiseReturnedFromAction = action({
       instanceName: "instance1",
       customerIds: [
         {
@@ -41,6 +35,7 @@ describe("Set Customer IDs", () => {
       ]
     });
 
+    expect(promiseReturnedFromAction).toBe(promiseReturnedFromInstance);
     expect(instanceManager.getInstance).toHaveBeenCalledWith("instance1");
     expect(instance).toHaveBeenCalledWith("setCustomerIds", {
       ECID: {
@@ -53,27 +48,29 @@ describe("Set Customer IDs", () => {
     });
   });
 
-  it("logs an error when no matching instance found", () => {
+  it("throws an error when no matching instance found", () => {
     const instanceManager = jasmine.createSpyObj("instanceManager", {
       getInstance: undefined
     });
-    const action = createSetCustomerIds({ instanceManager, turbine });
+    const action = createSetCustomerIds({ instanceManager });
 
-    action({
-      instanceName: "instance1",
-      customerIds: [
-        {
-          namespace: "ECID",
-          id: "wvg",
-          authenticatedState: "loggedOut",
-          primary: false,
-          hash: true
-        }
-      ]
-    });
-
-    expect(turbine.logger.error).toHaveBeenCalledWith(
-      'Failed to set customer IDs for instance "instance1". No matching instance was configured with this name.'
+    expect(() => {
+      action({
+        instanceName: "instance1",
+        customerIds: [
+          {
+            namespace: "ECID",
+            id: "wvg",
+            authenticatedState: "loggedOut",
+            primary: false,
+            hash: true
+          }
+        ]
+      });
+    }).toThrow(
+      new Error(
+        'Failed to set customer IDs for instance "instance1". No matching instance was configured with this name.'
+      )
     );
   });
 });

--- a/test/unit/lib/dataElements/eventMergeId/createEventMergeId.spec.js
+++ b/test/unit/lib/dataElements/eventMergeId/createEventMergeId.spec.js
@@ -16,12 +16,8 @@ describe("Event Merge ID", () => {
   let eventMergeIdCache;
   let instanceManager;
   let dataElement;
-  let turbine;
 
   beforeEach(() => {
-    turbine = {
-      logger: jasmine.createSpyObj("logger", ["error"])
-    };
     instanceManager = jasmine.createSpyObj("instanceManager", {
       createEventMergeId: "randomEventMergeId"
     });
@@ -31,8 +27,7 @@ describe("Event Merge ID", () => {
     ]);
     dataElement = createEventMergeId({
       instanceManager,
-      eventMergeIdCache,
-      turbine
+      eventMergeIdCache
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
**Tests are failing until https://github.com/adobe/reactor-extension-alloy/pull/72 is merged.**

This change is forward-looking for rule component sequencing support that will be coming in Launch. The change is that we return promises from the actions. Also, rather than logging an error when we can't find the Alloy instance by name, we now throw an error. This is probably more appropriate, since Launch will catch the error, log it, and prevent subsequent actions within the rule from executing (which, according to Launch users, would typically be the expected outcome when an action fails).
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-43465
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Support rule component sequencing.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] **Tests are failing until https://github.com/adobe/reactor-extension-alloy/pull/72 is merged.** All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
