### PR TITLE
Revert support for dataset ID until supported in AEP.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -163,10 +163,6 @@
           "mergeId": {
             "type": "string",
             "minLength": 1
-          },
-          "datasetId": {
-            "type": "string",
-            "minLength": 1
           }
         },
         "required": ["instanceName"],

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -85,8 +85,7 @@ const getInitialValues = ({ initInfo }) => {
     decisionScopes = null,
     xdm = "",
     type = "",
-    mergeId = "",
-    datasetId = ""
+    mergeId = ""
   } = initInfo.settings || {};
   const initialPersonalizationData = getInitialDecisionScopesData(
     decisionScopes
@@ -98,7 +97,6 @@ const getInitialValues = ({ initInfo }) => {
     xdm,
     type,
     mergeId,
-    datasetId,
     ...initialPersonalizationData
   };
 };
@@ -116,9 +114,6 @@ const getSettings = ({ values }) => {
   }
   if (values.mergeId) {
     settings.mergeId = values.mergeId;
-  }
-  if (values.datasetId) {
-    settings.datasetId = values.datasetId;
   }
 
   // Only add renderDecisions if the value is different than the default (false).
@@ -249,27 +244,6 @@ const SendEvent = () => {
                   data-test-id="mergeIdField"
                   id="mergeIdField"
                   name="mergeId"
-                  component={Textfield}
-                  componentClassName="u-fieldLong"
-                  supportDataElement="replace"
-                />
-              </div>
-            </div>
-            <div className="u-gapTop">
-              <InfoTipLayout
-                tip="A platform experience event dataset ID that is different from the 
-                dataset provided in the Edge configuration."
-              >
-                <FieldLabel
-                  labelFor="datasetIdField"
-                  label="Dataset ID (optional)"
-                />
-              </InfoTipLayout>
-              <div>
-                <WrappedField
-                  data-test-id="datasetIdField"
-                  id="datasetIdField"
-                  name="datasetId"
                   component={Textfield}
                   componentClassName="u-fieldLong"
                   supportDataElement="replace"

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -22,7 +22,6 @@ const renderDecisionsField = spectrum.checkbox("renderDecisionsField");
 const xdmField = spectrum.textfield("xdmField");
 const typeField = spectrum.textfield("typeField");
 const mergeIdField = spectrum.textfield("mergeIdField");
-const datasetIdField = spectrum.textfield("datasetIdField");
 const scopeDataElementField = spectrum.textfield("scopeDataElementField");
 const radioGroup = {
   dataElement: spectrum.radio("dataElementOptionField"),
@@ -66,8 +65,7 @@ test("initializes form fields with full settings, when decision scopes is data e
       xdm: "%myDataLayer%",
       type: "myType1",
       mergeId: "%myMergeId%",
-      decisionScopes: "%myDecisionScope%",
-      datasetId: "%myDatasetId%"
+      decisionScopes: "%myDecisionScope%"
     }
   });
   await instanceNameField.expectValue("alloy2");
@@ -75,7 +73,6 @@ test("initializes form fields with full settings, when decision scopes is data e
   await xdmField.expectValue("%myDataLayer%");
   await typeField.expectValue("myType1");
   await mergeIdField.expectValue("%myMergeId%");
-  await datasetIdField.expectValue("%myDatasetId%");
   await radioGroup.dataElement.expectChecked();
   await radioGroup.values.expectUnchecked();
   await scopeDataElementField.expectValue("%myDecisionScope%");
@@ -107,7 +104,6 @@ test("initializes form fields with minimal settings", async () => {
   await xdmField.expectValue("");
   await typeField.expectValue("");
   await mergeIdField.expectValue("");
-  await datasetIdField.expectValue("");
   await radioGroup.values.expectChecked();
   await radioGroup.dataElement.expectUnchecked();
   await scopeArrayValues[0].value.expectValue("");
@@ -122,7 +118,6 @@ test("initializes form fields with no settings", async () => {
   await xdmField.expectValue("");
   await typeField.expectValue("");
   await mergeIdField.expectValue("");
-  await datasetIdField.expectValue("");
   await radioGroup.values.expectChecked();
   await radioGroup.dataElement.expectUnchecked();
   await scopeArrayValues[0].value.expectValue("");


### PR DESCRIPTION
## Description

Passing a dataset without a schema is not supported in AEP for another 2 weeks.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
