### PR TITLE
Support IAB consent and IdentityMap in the setConsent action

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -181,30 +181,57 @@
               {
                 "type": "array",
                 "minItems": 1,
-                "maxItems": 1,
                 "items": {
-                  "type": "object",
-                  "properties": {
-                    "standard": {
-                      "type": "string",
-                      "enum": ["Adobe"]
-                    },
-                    "version": {
-                      "type": "string",
-                      "enum": ["1.0"]
-                    },
-                    "value": {
+                  "anyOf": [
+                    {
                       "type": "object",
+                      "required": ["standard", "version", "value"],
                       "properties": {
-                        "general": {
-                          "type": "string",
-                          "enum": ["in", "out"]
+                        "standard": { "type": "string", "enum": ["Adobe"] },
+                        "version": { "type": "string" },
+                        "value": {
+                          "type": "object",
+                          "required": ["general"],
+                          "properties": {
+                            "general": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["in", "out"]
+                                },
+                                {
+                                 "type": "string",
+                                  "pattern": "^%[^%]+%$"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["standard", "version", "value"],
+                      "properties": {
+                        "standard": { "type": "string", "enum": ["IAB TCF"] },
+                        "version": { "type": "string" },
+                        "value": { "type": "string" },
+                        "gdprApplies": {
+                          "anyOf": [
+                            { "type": "boolean" },
+                            { "type": "string", "pattern": "^%[^%]+%$" }
+                          ]
+                        },
+                        "containsPersonalData": {
+                          "anyOf": [
+                            { "type": "boolean" },
+                            { "type": "string", "pattern": "^%[^%]+%$" }
+                          ]
                         }
                       },
                       "additionalProperties": false
                     }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
               },
               {

--- a/extension.json
+++ b/extension.json
@@ -226,7 +226,7 @@
                             { "type": "string", "pattern": "^%[^%]+%$" }
                           ]
                         },
-                        "containsPersonalData": {
+                        "gdprContainsPersonalData": {
                           "anyOf": [
                             { "type": "boolean" },
                             { "type": "string", "pattern": "^%[^%]+%$" }

--- a/extension.json
+++ b/extension.json
@@ -176,6 +176,10 @@
             "type": "string",
             "minLength": 1
           },
+          "identityMap": {
+            "type": "string",
+            "pattern": "^%[^%]+%$"
+          },
           "consent": {
             "anyOf": [
               {

--- a/src/lib/actions/setConsent/createSetConsent.js
+++ b/src/lib/actions/setConsent/createSetConsent.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 module.exports = ({ instanceManager }) => settings => {
-  const { instanceName, ...options } = settings;
+  const { instanceName, identityMap, consent } = settings;
   const instance = instanceManager.getInstance(instanceName);
 
   if (!instance) {
@@ -19,6 +19,8 @@ module.exports = ({ instanceManager }) => settings => {
       `Failed to set consent for instance "${instanceName}". No matching instance was configured with this name.`
     );
   }
-
-  return instance("setConsent", options);
+  if (identityMap) {
+    return instance("setConsent", { identityMap, consent });
+  }
+  return instance("setConsent", { consent });
 };

--- a/src/lib/actions/setConsent/createSetConsent.js
+++ b/src/lib/actions/setConsent/createSetConsent.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 module.exports = ({ instanceManager }) => settings => {
-  const { instanceName, consent } = settings;
+  const { instanceName, ...options } = settings;
   const instance = instanceManager.getInstance(instanceName);
 
   if (!instance) {
@@ -20,5 +20,5 @@ module.exports = ({ instanceManager }) => settings => {
     );
   }
 
-  return instance("setConsent", { consent });
+  return instance("setConsent", options);
 };

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -256,6 +256,7 @@ const getSettings = ({ values }) => {
 const invalidDataMessage = "Please specify a data element.";
 const validationSchema = object().shape({
   instanceName: string().required(),
+  identityMap: string().matches(singleDataElementRegex, invalidDataMessage),
   dataElement: mixed().when("inputMethod", {
     is: DATA_ELEMENT.value,
     then: string()
@@ -413,6 +414,18 @@ const SetConsent = () => {
                   options={getInstanceOptions(initInfo)}
                 />
               </div>
+            </div>
+            <div className="u-gapTop">
+              <InfoTipLayout tip="Use a data element to provide custom identity information as part of the setConsent command. This data element should resolve to an identity map object.">
+                <FieldLabel labelFor="identityMapField" label="IdentityMap" />
+              </InfoTipLayout>
+              <WrappedField
+                name="identityMap"
+                id="identityMapField"
+                component={Textfield}
+                componentClassName="u-fieldLong"
+                supportDataElement="replace"
+              />
             </div>
             <div className="u-gapTop">
               <InfoTipLayout

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -60,7 +60,7 @@ const IAB_TCF = { value: "iab_tcf", label: "IAB TCF" };
  *     version: "2.0",
  *     value: "1234abcd",
  *     gdprApplies: true,
- *     containsPersonalData: false
+ *     gdprContainsPersonalData: false
  *   },
  *   ...]
  * }
@@ -83,7 +83,7 @@ const IAB_TCF = { value: "iab_tcf", label: "IAB TCF" };
  *       general: optionsWithDataElement("in", "out"),
  *       iabValue: "1234abcd", // or data_element
  *       gdprApplies: optionsWithDataElement(true, false),
- *       containsPersonalData: optionsWithDataElement(true, false)
+ *       gdprContainsPersonalData: optionsWithDataElement(true, false)
  *     },
  *     ...
  *   ]
@@ -100,7 +100,7 @@ const createBlankConsentObject = () => {
     general: { radio: IN.value, dataElement: "" },
     iabValue: "",
     gdprApplies: { radio: YES.value, dataElement: "" },
-    containsPersonalData: { radio: NO.value, dataElement: "" }
+    gdprContainsPersonalData: { radio: NO.value, dataElement: "" }
   };
 };
 
@@ -172,10 +172,10 @@ const getInitialValues = ({ initInfo }) => {
             [YES.value, NO.value]
           );
         }
-        if (consentObject.containsPersonalData != null) {
+        if (consentObject.gdprContainsPersonalData != null) {
           applyInitialValuesForOptionsWithDataElement(
-            booleanToYesNo(consentObject.containsPersonalData),
-            formikConsentObject.containsPersonalData,
+            booleanToYesNo(consentObject.gdprContainsPersonalData),
+            formikConsentObject.gdprContainsPersonalData,
             [YES.value, NO.value]
           );
         }
@@ -250,9 +250,9 @@ const getSettings = ({ values }) => {
               formikConsentObject.gdprApplies
             )
           ),
-          containsPersonalData: yesNoToBoolean(
+          gdprContainsPersonalData: yesNoToBoolean(
             getSettingsForOptionsWithDataElement(
-              formikConsentObject.containsPersonalData
+              formikConsentObject.gdprContainsPersonalData
             )
           )
         });
@@ -303,7 +303,7 @@ const validationSchema = object().shape({
             })
           })
         }),
-        containsPersonalData: mixed().when("standard", {
+        gdprContainsPersonalData: mixed().when("standard", {
           is: IAB_TCF.value,
           then: object().shape({
             radio: string().required(),
@@ -385,13 +385,13 @@ const ConsentObject = ({ formikConsentObject, index }) => {
             values={formikConsentObject.gdprApplies}
           />
           <OptionsWithDataElement
-            label="Contains Personal Data"
+            label="GDPR Contains Personal Data"
             infoTip="Does the event data associated with this user contain personal data? A data element should resolve to true or false."
-            id={`consent_${index}_containsPersonalData`}
-            data-test-id="containsPersonalData"
-            name={`consent.${index}.containsPersonalData`}
+            id={`consent_${index}_gdprContainsPersonalData`}
+            data-test-id="gdprContainsPersonalData"
+            name={`consent.${index}.gdprContainsPersonalData`}
             options={[YES, NO]}
-            values={formikConsentObject.containsPersonalData}
+            values={formikConsentObject.gdprContainsPersonalData}
           />
         </div>
       )}

--- a/src/view/components/optionsWithDataElement.jsx
+++ b/src/view/components/optionsWithDataElement.jsx
@@ -42,13 +42,13 @@ const OptionsWithDataElement = ({
         {options.map(({ value: optionValue, label: optionLabel }) => (
           <Radio
             key={optionValue}
-            data-test-id={`${dataTestId}_${optionValue}`}
+            data-test-id={`${dataTestId}${optionLabel}Radio`}
             value={optionValue}
             label={optionLabel}
           />
         ))}
         <Radio
-          data-test-id={`${dataTestId}_dataElement`}
+          data-test-id={`${dataTestId}DataElementRadio`}
           value="dataElement"
           label="Provided by data element"
         />
@@ -58,7 +58,7 @@ const OptionsWithDataElement = ({
         <div>
           <WrappedField
             id={`${id}DataElement`}
-            data-test-id={`${dataTestId}DataElement`}
+            data-test-id={`${dataTestId}DataElementField`}
             name={`${name}.dataElement`}
             component={Textfield}
             componentClassName="u-fieldLong"

--- a/src/view/components/optionsWithDataElement.jsx
+++ b/src/view/components/optionsWithDataElement.jsx
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import React from "react";
+import PropTypes from "prop-types";
+import RadioGroup from "@react/react-spectrum/RadioGroup";
+import Radio from "@react/react-spectrum/Radio";
+import Textfield from "@react/react-spectrum/Textfield";
+import FieldLabel from "@react/react-spectrum/FieldLabel";
+import InfoTipLayout from "./infoTipLayout";
+import WrappedField from "./wrappedField";
+
+const OptionsWithDataElement = ({
+  label,
+  infoTip,
+  options,
+  id,
+  "data-test-id": dataTestId,
+  name,
+  values
+}) => {
+  return (
+    <div className="u-gapTop">
+      <InfoTipLayout tip={infoTip}>
+        <FieldLabel labelFor={`${id}RadioGroup`} label={label} />
+      </InfoTipLayout>
+      <WrappedField
+        id={`${id}RadioGroup`}
+        name={`${name}.radio`}
+        component={RadioGroup}
+        componentClassName="u-flexColumn"
+      >
+        {options.map(({ value: optionValue, label: optionLabel }) => (
+          <Radio
+            key={optionValue}
+            data-test-id={`${dataTestId}_${optionValue}`}
+            value={optionValue}
+            label={optionLabel}
+          />
+        ))}
+        <Radio
+          data-test-id={`${dataTestId}_dataElement`}
+          value="dataElement"
+          label="Provided by data element"
+        />
+      </WrappedField>
+
+      {values && values.radio === "dataElement" && (
+        <div>
+          <WrappedField
+            id={`${id}DataElement`}
+            data-test-id={`${dataTestId}DataElement`}
+            name={`${name}.dataElement`}
+            component={Textfield}
+            componentClassName="u-fieldLong"
+            supportDataElement="replace"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+OptionsWithDataElement.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.object),
+  label: PropTypes.string,
+  infoTip: PropTypes.string,
+  id: PropTypes.string,
+  "data-test-id": PropTypes.string,
+  name: PropTypes.string,
+  values: PropTypes.object
+};
+
+export default OptionsWithDataElement;

--- a/src/view/components/optionsWithDataElementComponent.jsx
+++ b/src/view/components/optionsWithDataElementComponent.jsx
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import RadioGroup from "@react/react-spectrum/RadioGroup";
+import Radio from "@react/react-spectrum/Radio";
+import Textfield from "@react/react-spectrum/Textfield";
+
+const OptionsWithDataElement = ({ options, value, onChange }) => {
+  const valueIsString = !!(value && typeof value === "string");
+  const [dataElementChecked, setDataElementChecked] = useState(valueIsString);
+  const [dataElementValue, setDataElementValue] = useState(
+    valueIsString ? value : ""
+  );
+
+  return (
+    <div>
+      <RadioGroup
+        className="u-flexColumn"
+        checkedValue={dataElementChecked ? "__dataElement__" : value}
+        onChange={newValue => {
+          if (newValue === "__dataElement__") {
+            setDataElementChecked(true);
+            onChange(dataElementValue);
+          } else {
+            setDataElementChecked(false);
+            onChange(newValue);
+          }
+        }}
+      >
+        {options.map(
+          (
+            { value: optionValue, label: optionLabel, testId: optionTestId },
+            index
+          ) => (
+            <Radio
+              key={index}
+              data-test-id={optionTestId}
+              value={optionValue}
+              label={optionLabel}
+            />
+          )
+        )}
+        <Radio value="__dataElement__" label="Provided by data element" />
+      </RadioGroup>
+
+      {dataElementChecked && (
+        <Textfield
+          className="u-fieldLong"
+          onChange={newValue => {
+            setDataElementValue(newValue);
+            onChange(newValue);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+OptionsWithDataElement.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.object),
+  value: PropTypes.string,
+  onChange: PropTypes.func
+};
+
+export default OptionsWithDataElement;

--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -51,7 +51,7 @@ for (let i = 0; i < 2; i += 1) {
     ...generateOptionsWithDataElement(container, "general", ["In", "Out"]),
     iabValueField: container.textfield("iabValueField"),
     ...generateOptionsWithDataElement(container, "gdprApplies", ["Yes", "No"]),
-    ...generateOptionsWithDataElement(container, "containsPersonalData", [
+    ...generateOptionsWithDataElement(container, "gdprContainsPersonalData", [
       "Yes",
       "No"
     ]),
@@ -92,7 +92,7 @@ test("initializes form fields with settings containing a static consent array", 
           version: "2.0",
           value: "1234abcd",
           gdprApplies: false,
-          containsPersonalData: true
+          gdprContainsPersonalData: true
         }
       ]
     }
@@ -115,10 +115,10 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[0].gdprAppliesNoRadio.expectNotExists();
   await instances[0].gdprAppliesDataElementRadio.expectNotExists();
   await instances[0].gdprAppliesDataElementField.expectNotExists();
-  await instances[0].containsPersonalDataYesRadio.expectNotExists();
-  await instances[0].containsPersonalDataNoRadio.expectNotExists();
-  await instances[0].containsPersonalDataDataElementRadio.expectNotExists();
-  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+  await instances[0].gdprContainsPersonalDataYesRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataNoRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataDataElementRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
 
   await instances[1].standardSelect.expectValue("iab_tcf");
   await instances[1].versionField.expectValue("2.0");
@@ -131,10 +131,10 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[1].gdprAppliesNoRadio.expectChecked();
   await instances[1].gdprAppliesDataElementRadio.expectUnchecked();
   await instances[1].gdprAppliesDataElementField.expectNotExists();
-  await instances[1].containsPersonalDataYesRadio.expectChecked();
-  await instances[1].containsPersonalDataNoRadio.expectUnchecked();
-  await instances[1].containsPersonalDataDataElementRadio.expectUnchecked();
-  await instances[1].containsPersonalDataDataElementField.expectNotExists();
+  await instances[1].gdprContainsPersonalDataYesRadio.expectChecked();
+  await instances[1].gdprContainsPersonalDataNoRadio.expectUnchecked();
+  await instances[1].gdprContainsPersonalDataDataElementRadio.expectUnchecked();
+  await instances[1].gdprContainsPersonalDataDataElementField.expectNotExists();
 });
 
 test("initializes form fields with settings containing many data elements for parts", async () => {
@@ -150,7 +150,7 @@ test("initializes form fields with settings containing many data elements for pa
           version: "2.0",
           value: "%data2%",
           gdprApplies: "%data3%",
-          containsPersonalData: "%data4%"
+          gdprContainsPersonalData: "%data4%"
         }
       ]
     }
@@ -173,10 +173,10 @@ test("initializes form fields with settings containing many data elements for pa
   await instances[0].gdprAppliesNoRadio.expectNotExists();
   await instances[0].gdprAppliesDataElementRadio.expectNotExists();
   await instances[0].gdprAppliesDataElementField.expectNotExists();
-  await instances[0].containsPersonalDataYesRadio.expectNotExists();
-  await instances[0].containsPersonalDataNoRadio.expectNotExists();
-  await instances[0].containsPersonalDataDataElementRadio.expectNotExists();
-  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+  await instances[0].gdprContainsPersonalDataYesRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataNoRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataDataElementRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
 
   await instances[1].standardSelect.expectValue("iab_tcf");
   await instances[1].versionField.expectValue("2.0");
@@ -189,10 +189,10 @@ test("initializes form fields with settings containing many data elements for pa
   await instances[1].gdprAppliesNoRadio.expectUnchecked();
   await instances[1].gdprAppliesDataElementRadio.expectChecked();
   await instances[1].gdprAppliesDataElementField.expectValue("%data3%");
-  await instances[1].containsPersonalDataYesRadio.expectUnchecked();
-  await instances[1].containsPersonalDataNoRadio.expectUnchecked();
-  await instances[1].containsPersonalDataDataElementRadio.expectChecked();
-  await instances[1].containsPersonalDataDataElementField.expectValue(
+  await instances[1].gdprContainsPersonalDataYesRadio.expectUnchecked();
+  await instances[1].gdprContainsPersonalDataNoRadio.expectUnchecked();
+  await instances[1].gdprContainsPersonalDataDataElementRadio.expectChecked();
+  await instances[1].gdprContainsPersonalDataDataElementField.expectValue(
     "%data4%"
   );
 });
@@ -237,10 +237,10 @@ test("initializes form fields with no settings", async () => {
   await instances[0].gdprAppliesNoRadio.expectNotExists();
   await instances[0].gdprAppliesDataElementRadio.expectNotExists();
   await instances[0].gdprAppliesDataElementField.expectNotExists();
-  await instances[0].containsPersonalDataYesRadio.expectNotExists();
-  await instances[0].containsPersonalDataNoRadio.expectNotExists();
-  await instances[0].containsPersonalDataDataElementRadio.expectNotExists();
-  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+  await instances[0].gdprContainsPersonalDataYesRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataNoRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataDataElementRadio.expectNotExists();
+  await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
   await instances[1].container.expectNotExists();
 
   await instances[0].standardSelect.selectOption("IAB TCF");
@@ -256,10 +256,10 @@ test("initializes form fields with no settings", async () => {
   await instances[0].gdprAppliesNoRadio.expectUnchecked();
   await instances[0].gdprAppliesDataElementRadio.expectUnchecked();
   await instances[0].gdprAppliesDataElementField.expectNotExists();
-  await instances[0].containsPersonalDataYesRadio.expectUnchecked();
-  await instances[0].containsPersonalDataNoRadio.expectChecked();
-  await instances[0].containsPersonalDataDataElementRadio.expectUnchecked();
-  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+  await instances[0].gdprContainsPersonalDataYesRadio.expectUnchecked();
+  await instances[0].gdprContainsPersonalDataNoRadio.expectChecked();
+  await instances[0].gdprContainsPersonalDataDataElementRadio.expectUnchecked();
+  await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
   await instances[1].container.expectNotExists();
 });
 
@@ -287,7 +287,7 @@ test("returns minimal valid settings", async () => {
         version: "2.1",
         value: "1234abcd",
         gdprApplies: true,
-        containsPersonalData: false
+        gdprContainsPersonalData: false
       }
     ]
   });
@@ -303,7 +303,7 @@ test("returns full valid settings", async () => {
   await instances[0].versionField.typeText("2.2");
   await instances[0].iabValueField.typeText("a");
   await instances[0].gdprAppliesNoRadio.click();
-  await instances[0].containsPersonalDataYesRadio.click();
+  await instances[0].gdprContainsPersonalDataYesRadio.click();
   await addConsentButton.click();
   await instances[1].versionField.typeText("1.2");
   await instances[1].generalOutRadio.click();
@@ -318,7 +318,7 @@ test("returns full valid settings", async () => {
         version: "2.2",
         value: "a",
         gdprApplies: false,
-        containsPersonalData: true
+        gdprContainsPersonalData: true
       },
       {
         standard: "Adobe",
@@ -342,8 +342,10 @@ test("returns valid setting for guided form data elements", async () => {
   await instances[1].iabValueField.typeText("%data2%");
   await instances[1].gdprAppliesDataElementRadio.click();
   await instances[1].gdprAppliesDataElementField.typeText("%data3%");
-  await instances[1].containsPersonalDataDataElementRadio.click();
-  await instances[1].containsPersonalDataDataElementField.typeText("%data4%");
+  await instances[1].gdprContainsPersonalDataDataElementRadio.click();
+  await instances[1].gdprContainsPersonalDataDataElementField.typeText(
+    "%data4%"
+  );
 
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
@@ -359,7 +361,7 @@ test("returns valid setting for guided form data elements", async () => {
         version: "2.3",
         value: "%data2%",
         gdprApplies: "%data3%",
-        containsPersonalData: "%data4%"
+        gdprContainsPersonalData: "%data4%"
       }
     ]
   });
@@ -406,7 +408,7 @@ test("shows errors for empty values", async () => {
   await addConsentButton.click();
   await instances[1].standardSelect.selectOption("IAB TCF");
   await instances[1].gdprAppliesDataElementRadio.click();
-  await instances[1].containsPersonalDataDataElementRadio.click();
+  await instances[1].gdprContainsPersonalDataDataElementRadio.click();
 
   await extensionViewController.expectIsNotValid();
   await instances[0].versionField.expectError();
@@ -414,7 +416,7 @@ test("shows errors for empty values", async () => {
   await instances[1].versionField.expectError();
   await instances[1].iabValueField.expectError();
   await instances[1].gdprAppliesDataElementField.expectError();
-  await instances[1].containsPersonalDataDataElementField.expectError();
+  await instances[1].gdprContainsPersonalDataDataElementField.expectError();
 });
 
 test("shows errors for things that aren't data elements and does not show errors for hidden invalid fields", async () => {
@@ -430,8 +432,8 @@ test("shows errors for things that aren't data elements and does not show errors
   await instances[1].iabValueField.typeText("notadataelement");
   await instances[1].gdprAppliesDataElementRadio.click();
   await instances[1].gdprAppliesDataElementField.typeText("%data1%%data2%");
-  await instances[1].containsPersonalDataDataElementRadio.click();
-  await instances[1].containsPersonalDataDataElementField.typeText(
+  await instances[1].gdprContainsPersonalDataDataElementRadio.click();
+  await instances[1].gdprContainsPersonalDataDataElementField.typeText(
     "%notadataelement"
   );
 
@@ -439,7 +441,7 @@ test("shows errors for things that aren't data elements and does not show errors
   await instances[0].generalDataElementField.expectError();
   await instances[1].iabValueField.expectNoError();
   await instances[1].gdprAppliesDataElementField.expectError();
-  await instances[1].containsPersonalDataDataElementField.expectError();
+  await instances[1].gdprContainsPersonalDataDataElementField.expectError();
 
   await inputMethodDataElementRadio.click();
   await dataElementField.typeText("%dataelement%");
@@ -452,7 +454,7 @@ test("shows errors for things that aren't data elements and does not show errors
   await inputMethodFormRadio.click();
   await instances[0].generalInRadio.click();
   await instances[1].gdprAppliesYesRadio.click();
-  await instances[1].containsPersonalDataYesRadio.click();
+  await instances[1].gdprContainsPersonalDataYesRadio.click();
   await extensionViewController.expectIsValid();
 });
 

--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -17,12 +17,47 @@ import testInstanceNameOptions from "../helpers/testInstanceNameOptions";
 const extensionViewController = createExtensionViewController(
   "actions/setConsent.html"
 );
-const instanceNameField = spectrum.select("instanceNameField");
-const radioGroup = {
-  inField: spectrum.radio("inOptionField"),
-  outField: spectrum.radio("outOptionField"),
-  dataElementField: spectrum.radio("dataElementOptionField")
-};
+
+const generateOptionsWithDataElement = (container, prefix, options) =>
+  [...options, "DataElement"].reduce(
+    (elements, option) => {
+      elements[`${prefix}${option}Radio`] = container.radio(
+        `${prefix}${option}Radio`
+      );
+      return elements;
+    },
+    {
+      [`${prefix}DataElementField`]: container.textfield(
+        `${prefix}DataElementField`
+      )
+    }
+  );
+
+const instanceNameSelect = spectrum.select("instanceNameSelect");
+const identityMapField = spectrum.textfield("identityMapField");
+const inputMethodFormRadio = spectrum.radio("inputMethodFormRadio");
+const inputMethodDataElementRadio = spectrum.radio(
+  "inputMethodDataElementRadio"
+);
+const addConsentButton = spectrum.button("addConsentButton");
+const instances = [];
+
+for (let i = 0; i < 2; i += 1) {
+  const container = spectrum.container(`instance${i}`);
+  instances.push({
+    container,
+    standardSelect: container.select("standardSelect"),
+    versionField: container.textfield("versionField"),
+    ...generateOptionsWithDataElement(container, "general", ["In", "Out"]),
+    iabValueField: container.textfield("iabValueField"),
+    ...generateOptionsWithDataElement(container, "gdprApplies", ["Yes", "No"]),
+    ...generateOptionsWithDataElement(container, "containsPersonalData", [
+      "Yes",
+      "No"
+    ]),
+    deleteConsentButton: container.button("deleteConsentButton")
+  });
+}
 const dataElementField = spectrum.textfield("dataElementField");
 
 const mockExtensionSettings = {
@@ -44,94 +79,381 @@ fixture("Set Consent View").disablePageReloads.page(
   "http://localhost:3000/viewSandbox.html"
 );
 
-test("initializes form fields with settings containing static purposes", async () => {
+test("initializes form fields with settings containing a static consent array", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings,
     settings: {
       instanceName: "alloy2",
+      identityMap: "%dataelement1%",
       consent: [
-        { standard: "Adobe", version: "1.0", value: { general: "out" } }
+        { standard: "Adobe", version: "1.0", value: { general: "out" } },
+        {
+          standard: "IAB TCF",
+          version: "2.0",
+          value: "1234abcd",
+          gdprApplies: false,
+          containsPersonalData: true
+        }
       ]
     }
   });
-  await instanceNameField.expectValue("alloy2");
-  await radioGroup.inField.expectUnchecked();
-  await radioGroup.outField.expectChecked();
-  await radioGroup.dataElementField.expectUnchecked();
+  await instanceNameSelect.expectValue("alloy2");
+  await identityMapField.expectValue("%dataelement1%");
+  await inputMethodFormRadio.expectChecked();
+  await inputMethodDataElementRadio.expectUnchecked();
+  await dataElementField.expectNotExists();
+  await addConsentButton.expectExists();
+
+  await instances[0].standardSelect.expectValue("adobe");
+  await instances[0].versionField.expectValue("1.0");
+  await instances[0].generalInRadio.expectUnchecked();
+  await instances[0].generalOutRadio.expectChecked();
+  await instances[0].generalDataElementRadio.expectUnchecked();
+  await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].iabValueField.expectNotExists();
+  await instances[0].gdprAppliesYesRadio.expectNotExists();
+  await instances[0].gdprAppliesNoRadio.expectNotExists();
+  await instances[0].gdprAppliesDataElementRadio.expectNotExists();
+  await instances[0].gdprAppliesDataElementField.expectNotExists();
+  await instances[0].containsPersonalDataYesRadio.expectNotExists();
+  await instances[0].containsPersonalDataNoRadio.expectNotExists();
+  await instances[0].containsPersonalDataDataElementRadio.expectNotExists();
+  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+
+  await instances[1].standardSelect.expectValue("iab_tcf");
+  await instances[1].versionField.expectValue("2.0");
+  await instances[1].generalInRadio.expectNotExists();
+  await instances[1].generalOutRadio.expectNotExists();
+  await instances[1].generalDataElementRadio.expectNotExists();
+  await instances[1].generalDataElementField.expectNotExists();
+  await instances[1].iabValueField.expectValue("1234abcd");
+  await instances[1].gdprAppliesYesRadio.expectUnchecked();
+  await instances[1].gdprAppliesNoRadio.expectChecked();
+  await instances[1].gdprAppliesDataElementRadio.expectUnchecked();
+  await instances[1].gdprAppliesDataElementField.expectNotExists();
+  await instances[1].containsPersonalDataYesRadio.expectChecked();
+  await instances[1].containsPersonalDataNoRadio.expectUnchecked();
+  await instances[1].containsPersonalDataDataElementRadio.expectUnchecked();
+  await instances[1].containsPersonalDataDataElementField.expectNotExists();
 });
 
-test("initializes form fields with settings containing data element for purposes", async () => {
+test("initializes form fields with settings containing many data elements for parts", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings,
     settings: {
       instanceName: "alloy2",
-      consent: "%foo%"
+      identityMap: "%data0%",
+      consent: [
+        { standard: "Adobe", version: "1.0", value: { general: "%data1%" } },
+        {
+          standard: "IAB TCF",
+          version: "2.0",
+          value: "%data2%",
+          gdprApplies: "%data3%",
+          containsPersonalData: "%data4%"
+        }
+      ]
     }
   });
-  await instanceNameField.expectValue("alloy2");
-  await radioGroup.inField.expectUnchecked();
-  await radioGroup.outField.expectUnchecked();
-  await radioGroup.dataElementField.expectChecked();
-  await dataElementField.expectValue("%foo%");
+  await instanceNameSelect.expectValue("alloy2");
+  await identityMapField.expectValue("%data0%");
+  await inputMethodFormRadio.expectChecked();
+  await inputMethodDataElementRadio.expectUnchecked();
+  await dataElementField.expectNotExists();
+  await addConsentButton.expectExists();
+
+  await instances[0].standardSelect.expectValue("adobe");
+  await instances[0].versionField.expectValue("1.0");
+  await instances[0].generalInRadio.expectUnchecked();
+  await instances[0].generalOutRadio.expectUnchecked();
+  await instances[0].generalDataElementRadio.expectChecked();
+  await instances[0].generalDataElementField.expectValue("%data1%");
+  await instances[0].iabValueField.expectNotExists();
+  await instances[0].gdprAppliesYesRadio.expectNotExists();
+  await instances[0].gdprAppliesNoRadio.expectNotExists();
+  await instances[0].gdprAppliesDataElementRadio.expectNotExists();
+  await instances[0].gdprAppliesDataElementField.expectNotExists();
+  await instances[0].containsPersonalDataYesRadio.expectNotExists();
+  await instances[0].containsPersonalDataNoRadio.expectNotExists();
+  await instances[0].containsPersonalDataDataElementRadio.expectNotExists();
+  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+
+  await instances[1].standardSelect.expectValue("iab_tcf");
+  await instances[1].versionField.expectValue("2.0");
+  await instances[1].generalInRadio.expectNotExists();
+  await instances[1].generalOutRadio.expectNotExists();
+  await instances[1].generalDataElementRadio.expectNotExists();
+  await instances[1].generalDataElementField.expectNotExists();
+  await instances[1].iabValueField.expectValue("%data2%");
+  await instances[1].gdprAppliesYesRadio.expectUnchecked();
+  await instances[1].gdprAppliesNoRadio.expectUnchecked();
+  await instances[1].gdprAppliesDataElementRadio.expectChecked();
+  await instances[1].gdprAppliesDataElementField.expectValue("%data3%");
+  await instances[1].containsPersonalDataYesRadio.expectUnchecked();
+  await instances[1].containsPersonalDataNoRadio.expectUnchecked();
+  await instances[1].containsPersonalDataDataElementRadio.expectChecked();
+  await instances[1].containsPersonalDataDataElementField.expectValue(
+    "%data4%"
+  );
+});
+
+test("initializes form fields with settings containing data element for consent", async () => {
+  await extensionViewController.init({
+    extensionSettings: mockExtensionSettings,
+    settings: {
+      instanceName: "alloy2",
+      identityMap: "%data1%",
+      consent: "%data2%"
+    }
+  });
+  await instanceNameSelect.expectValue("alloy2");
+  await identityMapField.expectValue("%data1%");
+  await inputMethodFormRadio.expectUnchecked();
+  await inputMethodDataElementRadio.expectChecked();
+  await dataElementField.expectValue("%data2%");
+  await addConsentButton.expectNotExists();
+  await instances[0].container.expectNotExists();
 });
 
 test("initializes form fields with no settings", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instanceNameField.expectValue("alloy1");
-  await radioGroup.inField.expectChecked();
-  await radioGroup.outField.expectUnchecked();
-  await radioGroup.dataElementField.expectUnchecked();
+  await instanceNameSelect.expectValue("alloy1");
+  await identityMapField.expectValue("");
+  await inputMethodFormRadio.expectChecked();
+  await inputMethodDataElementRadio.expectUnchecked();
+  await dataElementField.expectNotExists();
+  await addConsentButton.expectExists();
+
+  await instances[0].standardSelect.expectValue("adobe");
+  await instances[0].versionField.expectValue("");
+  await instances[0].generalInRadio.expectChecked();
+  await instances[0].generalOutRadio.expectUnchecked();
+  await instances[0].generalDataElementRadio.expectUnchecked();
+  await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].iabValueField.expectNotExists();
+  await instances[0].gdprAppliesYesRadio.expectNotExists();
+  await instances[0].gdprAppliesNoRadio.expectNotExists();
+  await instances[0].gdprAppliesDataElementRadio.expectNotExists();
+  await instances[0].gdprAppliesDataElementField.expectNotExists();
+  await instances[0].containsPersonalDataYesRadio.expectNotExists();
+  await instances[0].containsPersonalDataNoRadio.expectNotExists();
+  await instances[0].containsPersonalDataDataElementRadio.expectNotExists();
+  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+  await instances[1].container.expectNotExists();
+
+  await instances[0].standardSelect.selectOption("IAB TCF");
+
+  await instances[0].standardSelect.expectValue("iab_tcf");
+  await instances[0].versionField.expectValue("");
+  await instances[0].generalInRadio.expectNotExists();
+  await instances[0].generalOutRadio.expectNotExists();
+  await instances[0].generalDataElementRadio.expectNotExists();
+  await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].iabValueField.expectValue("");
+  await instances[0].gdprAppliesYesRadio.expectChecked();
+  await instances[0].gdprAppliesNoRadio.expectUnchecked();
+  await instances[0].gdprAppliesDataElementRadio.expectUnchecked();
+  await instances[0].gdprAppliesDataElementField.expectNotExists();
+  await instances[0].containsPersonalDataYesRadio.expectUnchecked();
+  await instances[0].containsPersonalDataNoRadio.expectChecked();
+  await instances[0].containsPersonalDataDataElementRadio.expectUnchecked();
+  await instances[0].containsPersonalDataDataElementField.expectNotExists();
+  await instances[1].container.expectNotExists();
 });
 
-test("returns valid settings containing static purposes", async () => {
+test("returns minimal valid settings", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
+  await instances[0].versionField.typeText("1.1");
+  await addConsentButton.click();
+  await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].versionField.typeText("2.1");
+  await instances[1].iabValueField.typeText("1234abcd");
 
-  await instanceNameField.selectOption("alloy2");
-  await radioGroup.outField.click();
+  await extensionViewController.expectIsValid();
+  await extensionViewController.expectSettings({
+    instanceName: "alloy1",
+    consent: [
+      {
+        standard: "Adobe",
+        version: "1.1",
+        value: { general: "in" }
+      },
+      {
+        standard: "IAB TCF",
+        version: "2.1",
+        value: "1234abcd",
+        gdprApplies: true,
+        containsPersonalData: false
+      }
+    ]
+  });
+});
+
+test("returns full valid settings", async () => {
+  await extensionViewController.init({
+    extensionSettings: mockExtensionSettings
+  });
+  await instanceNameSelect.selectOption("alloy2");
+  await identityMapField.typeText("%data0%");
+  await instances[0].standardSelect.selectOption("IAB TCF");
+  await instances[0].versionField.typeText("2.2");
+  await instances[0].iabValueField.typeText("a");
+  await instances[0].gdprAppliesNoRadio.click();
+  await instances[0].containsPersonalDataYesRadio.click();
+  await addConsentButton.click();
+  await instances[1].versionField.typeText("1.2");
+  await instances[1].generalOutRadio.click();
+
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
     instanceName: "alloy2",
-    consent: [{ standard: "Adobe", version: "1.0", value: { general: "out" } }]
+    identityMap: "%data0%",
+    consent: [
+      {
+        standard: "IAB TCF",
+        version: "2.2",
+        value: "a",
+        gdprApplies: false,
+        containsPersonalData: true
+      },
+      {
+        standard: "Adobe",
+        version: "1.2",
+        value: { general: "out" }
+      }
+    ]
   });
 });
 
-test("returns valid settings containing data element for purposes", async () => {
+test("returns valid setting for guided form data elements", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
+  await instances[0].versionField.typeText("1.3");
+  await instances[0].generalDataElementRadio.click();
+  await instances[0].generalDataElementField.typeText("%data1%");
+  await addConsentButton.click();
+  await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].versionField.typeText("2.3");
+  await instances[1].iabValueField.typeText("%data2%");
+  await instances[1].gdprAppliesDataElementRadio.click();
+  await instances[1].gdprAppliesDataElementField.typeText("%data3%");
+  await instances[1].containsPersonalDataDataElementRadio.click();
+  await instances[1].containsPersonalDataDataElementField.typeText("%data4%");
 
-  await instanceNameField.selectOption("alloy2");
-  await radioGroup.dataElementField.click();
-  await dataElementField.typeText("%foo%");
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
-    instanceName: "alloy2",
-    consent: "%foo%"
+    instanceName: "alloy1",
+    consent: [
+      {
+        standard: "Adobe",
+        version: "1.3",
+        value: { general: "%data1%" }
+      },
+      {
+        standard: "IAB TCF",
+        version: "2.3",
+        value: "%data2%",
+        gdprApplies: "%data3%",
+        containsPersonalData: "%data4%"
+      }
+    ]
   });
 });
 
-test("shows error for purposes data element value that is not a data element", async () => {
+test("returns valid settings for data element", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await radioGroup.dataElementField.click();
-  await dataElementField.typeText("foo");
-  await extensionViewController.expectIsNotValid();
-  await dataElementField.expectError();
+  await inputMethodDataElementRadio.click();
+  await dataElementField.typeText("%data2%");
+  await extensionViewController.expectIsValid();
+  await extensionViewController.expectSettings({
+    instanceName: "alloy1",
+    consent: "%data2%"
+  });
 });
 
-test("shows error for purposes data element value that is more than one data element", async () => {
+test("deletes consent objects", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await radioGroup.dataElementField.click();
-  await dataElementField.typeText("%foo%%bar%");
-  await extensionViewController.expectIsNotValid();
-  await dataElementField.expectError();
+  await instances[0].versionField.typeText("1");
+  await instances[0].deleteConsentButton.expectDisabled();
+  await instances[1].container.expectNotExists();
+  await addConsentButton.click();
+  await instances[0].deleteConsentButton.expectEnabled();
+  await instances[1].versionField.typeText("2");
+  await instances[0].deleteConsentButton.click();
+  await instances[0].versionField.expectValue("2");
+  await instances[1].container.expectNotExists();
+  await addConsentButton.click();
+  await instances[1].versionField.typeText("3");
+  await instances[1].deleteConsentButton.click();
+  await instances[1].container.expectNotExists();
+  await instances[0].versionField.expectValue("2");
 });
 
-testInstanceNameOptions(extensionViewController, instanceNameField);
+test("shows errors for empty values", async () => {
+  await extensionViewController.init({
+    extensionSettings: mockExtensionSettings
+  });
+  await instances[0].generalDataElementRadio.click();
+  await addConsentButton.click();
+  await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].gdprAppliesDataElementRadio.click();
+  await instances[1].containsPersonalDataDataElementRadio.click();
+
+  await extensionViewController.expectIsNotValid();
+  await instances[0].versionField.expectError();
+  await instances[0].generalDataElementField.expectError();
+  await instances[1].versionField.expectError();
+  await instances[1].iabValueField.expectError();
+  await instances[1].gdprAppliesDataElementField.expectError();
+  await instances[1].containsPersonalDataDataElementField.expectError();
+});
+
+test("shows errors for things that aren't data elements and does not show errors for hidden invalid fields", async () => {
+  await extensionViewController.init({
+    extensionSettings: mockExtensionSettings
+  });
+  await instances[0].versionField.typeText("1");
+  await instances[0].generalDataElementRadio.click();
+  await instances[0].generalDataElementField.typeText("notadataelement");
+  await addConsentButton.click();
+  await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].versionField.typeText("2");
+  await instances[1].iabValueField.typeText("notadataelement");
+  await instances[1].gdprAppliesDataElementRadio.click();
+  await instances[1].gdprAppliesDataElementField.typeText("%data1%%data2%");
+  await instances[1].containsPersonalDataDataElementRadio.click();
+  await instances[1].containsPersonalDataDataElementField.typeText(
+    "%notadataelement"
+  );
+
+  await extensionViewController.expectIsNotValid();
+  await instances[0].generalDataElementField.expectError();
+  await instances[1].iabValueField.expectNoError();
+  await instances[1].gdprAppliesDataElementField.expectError();
+  await instances[1].containsPersonalDataDataElementField.expectError();
+
+  await inputMethodDataElementRadio.click();
+  await dataElementField.typeText("%dataelement%");
+  await extensionViewController.expectIsValid();
+
+  await dataElementField.typeText("notadataelement");
+  await extensionViewController.expectIsNotValid();
+  await dataElementField.expectError();
+
+  await inputMethodFormRadio.click();
+  await instances[0].generalInRadio.click();
+  await instances[1].gdprAppliesYesRadio.click();
+  await instances[1].containsPersonalDataYesRadio.click();
+  await extensionViewController.expectIsValid();
+});
+
+testInstanceNameOptions(extensionViewController, instanceNameSelect);

--- a/test/unit/lib/actions/setConsent/createSetConsent.spec.js
+++ b/test/unit/lib/actions/setConsent/createSetConsent.spec.js
@@ -25,6 +25,7 @@ describe("Set Consent", () => {
       const action = createSetConsent({ instanceManager });
       const promiseReturnedFromAction = action({
         instanceName: "myinstance",
+        identityMap: "%dataelement123%",
         consent: [
           {
             standard: "Adobe",
@@ -37,6 +38,7 @@ describe("Set Consent", () => {
       expect(promiseReturnedFromAction).toBe(promiseReturnedFromInstance);
       expect(instanceManager.getInstance).toHaveBeenCalledWith("myinstance");
       expect(instance).toHaveBeenCalledWith("setConsent", {
+        identityMap: "%dataelement123%",
         consent: [
           {
             standard: "Adobe",
@@ -46,6 +48,24 @@ describe("Set Consent", () => {
             }
           }
         ]
+      });
+    });
+  });
+
+  ["", null, undefined].forEach(identityMap => {
+    it(`doesn't pass identityMap when it is ${JSON.stringify(
+      identityMap
+    )}`, () => {
+      const instance = jasmine.createSpy();
+      const instanceManager = { getInstance: () => instance };
+      const action = createSetConsent({ instanceManager });
+      action({
+        instanceName: "myinstance",
+        identityMap,
+        consent: [{ standard: "IAB TCF", version: "2.0", value: "1234abcd" }]
+      });
+      expect(instance).toHaveBeenCalledWith("setConsent", {
+        consent: [{ standard: "IAB TCF", version: "2.0", value: "1234abcd" }]
       });
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a form for building IAB consent objects in the setConsent action, and allow multiple consent objects to be provided at once. Add a field for identity map.

## Related Issues

https://jira.corp.adobe.com/browse/CORE-48371
https://jira.corp.adobe.com/browse/CORE-48386

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
