### PR TITLE
Rebase the `alloy-latest-release` after tagging Alloy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This steps listed below assume the new extension version includes changes from t
 1. Open the Alloy repository locally. 
 1. Make sure you're on the `master` branch and have pulled the latest changes.
 1. Version and tag Alloy by running `npm version major/minor/patch`. Whether you use `major`, `minor`, or `patch` depends on what has changed since the last release and how that matches [semantic versioning](https://semver.org/). Note that while the version is below 1.0.0, semantic versioning is flexible on how a project should be versioned. In our case, we have decided that breaking changes should bump the minor version (`npm version minor`) while any other change should bump the patch version (`npm version patch`).
+1. Rebase the `alloy-latest-release` branch on top of the tag, because this branch is used to run the Prod E2E tests against.
 1. Running `npm version major/minor/patch` should have changed `package.json` and `package-lock.json`, committed the changes, and created a new git tag. Push these changes to Github by running `git push origin master --follow-tags`. Go to Github and ensure you see the newly added commit and tag.
 1. Create a new production build of Alloy by running `npm run build:prod`.
 1. Open up `dist/reactor/alloy.js` and copy the file's contents.


### PR DESCRIPTION
`alloy-latest-release` is the branch we will start using to run the Prod E2E tests. We were using `master` in the past but that was causing issues because we might have updated testing specs in master that don't match the PROD released Alloy. @Aaronius

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
