### PR TITLE
Support passing a dataset id in send event.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -149,6 +149,9 @@
           },
           "mergeId": {
             "type": "string"
+          },
+          "datasetId": {
+            "type": "string"
           }
         },
         "required": ["instanceName"],

--- a/extension.json
+++ b/extension.json
@@ -145,13 +145,16 @@
             "pattern": "^%[^%]+%$"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "mergeId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "datasetId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         },
         "required": ["instanceName"],

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -85,7 +85,8 @@ const getInitialValues = ({ initInfo }) => {
     decisionScopes = null,
     xdm = "",
     type = "",
-    mergeId = ""
+    mergeId = "",
+    datasetId = ""
   } = initInfo.settings || {};
   const initialPersonalizationData = getInitialDecisionScopesData(
     decisionScopes
@@ -97,6 +98,7 @@ const getInitialValues = ({ initInfo }) => {
     xdm,
     type,
     mergeId,
+    datasetId,
     ...initialPersonalizationData
   };
 };
@@ -114,6 +116,9 @@ const getSettings = ({ values }) => {
   }
   if (values.mergeId) {
     settings.mergeId = values.mergeId;
+  }
+  if (values.datasetId) {
+    settings.datasetId = values.datasetId;
   }
 
   // Only add renderDecisions if the value is different than the default (false).
@@ -244,6 +249,27 @@ const SendEvent = () => {
                   data-test-id="mergeIdField"
                   id="mergeIdField"
                   name="mergeId"
+                  component={Textfield}
+                  componentClassName="u-fieldLong"
+                  supportDataElement="replace"
+                />
+              </div>
+            </div>
+            <div className="u-gapTop">
+              <InfoTipLayout
+                tip="A platform experience event data set ID that is different from the 
+                data set used in the Configuration UI."
+              >
+                <FieldLabel
+                  labelFor="datasetIdField"
+                  label="Data Set ID (optional)"
+                />
+              </InfoTipLayout>
+              <div>
+                <WrappedField
+                  data-test-id="datasetIdField"
+                  id="datasetIdField"
+                  name="datasetId"
                   component={Textfield}
                   componentClassName="u-fieldLong"
                   supportDataElement="replace"

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -257,12 +257,12 @@ const SendEvent = () => {
             </div>
             <div className="u-gapTop">
               <InfoTipLayout
-                tip="A platform experience event data set ID that is different from the 
-                data set used in the Configuration UI."
+                tip="A platform experience event dataset ID that is different from the 
+                dataset provided in the Edge configuration."
               >
                 <FieldLabel
                   labelFor="datasetIdField"
-                  label="Data Set ID (optional)"
+                  label="Dataset ID (optional)"
                 />
               </InfoTipLayout>
               <div>

--- a/src/view/dataElements/xdmObject/helpers/fetchSchema.js
+++ b/src/view/dataElements/xdmObject/helpers/fetchSchema.js
@@ -31,7 +31,7 @@ export default ({ orgId, imsAccess, schemaMeta }) => {
   )
     .then(response => {
       if (!response.ok) {
-        throw new Error('Cannot fetch schema from schema registry');
+        throw new Error("Cannot fetch schema from schema registry");
       }
       return response.json();
     })

--- a/src/view/dataElements/xdmObject/helpers/fetchSchemasMeta.js
+++ b/src/view/dataElements/xdmObject/helpers/fetchSchemasMeta.js
@@ -29,7 +29,7 @@ export default ({ orgId, imsAccess }) => {
   )
     .then(response => {
       if (!response.ok) {
-        throw new Error('Cannot fetch schemas from schema registry');
+        throw new Error("Cannot fetch schemas from schema registry");
       }
       return response.json();
     })

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -22,6 +22,7 @@ const renderDecisionsField = spectrum.checkbox("renderDecisionsField");
 const xdmField = spectrum.textfield("xdmField");
 const typeField = spectrum.textfield("typeField");
 const mergeIdField = spectrum.textfield("mergeIdField");
+const datasetIdField = spectrum.textfield("datasetIdField");
 const scopeDataElementField = spectrum.textfield("scopeDataElementField");
 const radioGroup = {
   dataElement: spectrum.radio("dataElementOptionField"),
@@ -65,7 +66,8 @@ test("initializes form fields with full settings, when decision scopes is data e
       xdm: "%myDataLayer%",
       type: "myType1",
       mergeId: "%myMergeId%",
-      decisionScopes: "%myDecisionScope%"
+      decisionScopes: "%myDecisionScope%",
+      datasetId: "%myDatasetId%"
     }
   });
   await instanceNameField.expectValue("alloy2");
@@ -73,6 +75,7 @@ test("initializes form fields with full settings, when decision scopes is data e
   await xdmField.expectValue("%myDataLayer%");
   await typeField.expectValue("myType1");
   await mergeIdField.expectValue("%myMergeId%");
+  await datasetIdField.expectValue("%myDatasetId%");
   await radioGroup.dataElement.expectChecked();
   await radioGroup.values.expectUnchecked();
   await scopeDataElementField.expectValue("%myDecisionScope%");
@@ -104,6 +107,7 @@ test("initializes form fields with minimal settings", async () => {
   await xdmField.expectValue("");
   await typeField.expectValue("");
   await mergeIdField.expectValue("");
+  await datasetIdField.expectValue("");
   await radioGroup.values.expectChecked();
   await radioGroup.dataElement.expectUnchecked();
   await scopeArrayValues[0].value.expectValue("");
@@ -118,6 +122,7 @@ test("initializes form fields with no settings", async () => {
   await xdmField.expectValue("");
   await typeField.expectValue("");
   await mergeIdField.expectValue("");
+  await datasetIdField.expectValue("");
   await radioGroup.values.expectChecked();
   await radioGroup.dataElement.expectUnchecked();
   await scopeArrayValues[0].value.expectValue("");


### PR DESCRIPTION
## Description

Support the use case of wanting to send a specific event to a different data set than the one configured in the Configuration Service UI.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-44945

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [xI've updated the schema in extension.json or no changes are necessary.
