### PR TITLE
CORE-44841 Fix a few remaining configId references.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -25,7 +25,7 @@
                 "type": "string",
                 "pattern": "\\D+"
               },
-              "configId": {
+              "edgeConfigId": {
                 "type": "string",
                 "minLength": 1
               },
@@ -76,7 +76,7 @@
                 "minLength": 1
               }
             },
-            "required": ["configId", "name"],
+            "required": ["edgeConfigId", "name"],
             "additionalProperties": true
           }
         }

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -482,7 +482,7 @@ test("does not save prehidingStyle code if it matches placeholder", async () => 
     instances: [
       {
         name: "alloy",
-        configId: "PR123"
+        edgeConfigId: "PR123"
       }
     ]
   });
@@ -504,7 +504,7 @@ test("does not save onBeforeEventSend code if it matches placeholder", async () 
     instances: [
       {
         name: "alloy",
-        configId: "PR123"
+        edgeConfigId: "PR123"
       }
     ]
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing some lingering `configId`s that weren't changed in https://github.com/adobe/reactor-extension-alloy/pull/71.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-44841
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Make e2e tests pass. Make the extension work.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
