### PR TITLE
CORE-45217 Fix defaultConsent schema.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -44,8 +44,16 @@
               "errorsEnabled": {
                 "type": "boolean"
               },
-              "optInEnabled": {
-                "type": "boolean"
+              "defaultConsent": {
+                "type": "object",
+                "properties": {
+                  "general": {
+                    "type": "string",
+                    "enum": ["in", "pending"]
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["general"]
               },
               "idMigrationEnabled": {
                 "type": "boolean"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix defaultConsent schema. It was still using the old `optInEnabled`.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-45217
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix it so the configuration will save successfully with defaultConsent set to pending.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
