### PR TITLE
Xdm Tree Data Element fixes

### DIFF
--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -563,7 +563,9 @@ const Configuration = ({
                     <div>
                       <h2 className="Rule">Edge Configurations</h2>
                       <Rule variant="small" />
-                      <Link href="https://adobe.ly/3eY91Er" target="_blank">Learn more</Link>
+                      <Link href="https://adobe.ly/3eY91Er" target="_blank">
+                        Learn more
+                      </Link>
 
                       <div className="u-gapTop">
                         {index === 0 && (
@@ -713,7 +715,9 @@ const Configuration = ({
                     <div>
                       <h2 className="Rule">Privacy</h2>
                       <Rule variant="small" />
-                      <Link href="https://adobe.ly/2WSngEh" target="_blank">Learn more</Link>
+                      <Link href="https://adobe.ly/2WSngEh" target="_blank">
+                        Learn more
+                      </Link>
 
                       <div className="u-gapTop2x">
                         <InfoTipLayout tip="The consent level to be used if the user has not previously provided consent.">
@@ -745,7 +749,9 @@ const Configuration = ({
                     <div>
                       <h2 className="Rule">Identity</h2>
                       <Rule variant="small" />
-                      <Link href="https://adobe.ly/39ouRzA" target="_blank">Learn more</Link>
+                      <Link href="https://adobe.ly/39ouRzA" target="_blank">
+                        Learn more
+                      </Link>
 
                       <div className="u-gapTop">
                         <InfoTipLayout tip="Enables the AEP Web SDK to preserve the ECID by reading/writing the AMCV cookie. Use this config until users are fully migrated to the Alloy cookie and in situations where you have mixed pages on your website.">
@@ -773,7 +779,9 @@ const Configuration = ({
                     <div>
                       <h2 className="Rule">Personalization</h2>
                       <Rule variant="small" />
-                      <Link href="https://adobe.ly/3fYDkfh" target="_blank">Learn more</Link>
+                      <Link href="https://adobe.ly/3fYDkfh" target="_blank">
+                        Learn more
+                      </Link>
 
                       <div className="u-gapTop">
                         <InfoTipLayout tip="A CSS style definition that will hide content areas of your web page while personalized content is loaded from the server.">
@@ -816,7 +824,9 @@ const Configuration = ({
                     <div>
                       <h2 className="Rule">Data Collection</h2>
                       <Rule variant="small" />
-                      <Link href="https://adobe.ly/2CYnq65" target="_blank">Learn more</Link>
+                      <Link href="https://adobe.ly/2CYnq65" target="_blank">
+                        Learn more
+                      </Link>
                       <div className="u-gapTop">
                         <InfoTipLayout tip='A variable named "content" will be available for use within your custom code. Modify "content.xdm" as needed to transform data before it is sent to the server.'>
                           <FieldLabel

--- a/src/view/dataElements/xdmObject/constants/alwaysDisabledFields.js
+++ b/src/view/dataElements/xdmObject/constants/alwaysDisabledFields.js
@@ -20,5 +20,6 @@ export default [
   "eventMergeId",
   "implementationDetails",
   "implementationDetails.name",
-  "implementationDetails.version"
+  "implementationDetails.version",
+  "implementationDetails.environment"
 ];

--- a/src/view/dataElements/xdmObject/helpers/array/populateTreeNode.js
+++ b/src/view/dataElements/xdmObject/helpers/array/populateTreeNode.js
@@ -23,7 +23,14 @@ export default ({
 }) => {
   const { items } = formStateNode;
 
-  if (items && items.length) {
+  // Arrays using the whole population strategy do not have children visible in the tree
+  // Also, arrays with an ancestor using the whole population strategy do not have children visible in the tree.
+  if (
+    items &&
+    items.length &&
+    !isUsingWholePopulationStrategy &&
+    !isAncestorUsingWholePopulationStrategy
+  ) {
     treeNode.children = items.map((itemFormStateNode, index) => {
       const childNode = getTreeNode({
         formStateNode: itemFormStateNode,

--- a/src/view/dataElements/xdmObject/helpers/array/validate.js
+++ b/src/view/dataElements/xdmObject/helpers/array/validate.js
@@ -33,16 +33,14 @@ export default ({
   }
 
   if (items) {
-    const itemErrors = items
-      .map(itemFormStateNode => {
-        return validate({
-          formStateNode: itemFormStateNode,
-          isParentAnArray: true,
-          notifyParentOfDataPopulation: confirmDataPopulatedAtCurrentOrDescendantNode
-        });
-      })
-      .filter(error => error);
-    if (itemErrors.length) {
+    const itemErrors = items.map(itemFormStateNode => {
+      return validate({
+        formStateNode: itemFormStateNode,
+        isParentAnArray: true,
+        notifyParentOfDataPopulation: confirmDataPopulatedAtCurrentOrDescendantNode
+      });
+    });
+    if (itemErrors.filter(error => error).length) {
       return { items: itemErrors };
     }
   }

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -273,6 +273,24 @@ test("initializes form fields with whole array value", async () => {
   await arrayEdit.expectValue("%industries%");
 });
 
+test.only("Arrays with no values are invalid", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.toggleExpansion("_alloyengineering");
+  await xdmTree.toggleExpansion("vendor");
+  await xdmTree.click("industries");
+  await arrayEdit.selectPartsPopulationStrategy();
+  await arrayEdit.addItem();
+  await arrayEdit.addItem();
+  await arrayEdit.clickItem(0);
+  await arrayEdit.enterValue("%item1%");
+  await xdmTree.toggleExpansion("industries");
+
+  await extensionViewController.expectIsNotValid();
+  await xdmTree.expectIsValid("Item 1");
+  await xdmTree.expectIsNotValid("Item 2");
+});
+
 test("allows user to provide value for property with string type", async () => {
   await initializeExtensionView();
   await selectSchemaFromSchemasMeta();

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -92,7 +92,7 @@ fixture("XDM Object View")
   })
   .disablePageReloads.page("http://localhost:3000/viewSandbox.html")
   .meta("requiresAdobeIOIntegration", true)
-  .requestHooks(platformMocks.sandboxes)
+  .requestHooks(platformMocks.sandboxes);
 
 test("initializes form fields with individual object attribute values", async () => {
   await initializeExtensionView({
@@ -508,4 +508,11 @@ test("allows user to select no constant value for property with boolean type", a
 
   await extensionViewController.expectIsValid();
   await expectSettingsToContainData({});
+});
+
+test("disables auto-populated fields", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.click("_id");
+  await stringEdit.expectNotExists();
 });

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -273,7 +273,7 @@ test("initializes form fields with whole array value", async () => {
   await arrayEdit.expectValue("%industries%");
 });
 
-test.only("Arrays with no values are invalid", async () => {
+test("arrays with no values are invalid", async () => {
   await initializeExtensionView();
   await selectSchemaFromSchemasMeta();
   await xdmTree.toggleExpansion("_alloyengineering");
@@ -289,6 +289,35 @@ test.only("Arrays with no values are invalid", async () => {
   await extensionViewController.expectIsNotValid();
   await xdmTree.expectIsValid("Item 1");
   await xdmTree.expectIsNotValid("Item 2");
+});
+
+test("arrays using whole population strategy do not have children", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.toggleExpansion("_alloyengineering");
+  await xdmTree.toggleExpansion("vendor");
+  await xdmTree.click("industries");
+  await arrayEdit.selectPartsPopulationStrategy();
+  await arrayEdit.addItem();
+  await xdmTree.toggleExpansion("industries");
+  await xdmTree.expectExists("Item 1");
+  await arrayEdit.selectWholePopulationStrategy();
+  await xdmTree.expectNotExists("Item 1");
+});
+
+test("arrays with a whole population strategy ancestor do not have children", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.toggleExpansion("_alloyengineering");
+  await xdmTree.toggleExpansion("vendor");
+  await xdmTree.click("industries");
+  await arrayEdit.selectPartsPopulationStrategy();
+  await arrayEdit.addItem();
+  await xdmTree.toggleExpansion("industries");
+  await xdmTree.expectExists("Item 1");
+  await xdmTree.click("vendor");
+  await objectEdit.selectWholePopulationStrategy();
+  await xdmTree.expectNotExists("Item 1");
 });
 
 test("allows user to provide value for property with string type", async () => {

--- a/test/functional/dataElements/xdmObject/helpers/stringEdit.js
+++ b/test/functional/dataElements/xdmObject/helpers/stringEdit.js
@@ -20,5 +20,11 @@ export default {
   },
   expectValue: async text => {
     await spectrum.textfield("valueField").expectValue(text);
+  },
+  expectExists: async () => {
+    await spectrum.textfield("valueField").expectExists();
+  },
+  expectNotExists: async () => {
+    await spectrum.textfield("valueField").expectNotExists();
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/xdmTree.js
+++ b/test/functional/dataElements/xdmObject/helpers/xdmTree.js
@@ -49,5 +49,13 @@ export default {
   expectIsNotValid: async title => {
     const node = await getNode(title);
     await t.expect(node.hasClass("is-invalid")).ok();
+  },
+  expectExists: async title => {
+    const node = await getNode(title);
+    await t.expect(node.exists).ok();
+  },
+  expectNotExists: async title => {
+    const node = await getNode(title);
+    await t.expect(node.exists).notOk();
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/xdmTree.js
+++ b/test/functional/dataElements/xdmObject/helpers/xdmTree.js
@@ -41,5 +41,13 @@ export default {
         .nth(0)
         .find(".ant-tree-switcher")
     );
+  },
+  expectIsValid: async title => {
+    const node = await getNode(title);
+    await t.expect(node.hasClass("is-invalid")).notOk();
+  },
+  expectIsNotValid: async title => {
+    const node = await getNode(title);
+    await t.expect(node.hasClass("is-invalid")).ok();
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I found a few bugs in the XDM Tree Data Element while working on the Population Indicator feature. I'm including them here as a separate PR so that the Population Indicator changes don't hold up the merging of these fixes.

* implementationDetails.environment should be disabled.
* Array validation for checking if an array object is empty, can apply to the wrong node.
* When using a whole population strategy for an array, the array items are still visible.

## Related Issue

I didn't file tickets for these issues, but the population indicator feature is here: https://jira.corp.adobe.com/browse/CORE-42302

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
