### PR TITLE
Adds sandbox functional tests

### DIFF
--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -270,9 +270,7 @@ const XdmExtensionView = () => {
             });
           })
           .then(schema => {
-            if (schema) {
-              setSchemaStatus(STATUS_LOADED);
-            }
+            setSchemaStatus(STATUS_LOADED);
             const initialValues = getInitialFormState({
               value: (initInfo.settings && initInfo.settings.data) || {},
               schema: schema || {}

--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -82,29 +82,27 @@ const XdmObject = ({
         </InfoTipLayout>
       </div>
       <div>
-        {selectedSandboxMeta && (
-          <Select
-            id="sandboxField"
-            data-test-id="sandboxField"
-            className="u-widthAuto u-gapBottom u-fieldLong"
-            options={sandboxOptions}
-            value={selectedSandboxMeta.name}
-            onChange={sandboxMetaName => {
-              setSelectedNodeId(undefined);
-              setSchemasMetaStatus(STATUS_LOADING);
-              setSelectedSandboxMeta(
-                sandboxesMeta.sandboxes.find(
-                  sandboxMeta => sandboxMeta.name === sandboxMetaName
-                )
-              );
-            }}
-            disabled={sandboxesMeta.disabled}
-            placeholder="PRODUCTION Prod"
-          />
-        )}
+        <Select
+          id="sandboxField"
+          data-test-id="sandboxField"
+          className="u-widthAuto u-gapBottom u-fieldLong"
+          options={sandboxOptions}
+          value={selectedSandboxMeta.name}
+          onChange={sandboxMetaName => {
+            setSelectedNodeId(undefined);
+            setSchemasMetaStatus(STATUS_LOADING);
+            setSelectedSandboxMeta(
+              sandboxesMeta.sandboxes.find(
+                sandboxMeta => sandboxMeta.name === sandboxMetaName
+              )
+            );
+          }}
+          disabled={sandboxesMeta.disabled}
+          placeholder="PRODUCTION Prod"
+        />
       </div>
       {schemasMetaStatus === STATUS_ERROR && (
-        <Alert variant="warning">
+        <Alert data-test-id="selectedSandboxWarning" variant="warning">
           Unable to load schemas for the selected sandbox. Please check the
           settings or choose a different sandbox.
         </Alert>
@@ -137,7 +135,7 @@ const XdmObject = ({
         </div>
       )}
       {schemasMetaStatus === STATUS_LOADED && schemaStatus === STATUS_ERROR && (
-        <Alert variant="error">
+        <Alert data-test-id="selectedSchemaError" variant="error">
           An error occurred while loading the selected schema. Please try again
           or choose a different schema.
         </Alert>
@@ -272,10 +270,12 @@ const XdmExtensionView = () => {
             });
           })
           .then(schema => {
-            setSchemaStatus(STATUS_LOADED);
+            if (schema) {
+              setSchemaStatus(STATUS_LOADED);
+            }
             const initialValues = getInitialFormState({
               value: (initInfo.settings && initInfo.settings.data) || {},
-              schema
+              schema: schema || {}
             });
 
             return initialValues;

--- a/src/view/dataElements/xdmObject/helpers/fetchSandboxes.js
+++ b/src/view/dataElements/xdmObject/helpers/fetchSandboxes.js
@@ -16,10 +16,10 @@ import platform from "./platform";
 export default ({ orgId, imsAccess }) => {
   const baseRequestHeaders = getBaseRequestHeaders({ orgId, imsAccess });
 
-  const DEFAULT_SANDBOX = {
+  const DEFAULT_SANDBOX_RESPONSE_BODY = {
     sandboxes: [
       {
-        name: platform.getDefaultSandbox(),
+        name: platform.getDefaultSandboxName(),
         title: "Prod",
         type: "production",
         isDefault: true,
@@ -41,7 +41,7 @@ export default ({ orgId, imsAccess }) => {
     })
     .then(responseBody => {
       if (responseBody.sandboxes && responseBody.sandboxes.length === 0) {
-        return DEFAULT_SANDBOX;
+        return DEFAULT_SANDBOX_RESPONSE_BODY;
       }
       return responseBody;
     });

--- a/src/view/dataElements/xdmObject/helpers/fetchSandboxes.js
+++ b/src/view/dataElements/xdmObject/helpers/fetchSandboxes.js
@@ -16,37 +16,33 @@ import platform from "./platform";
 export default ({ orgId, imsAccess }) => {
   const baseRequestHeaders = getBaseRequestHeaders({ orgId, imsAccess });
 
-  const SANDBOX_PERMISSION_ERROR = 403;
-
   const DEFAULT_SANDBOX = {
-    name: platform.getDefaultSandbox(),
-    title: "Prod",
-    type: "production",
-    isDefault: true,
-    region: null,
-    state: "active"
+    sandboxes: [
+      {
+        name: platform.getDefaultSandbox(),
+        title: "Prod",
+        type: "production",
+        isDefault: true,
+        region: null,
+        state: "active"
+      }
+    ],
+    disabled: true
   };
 
-  return fetch(
-    `${platform.getHost()}/data/foundation/sandbox-management/sandboxes`,
-    {
-      headers: baseRequestHeaders
-    }
-  )
+  return fetch(`${platform.getHost()}/data/foundation/sandbox-management/`, {
+    headers: baseRequestHeaders
+  })
     .then(response => {
-      // Some platform users may not have permission to call the sandbox-management API endpoint.
-      // In this case we return a default sandbox representing production. This allows schema meta
-      // and schemas to be loaded using the organization's default sandbox name 'prod'.
-      if (response.status === SANDBOX_PERMISSION_ERROR) {
-        return {
-          sandboxes: [DEFAULT_SANDBOX],
-          disabled: true
-        };
-      }
       if (!response.ok) {
         throw new Error("Cannot fetch active sandboxes list");
       }
       return response.json();
     })
-    .then(responseBody => responseBody);
+    .then(responseBody => {
+      if (responseBody.sandboxes && responseBody.sandboxes.length === 0) {
+        return DEFAULT_SANDBOX;
+      }
+      return responseBody;
+    });
 };

--- a/src/view/dataElements/xdmObject/helpers/fetchSchema.js
+++ b/src/view/dataElements/xdmObject/helpers/fetchSchema.js
@@ -30,7 +30,7 @@ export default ({ orgId, imsAccess, schemaMeta, sandboxName }) => {
   if (sandboxName) {
     headers["x-sandbox-name"] = sandboxName;
   } else {
-    headers["x-sandbox-name"] = platform.getDefaultSandbox();
+    headers["x-sandbox-name"] = platform.getDefaultSandboxName();
   }
 
   return fetch(

--- a/src/view/dataElements/xdmObject/helpers/fetchSchemasMeta.js
+++ b/src/view/dataElements/xdmObject/helpers/fetchSchemasMeta.js
@@ -29,7 +29,7 @@ export default ({ orgId, imsAccess, sandboxName }) => {
   if (sandboxName) {
     headers["x-sandbox-name"] = sandboxName;
   } else {
-    headers["x-sandbox-name"] = platform.getDefaultSandbox();
+    headers["x-sandbox-name"] = platform.getDefaultSandboxName();
   }
 
   // TODO: paginate this response using on responseBody._page.count or responseBody._links.next

--- a/src/view/dataElements/xdmObject/helpers/platform.js
+++ b/src/view/dataElements/xdmObject/helpers/platform.js
@@ -16,7 +16,7 @@ export default {
   getHost: () => {
     return PROD;
   },
-  getDefaultSandbox: () => {
+  getDefaultSandboxName: () => {
     return "prod";
   }
 };

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -86,9 +86,13 @@ const initializeExtensionView = async additionalInitInfo => {
 // disablePageReloads is not a publicized feature, but it sure helps speed up tests.
 // https://github.com/DevExpress/testcafe/issues/1770
 fixture("XDM Object View")
+  .beforeEach(async () => {
+    // adds a mocked sandboxes response
+    await t.addRequestHooks(platformMocks.sandboxes);
+  })
   .disablePageReloads.page("http://localhost:3000/viewSandbox.html")
   .meta("requiresAdobeIOIntegration", true)
-  .requestHooks(platformMocks.sandboxes);
+  .requestHooks(platformMocks.sandboxes)
 
 test("initializes form fields with individual object attribute values", async () => {
   await initializeExtensionView({
@@ -118,8 +122,6 @@ test("disables user from selecting a sandbox", async () => {
   await spectrum.select("sandboxField").expectDisabled();
   await selectSchemaFromSchemasMeta();
   await xdmTree.toggleExpansion("_alloyengineering");
-  // restore original sandboxes mock
-  await t.addRequestHooks(platformMocks.sandboxes);
 });
 
 test("checks sandbox with no schemas", async () => {

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -113,7 +113,7 @@ test("disables user from selecting a sandbox", async () => {
   // temporarily remove sandboxes mock
   await t.removeRequestHooks(platformMocks.sandboxes);
   // replace with unaurhotized mock
-  await t.addRequestHooks(platformMocks.sandboxesUnauthorized);
+  await t.addRequestHooks(platformMocks.sandboxesEmpty);
   await initializeExtensionView();
   await spectrum.select("sandboxField").expectDisabled();
   await selectSchemaFromSchemasMeta();

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -36,8 +36,10 @@ const schema = {
 
 const schemaTitle = "XDM Object Data Element Tests";
 
+const schemaField = spectrum.select("schemaField");
+
 const selectSchemaFromSchemasMeta = async () => {
-  await spectrum.select("schemaField").selectOption(schemaTitle);
+  await schemaField.selectOption(schemaTitle);
 };
 
 /**

--- a/test/functional/dataElements/xdmObject/helpers/platformMocks.js
+++ b/test/functional/dataElements/xdmObject/helpers/platformMocks.js
@@ -1,20 +1,16 @@
 import { RequestMock } from "testcafe";
 
 /**
- * Mocks a 403 unauthorized response from the platform sandboxes endpoint
+ * Mocks an empty response from the platform sandboxes endpoint
  * @type {RequestMock}
  */
-const sandboxesUnauthorized = RequestMock()
-  .onRequestTo(
-    "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes"
-  )
+const sandboxesEmpty = RequestMock()
+  .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond(
     {
-      status: 403,
-      title: "User does not have READ permission to access the sandbox.",
-      type: "http://ns.adobe.com/aep/errors/SMS-2010-403"
+      sandboxes: []
     },
-    403,
+    200,
     { "Access-Control-Allow-Origin": "*" }
   );
 
@@ -23,9 +19,7 @@ const sandboxesUnauthorized = RequestMock()
  * @type {RequestMock}
  */
 const sandboxes = RequestMock()
-  .onRequestTo(
-    "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes"
-  )
+  .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond(
     {
       sandboxes: [
@@ -80,6 +74,6 @@ const schemasMeta = RequestMock()
 
 export default {
   sandboxes,
-  sandboxesUnauthorized,
+  sandboxesEmpty,
   schemasMeta
 };

--- a/test/functional/dataElements/xdmObject/helpers/platformMocks.js
+++ b/test/functional/dataElements/xdmObject/helpers/platformMocks.js
@@ -1,0 +1,85 @@
+import { RequestMock } from "testcafe";
+
+/**
+ * Mocks a 403 unauthorized response from the platform sandboxes endpoint
+ * @type {RequestMock}
+ */
+const sandboxesUnauthorized = RequestMock()
+  .onRequestTo(
+    "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes"
+  )
+  .respond(
+    {
+      status: 403,
+      title: "User does not have READ permission to access the sandbox.",
+      type: "http://ns.adobe.com/aep/errors/SMS-2010-403"
+    },
+    403,
+    { "Access-Control-Allow-Origin": "*" }
+  );
+
+/**
+ * Mocks a response from the platform sandboxes endpoint
+ * @type {RequestMock}
+ */
+const sandboxes = RequestMock()
+  .onRequestTo(
+    "https://platform.adobe.io/data/foundation/sandbox-management/sandboxes"
+  )
+  .respond(
+    {
+      sandboxes: [
+        {
+          name: "prod",
+          title: "Prod",
+          type: "production",
+          isDefault: true,
+          region: "VA7",
+          state: "active"
+        },
+        {
+          name: "alloy-test",
+          title: "Alloy Test",
+          type: "production",
+          isDefault: false,
+          region: "FOO",
+          state: "active"
+        }
+      ]
+    },
+    200,
+    { "Access-Control-Allow-Origin": "*" }
+  );
+
+/**
+ * Mocks a response from the platform schema meta endpoint
+ * @type {RequestMock}
+ */
+const schemasMeta = RequestMock()
+  .onRequestTo(
+    "https://platform.adobe.io/data/foundation/schemaregistry/tenant/schemas?orderby=title&property=meta:extends==https%3A%2F%2Fns.adobe.com%2Fxdm%2Fcontext%2Fexperienceevent"
+  )
+  .respond(
+    {
+      results: [
+        {
+          $id: "https://ns.adobe.com/alloyengineering/schemas/foo",
+          version: "1.0",
+          title: "Foo1"
+        },
+        {
+          $id: "https://ns.adobe.com/alloyengineering/schemas/foo2",
+          version: "1.0",
+          title: "Foo2"
+        }
+      ]
+    },
+    200,
+    { "Access-Control-Allow-Origin": "*" }
+  );
+
+export default {
+  sandboxes,
+  sandboxesUnauthorized,
+  schemasMeta
+};

--- a/test/functional/helpers/spectrum.js
+++ b/test/functional/helpers/spectrum.js
@@ -257,10 +257,10 @@ Object.keys(componentWrappers).forEach(componentName => {
     return {
       expectEnabled: createExpectEnabled(selector),
       expectDisabled: createExpectDisabled(selector),
-      ...componentWrapper.call(this, selector),
-      selector,
       expectExists: createExpectExists(selector),
-      expectNotExists: createExpectNotExists(selector)
+      expectNotExists: createExpectNotExists(selector),
+      ...componentWrapper.call(this, selector),
+      selector
     };
   };
 });

--- a/test/functional/helpers/spectrum.js
+++ b/test/functional/helpers/spectrum.js
@@ -137,7 +137,9 @@ const componentWrappers = {
         await switchToIframe();
         await t.click(selector.find("button"));
         await selectMenuItem(popoverSelector, label);
-      }
+      },
+      expectDisabled: createExpectDisabled(selector.find("button")),
+      expectEnabled: createExpectEnabled(selector.find("button"))
     };
   },
   textfield(selector) {
@@ -253,12 +255,12 @@ Object.keys(componentWrappers).forEach(componentName => {
   ) {
     const selector = selectorize(testIdOrSelector);
     return {
+      expectEnabled: createExpectEnabled(selector),
+      expectDisabled: createExpectDisabled(selector),
       ...componentWrapper.call(this, selector),
       selector,
       expectExists: createExpectExists(selector),
-      expectNotExists: createExpectNotExists(selector),
-      expectEnabled: createExpectEnabled(selector),
-      expectDisabled: createExpectDisabled(selector)
+      expectNotExists: createExpectNotExists(selector)
     };
   };
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds functional tests to cover most of the use cases for AEM sandbox manipulation in the xdm data elements view. This PR also changes the sandbox endpoint to return just the list the user has access to
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This change is needed to add automated testing coverage to recent features added to the extension

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
