### PR TITLE
CORE-48075 - fetch namespaces from platform

### DIFF
--- a/src/view/components/identityWrapper.jsx
+++ b/src/view/components/identityWrapper.jsx
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import "regenerator-runtime"; // needed for some of react-spectrum
-import React from "react";
+import React, { useState } from "react";
 import { FieldArray } from "formik";
 import Textfield from "@react/react-spectrum/Textfield";
 import Checkbox from "@react/react-spectrum/Checkbox";
@@ -33,6 +33,9 @@ import NamespaceComponent from "./namespaceComponent";
 
 function IdentityWrapper({ values }) {
   const { namespaces } = values;
+  const [selectedAccordionIndex, setSelectedAccordionIndex] = useState(
+    values.identities.length === 1 ? 0 : undefined
+  );
 
   return (
     <React.Fragment>
@@ -47,6 +50,7 @@ function IdentityWrapper({ values }) {
                   label="Add Identity"
                   onClick={() => {
                     arrayHelpers.push(getDefaultIdentity());
+                    setSelectedAccordionIndex(values.identities.length);
                   }}
                 />
               </div>
@@ -54,6 +58,8 @@ function IdentityWrapper({ values }) {
               <Accordion
                 data-test-id="identitiesAccordion"
                 className="u-gapTop2x"
+                selectedIndex={selectedAccordionIndex}
+                onChange={setSelectedAccordionIndex}
               >
                 {values.identities.map((identity, index) => (
                   <AccordionItem
@@ -181,6 +187,7 @@ function IdentityWrapper({ values }) {
                         disabled={values.identities.length === 1}
                         onClick={() => {
                           arrayHelpers.remove(index);
+                          setSelectedAccordionIndex(0);
                         }}
                       />
                       {values.identities.length === 1 ? (

--- a/src/view/components/identityWrapper.jsx
+++ b/src/view/components/identityWrapper.jsx
@@ -29,191 +29,175 @@ import authenticatedStateOptions from "../constants/authenticatedStateOptions";
 import getDefaultIdentifier from "../utils/getDefaultIdentifier";
 import InfoTipLayout from "./infoTipLayout";
 import getDefaultIdentity from "../utils/getDefaultIdentity";
+import NamespaceComponent from "./namespaceComponent";
 
 function IdentityWrapper({ values }) {
   const { namespaces } = values;
-  return (
-    <div>
-      <React.Fragment>
-        <FieldArray
-          name="identities"
-          render={arrayHelpers => {
-            return (
-              <React.Fragment>
-                <div className="u-gapTop u-alignRight">
-                  <Button
-                    data-test-id="addIdentityButton"
-                    label="Add Identity"
-                    onClick={() => {
-                      arrayHelpers.push(getDefaultIdentity());
-                    }}
-                  />
-                </div>
-                <Heading variant="subtitle2">Identities</Heading>
-                <Accordion
-                  data-test-id="identitiesAccordion"
-                  className="u-gapTop2x"
-                >
-                  {values.identities.map((identity, index) => (
-                    <AccordionItem
-                      key={index}
-                      header={identity.namespace || "unnamed identity"}
-                    >
-                      <div>
-                        <FieldLabel
-                          labelFor={
-                            namespaces.length > 0
-                              ? `namespaceSelect${index}Field`
-                              : `namespace${index}Field`
-                          }
-                          label="Namespace"
-                        />
-                        {namespaces.length > 0 ? (
-                          <div>
-                            <WrappedField
-                              data-test-id={`namespaceSelect${index}Field`}
-                              id={`namespace${index}Field`}
-                              name={`identities.${index}.namespace`}
-                              component={Select}
-                              componentClassName="u-fieldLong"
-                              options={namespaces}
-                            />
-                          </div>
-                        ) : (
-                          <div>
-                            <WrappedField
-                              data-test-id={`namespace${index}Field`}
-                              id={`namespace${index}Field`}
-                              name={`identities.${index}.namespace`}
-                              component={Textfield}
-                              componentClassName="u-fieldLong"
-                            />
-                          </div>
-                        )}
-                      </div>
-                      <div>
-                        <FieldArray
-                          id={`identities.${index}.identifiers`}
-                          name={`identities.${index}.identifiers`}
-                          render={identityArrayHelpers => {
-                            return (
-                              <React.Fragment>
-                                <div className="u-gapTop u-alignRight">
-                                  <Button
-                                    data-test-id={`addIdentifier${index}Button`}
-                                    label="Add Identifier"
-                                    onClick={() => {
-                                      identityArrayHelpers.push(
-                                        getDefaultIdentifier()
-                                      );
-                                    }}
-                                  />
-                                </div>
-                                {identity.identifiers.map(
-                                  (identifier, identifierIndex) => (
-                                    <Well
-                                      key={`identity${index}identifier${identifierIndex}`}
-                                    >
-                                      <div className="u-gapTop">
-                                        <FieldLabel
-                                          labelFor={`identity${index}idField${identifierIndex}`}
-                                          label="ID"
-                                        />
-                                        <div>
-                                          <WrappedField
-                                            data-test-id={`identity${index}idField${identifierIndex}`}
-                                            id={`identity${index}idField${identifierIndex}`}
-                                            name={`identities.${index}.identifiers.${identifierIndex}.id`}
-                                            component={Textfield}
-                                            componentClassName="u-fieldLong"
-                                            supportDataElement="replace"
-                                          />
-                                        </div>
-                                      </div>
 
-                                      <div className="u-gapTop">
-                                        <FieldLabel
-                                          labelFor={`identity${index}authenticatedStateField${identifierIndex}`}
-                                          label="Authenticated State"
+  return (
+    <React.Fragment>
+      <FieldArray
+        name="identities"
+        render={arrayHelpers => {
+          return (
+            <React.Fragment>
+              <div className="u-gapTop u-alignRight">
+                <Button
+                  data-test-id="addIdentityButton"
+                  label="Add Identity"
+                  onClick={() => {
+                    arrayHelpers.push(getDefaultIdentity());
+                  }}
+                />
+              </div>
+              <Heading variant="subtitle2">Identities</Heading>
+              <Accordion
+                data-test-id="identitiesAccordion"
+                className="u-gapTop2x"
+              >
+                {values.identities.map((identity, index) => (
+                  <AccordionItem
+                    key={index}
+                    header={identity.namespace || "unnamed identity"}
+                  >
+                    <div>
+                      <FieldLabel
+                        labelFor={
+                          namespaces.length > 0
+                            ? `namespaceSelect${index}Field`
+                            : `namespace${index}Field`
+                        }
+                        label="Namespace"
+                      />
+                      <NamespaceComponent
+                        name={`identities.${index}.namespace`}
+                        namespace={identity.namespace}
+                        options={namespaces}
+                        index={index}
+                      />
+                    </div>
+                    <div>
+                      <FieldArray
+                        id={`identities.${index}.identifiers`}
+                        name={`identities.${index}.identifiers`}
+                        render={identityArrayHelpers => {
+                          return (
+                            <React.Fragment>
+                              <div className="u-gapTop u-alignRight">
+                                <Button
+                                  data-test-id={`addIdentifier${index}Button`}
+                                  label="Add Identifier"
+                                  onClick={() => {
+                                    identityArrayHelpers.push(
+                                      getDefaultIdentifier()
+                                    );
+                                  }}
+                                />
+                              </div>
+                              {identity.identifiers.map(
+                                (identifier, identifierIndex) => (
+                                  <Well
+                                    key={`identity${index}identifier${identifierIndex}`}
+                                  >
+                                    <div className="u-gapTop">
+                                      <FieldLabel
+                                        labelFor={`identity${index}idField${identifierIndex}`}
+                                        label="ID"
+                                      />
+                                      <div>
+                                        <WrappedField
+                                          data-test-id={`identity${index}idField${identifierIndex}`}
+                                          id={`identity${index}idField${identifierIndex}`}
+                                          name={`identities.${index}.identifiers.${identifierIndex}.id`}
+                                          component={Textfield}
+                                          componentClassName="u-fieldLong"
+                                          supportDataElement="replace"
                                         />
-                                        <div>
-                                          <WrappedField
-                                            data-test-id={`identity${index}authenticatedStateField${identifierIndex}`}
-                                            id={`identity${index}authenticatedStateField${identifierIndex}`}
-                                            name={`identities.${index}.identifiers.${identifierIndex}.authenticatedState`}
-                                            component={Select}
-                                            componentClassName="u-fieldLong"
-                                            options={authenticatedStateOptions}
-                                          />
-                                        </div>
                                       </div>
-                                      <div className="u-gapTop">
-                                        <InfoTipLayout tip="Adobe Experience Platform will use the identity as an identifier to help stitch together more information about that individual. If left unchecked, the identifier within this namespace will still be collected but the ECID will be used as the primary identifier for stitching.">
-                                          <WrappedField
-                                            data-test-id={`identity${index}primaryField${identifierIndex}`}
-                                            name={`identities.${index}.identifiers.${identifierIndex}.primary`}
-                                            component={Checkbox}
-                                            label="Primary"
-                                          />
-                                        </InfoTipLayout>
-                                      </div>
-                                      <div className="u-gapTop">
-                                        <Button
-                                          data-test-id={`deleteIdentifier${index}Button${identifierIndex}`}
-                                          label="Delete Identifier"
-                                          icon={<Delete />}
-                                          disabled={
-                                            values.identities[index].identifiers
-                                              .length === 1
-                                          }
-                                          onClick={() => {
-                                            identityArrayHelpers.remove(
-                                              identifierIndex
-                                            );
-                                          }}
+                                    </div>
+
+                                    <div className="u-gapTop">
+                                      <FieldLabel
+                                        labelFor={`identity${index}authenticatedStateField${identifierIndex}`}
+                                        label="Authenticated State"
+                                      />
+                                      <div>
+                                        <WrappedField
+                                          data-test-id={`identity${index}authenticatedStateField${identifierIndex}`}
+                                          id={`identity${index}authenticatedStateField${identifierIndex}`}
+                                          name={`identities.${index}.identifiers.${identifierIndex}.authenticatedState`}
+                                          component={Select}
+                                          componentClassName="u-fieldLong"
+                                          options={authenticatedStateOptions}
                                         />
-                                        {values.identities[index].identifiers
-                                          .length === 1 ? (
-                                          <span className="Note u-gapLeft">
-                                            You must have at least one
-                                            identifier to use this action.
-                                          </span>
-                                        ) : null}
                                       </div>
-                                    </Well>
-                                  )
-                                )}
-                              </React.Fragment>
-                            );
-                          }}
-                        />
-                      </div>
-                      <div className="u-gapTop">
-                        <Button
-                          data-test-id={`deleteIdentity${index}Button`}
-                          label="Delete Identity"
-                          icon={<Delete />}
-                          disabled={values.identities.length === 1}
-                          onClick={() => {
-                            arrayHelpers.remove(index);
-                          }}
-                        />
-                        {values.identities.length === 1 ? (
-                          <span className="Note u-gapLeft">
-                            You must have at least one identity to use this
-                            action.
-                          </span>
-                        ) : null}
-                      </div>
-                    </AccordionItem>
-                  ))}
-                </Accordion>
-              </React.Fragment>
-            );
-          }}
-        />
-      </React.Fragment>
-    </div>
+                                    </div>
+                                    <div className="u-gapTop">
+                                      <InfoTipLayout tip="Adobe Experience Platform will use the identity as an identifier to help stitch together more information about that individual. If left unchecked, the identifier within this namespace will still be collected but the ECID will be used as the primary identifier for stitching.">
+                                        <WrappedField
+                                          data-test-id={`identity${index}primaryField${identifierIndex}`}
+                                          name={`identities.${index}.identifiers.${identifierIndex}.primary`}
+                                          component={Checkbox}
+                                          label="Primary"
+                                        />
+                                      </InfoTipLayout>
+                                    </div>
+                                    <div className="u-gapTop">
+                                      <Button
+                                        data-test-id={`deleteIdentifier${index}Button${identifierIndex}`}
+                                        label="Delete Identifier"
+                                        icon={<Delete />}
+                                        disabled={
+                                          values.identities[index].identifiers
+                                            .length === 1
+                                        }
+                                        onClick={() => {
+                                          identityArrayHelpers.remove(
+                                            identifierIndex
+                                          );
+                                        }}
+                                      />
+                                      {values.identities[index].identifiers
+                                        .length === 1 ? (
+                                        <span className="Note u-gapLeft">
+                                          You must have at least one identifier
+                                          to use this action.
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                  </Well>
+                                )
+                              )}
+                            </React.Fragment>
+                          );
+                        }}
+                      />
+                    </div>
+                    <div className="u-gapTop">
+                      <Button
+                        data-test-id={`deleteIdentity${index}Button`}
+                        label="Delete Identity"
+                        icon={<Delete />}
+                        disabled={values.identities.length === 1}
+                        onClick={() => {
+                          arrayHelpers.remove(index);
+                        }}
+                      />
+                      {values.identities.length === 1 ? (
+                        <span className="Note u-gapLeft">
+                          You must have at least one identity to use this
+                          action.
+                        </span>
+                      ) : null}
+                    </div>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </React.Fragment>
+          );
+        }}
+      />
+    </React.Fragment>
   );
 }
 

--- a/src/view/components/identityWrapper.jsx
+++ b/src/view/components/identityWrapper.jsx
@@ -31,169 +31,189 @@ import InfoTipLayout from "./infoTipLayout";
 import getDefaultIdentity from "../utils/getDefaultIdentity";
 
 function IdentityWrapper({ values }) {
+  const { namespaces } = values;
   return (
-    <React.Fragment>
-      <FieldArray
-        name="identities"
-        render={arrayHelpers => {
-          return (
-            <React.Fragment>
-              <div className="u-gapTop u-alignRight">
-                <Button
-                  data-test-id="addIdentityButton"
-                  label="Add Identity"
-                  onClick={() => {
-                    arrayHelpers.push(getDefaultIdentity());
-                  }}
-                />
-              </div>
-              <Heading variant="subtitle2">Identities</Heading>
-              <Accordion
-                data-test-id="identitiesAccordion"
-                className="u-gapTop2x"
-              >
-                {values.identities.map((identity, index) => (
-                  <AccordionItem
-                    key={index}
-                    header={identity.namespace || "unnamed identity"}
-                  >
-                    <div>
-                      <FieldLabel
-                        labelFor={`namespace${index}Field`}
-                        label="Namespace"
-                      />
+    <div>
+      <React.Fragment>
+        <FieldArray
+          name="identities"
+          render={arrayHelpers => {
+            return (
+              <React.Fragment>
+                <div className="u-gapTop u-alignRight">
+                  <Button
+                    data-test-id="addIdentityButton"
+                    label="Add Identity"
+                    onClick={() => {
+                      arrayHelpers.push(getDefaultIdentity());
+                    }}
+                  />
+                </div>
+                <Heading variant="subtitle2">Identities</Heading>
+                <Accordion
+                  data-test-id="identitiesAccordion"
+                  className="u-gapTop2x"
+                >
+                  {values.identities.map((identity, index) => (
+                    <AccordionItem
+                      key={index}
+                      header={identity.namespace || "unnamed identity"}
+                    >
                       <div>
-                        <WrappedField
-                          data-test-id={`namespace${index}Field`}
-                          id={`namespace${index}Field`}
-                          name={`identities.${index}.namespace`}
-                          component={Textfield}
-                          componentClassName="u-fieldLong"
+                        <FieldLabel
+                          labelFor={
+                            namespaces.length > 0
+                              ? `namespaceSelect${index}Field`
+                              : `namespace${index}Field`
+                          }
+                          label="Namespace"
+                        />
+                        {namespaces.length > 0 ? (
+                          <div>
+                            <WrappedField
+                              data-test-id={`namespaceSelect${index}Field`}
+                              id={`namespace${index}Field`}
+                              name={`identities.${index}.namespace`}
+                              component={Select}
+                              componentClassName="u-fieldLong"
+                              options={namespaces}
+                            />
+                          </div>
+                        ) : (
+                          <div>
+                            <WrappedField
+                              data-test-id={`namespace${index}Field`}
+                              id={`namespace${index}Field`}
+                              name={`identities.${index}.namespace`}
+                              component={Textfield}
+                              componentClassName="u-fieldLong"
+                            />
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <FieldArray
+                          id={`identities.${index}.identifiers`}
+                          name={`identities.${index}.identifiers`}
+                          render={identityArrayHelpers => {
+                            return (
+                              <React.Fragment>
+                                <div className="u-gapTop u-alignRight">
+                                  <Button
+                                    data-test-id={`addIdentifier${index}Button`}
+                                    label="Add Identifier"
+                                    onClick={() => {
+                                      identityArrayHelpers.push(
+                                        getDefaultIdentifier()
+                                      );
+                                    }}
+                                  />
+                                </div>
+                                {identity.identifiers.map(
+                                  (identifier, identifierIndex) => (
+                                    <Well
+                                      key={`identity${index}identifier${identifierIndex}`}
+                                    >
+                                      <div className="u-gapTop">
+                                        <FieldLabel
+                                          labelFor={`identity${index}idField${identifierIndex}`}
+                                          label="ID"
+                                        />
+                                        <div>
+                                          <WrappedField
+                                            data-test-id={`identity${index}idField${identifierIndex}`}
+                                            id={`identity${index}idField${identifierIndex}`}
+                                            name={`identities.${index}.identifiers.${identifierIndex}.id`}
+                                            component={Textfield}
+                                            componentClassName="u-fieldLong"
+                                            supportDataElement="replace"
+                                          />
+                                        </div>
+                                      </div>
+
+                                      <div className="u-gapTop">
+                                        <FieldLabel
+                                          labelFor={`identity${index}authenticatedStateField${identifierIndex}`}
+                                          label="Authenticated State"
+                                        />
+                                        <div>
+                                          <WrappedField
+                                            data-test-id={`identity${index}authenticatedStateField${identifierIndex}`}
+                                            id={`identity${index}authenticatedStateField${identifierIndex}`}
+                                            name={`identities.${index}.identifiers.${identifierIndex}.authenticatedState`}
+                                            component={Select}
+                                            componentClassName="u-fieldLong"
+                                            options={authenticatedStateOptions}
+                                          />
+                                        </div>
+                                      </div>
+                                      <div className="u-gapTop">
+                                        <InfoTipLayout tip="Adobe Experience Platform will use the identity as an identifier to help stitch together more information about that individual. If left unchecked, the identifier within this namespace will still be collected but the ECID will be used as the primary identifier for stitching.">
+                                          <WrappedField
+                                            data-test-id={`identity${index}primaryField${identifierIndex}`}
+                                            name={`identities.${index}.identifiers.${identifierIndex}.primary`}
+                                            component={Checkbox}
+                                            label="Primary"
+                                          />
+                                        </InfoTipLayout>
+                                      </div>
+                                      <div className="u-gapTop">
+                                        <Button
+                                          data-test-id={`deleteIdentifier${index}Button${identifierIndex}`}
+                                          label="Delete Identifier"
+                                          icon={<Delete />}
+                                          disabled={
+                                            values.identities[index].identifiers
+                                              .length === 1
+                                          }
+                                          onClick={() => {
+                                            identityArrayHelpers.remove(
+                                              identifierIndex
+                                            );
+                                          }}
+                                        />
+                                        {values.identities[index].identifiers
+                                          .length === 1 ? (
+                                          <span className="Note u-gapLeft">
+                                            You must have at least one
+                                            identifier to use this action.
+                                          </span>
+                                        ) : null}
+                                      </div>
+                                    </Well>
+                                  )
+                                )}
+                              </React.Fragment>
+                            );
+                          }}
                         />
                       </div>
-                    </div>
-                    <div>
-                      <FieldArray
-                        id={`identities.${index}.identifiers`}
-                        name={`identities.${index}.identifiers`}
-                        render={identityArrayHelpers => {
-                          return (
-                            <React.Fragment>
-                              <div className="u-gapTop u-alignRight">
-                                <Button
-                                  data-test-id={`addIdentifier${index}Button`}
-                                  label="Add Identifier"
-                                  onClick={() => {
-                                    identityArrayHelpers.push(
-                                      getDefaultIdentifier()
-                                    );
-                                  }}
-                                />
-                              </div>
-                              {identity.identifiers.map(
-                                (identifier, identifierIndex) => (
-                                  <Well
-                                    key={`identity${index}identifier${identifierIndex}`}
-                                  >
-                                    <div className="u-gapTop">
-                                      <FieldLabel
-                                        labelFor={`identity${index}idField${identifierIndex}`}
-                                        label="ID"
-                                      />
-                                      <div>
-                                        <WrappedField
-                                          data-test-id={`identity${index}idField${identifierIndex}`}
-                                          id={`identity${index}idField${identifierIndex}`}
-                                          name={`identities.${index}.identifiers.${identifierIndex}.id`}
-                                          component={Textfield}
-                                          componentClassName="u-fieldLong"
-                                          supportDataElement="replace"
-                                        />
-                                      </div>
-                                    </div>
-
-                                    <div className="u-gapTop">
-                                      <FieldLabel
-                                        labelFor={`identity${index}authenticatedStateField${identifierIndex}`}
-                                        label="Authenticated State"
-                                      />
-                                      <div>
-                                        <WrappedField
-                                          data-test-id={`identity${index}authenticatedStateField${identifierIndex}`}
-                                          id={`identity${index}authenticatedStateField${identifierIndex}`}
-                                          name={`identities.${index}.identifiers.${identifierIndex}.authenticatedState`}
-                                          component={Select}
-                                          componentClassName="u-fieldLong"
-                                          options={authenticatedStateOptions}
-                                        />
-                                      </div>
-                                    </div>
-                                    <div className="u-gapTop">
-                                      <InfoTipLayout tip="Adobe Experience Platform will use the identity as an identifier to help stitch together more information about that individual. If left unchecked, the identifier within this namespace will still be collected but the ECID will be used as the primary identifier for stitching.">
-                                        <WrappedField
-                                          data-test-id={`identity${index}primaryField${identifierIndex}`}
-                                          name={`identities.${index}.identifiers.${identifierIndex}.primary`}
-                                          component={Checkbox}
-                                          label="Primary"
-                                        />
-                                      </InfoTipLayout>
-                                    </div>
-                                    <div className="u-gapTop">
-                                      <Button
-                                        data-test-id={`deleteIdentifier${index}Button${identifierIndex}`}
-                                        label="Delete Identifier"
-                                        icon={<Delete />}
-                                        disabled={
-                                          values.identities[index].identifiers
-                                            .length === 1
-                                        }
-                                        onClick={() => {
-                                          identityArrayHelpers.remove(
-                                            identifierIndex
-                                          );
-                                        }}
-                                      />
-                                      {values.identities[index].identifiers
-                                        .length === 1 ? (
-                                        <span className="Note u-gapLeft">
-                                          You must have at least one identifier
-                                          to use this action.
-                                        </span>
-                                      ) : null}
-                                    </div>
-                                  </Well>
-                                )
-                              )}
-                            </React.Fragment>
-                          );
-                        }}
-                      />
-                    </div>
-                    <div className="u-gapTop">
-                      <Button
-                        data-test-id={`deleteIdentity${index}Button`}
-                        label="Delete Identity"
-                        icon={<Delete />}
-                        disabled={values.identities.length === 1}
-                        onClick={() => {
-                          arrayHelpers.remove(index);
-                        }}
-                      />
-                      {values.identities.length === 1 ? (
-                        <span className="Note u-gapLeft">
-                          You must have at least one identity to use this
-                          action.
-                        </span>
-                      ) : null}
-                    </div>
-                  </AccordionItem>
-                ))}
-              </Accordion>
-            </React.Fragment>
-          );
-        }}
-      />
-    </React.Fragment>
+                      <div className="u-gapTop">
+                        <Button
+                          data-test-id={`deleteIdentity${index}Button`}
+                          label="Delete Identity"
+                          icon={<Delete />}
+                          disabled={values.identities.length === 1}
+                          onClick={() => {
+                            arrayHelpers.remove(index);
+                          }}
+                        />
+                        {values.identities.length === 1 ? (
+                          <span className="Note u-gapLeft">
+                            You must have at least one identity to use this
+                            action.
+                          </span>
+                        ) : null}
+                      </div>
+                    </AccordionItem>
+                  ))}
+                </Accordion>
+              </React.Fragment>
+            );
+          }}
+        />
+      </React.Fragment>
+    </div>
   );
 }
 

--- a/src/view/components/namespaceComponent.jsx
+++ b/src/view/components/namespaceComponent.jsx
@@ -1,0 +1,61 @@
+import Select from "@react/react-spectrum/Select";
+import React from "react";
+import Textfield from "@react/react-spectrum/Textfield";
+import PropTypes from "prop-types";
+import WrappedField from "./wrappedField";
+
+const getSelectedNamespace = (options, namespace) => {
+  if (options.length < 1) {
+    return undefined;
+  }
+
+  if (namespace === "") {
+    return "Select an option";
+  }
+
+  const found = options.find(
+    ({ value }) => value.toUpperCase() === namespace.toUpperCase()
+  );
+
+  return found ? found.value : undefined;
+};
+
+function NamespaceComponent({ options, name, index, namespace }) {
+  const selectedNamespace = getSelectedNamespace(options, namespace);
+  return (
+    <div>
+      {selectedNamespace ? (
+        <div>
+          <WrappedField
+            data-test-id={`namespaceSelect${index}Field`}
+            id={`namespace${index}Field`}
+            name={name}
+            component={Select}
+            componentClassName="u-fieldLong"
+            options={options}
+            value={selectedNamespace}
+          />
+        </div>
+      ) : (
+        <div>
+          <WrappedField
+            name={name}
+            data-test-id={`namespace${index}Field`}
+            id={`namespace${index}Field`}
+            component={Textfield}
+            componentClassName="u-fieldLong"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+NamespaceComponent.propTypes = {
+  options: PropTypes.array,
+  namespace: PropTypes.string,
+  index: PropTypes.number,
+  name: PropTypes.string
+};
+
+export default NamespaceComponent;

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -22,13 +22,18 @@ import "./identityMap.styl";
 import { AMBIGUOUS } from "../utils/authenticatedState";
 import fetchNamespaces from "./identityMap/fetchNamespaces";
 
+const isNotECID = namespace => {
+  return namespace.code !== "ECID";
+};
 const identitiesMapToArray = identityMap => {
-  return Object.keys(identityMap).map(namespace => {
-    return {
-      namespace,
-      identifiers: identityMap[namespace]
-    };
-  });
+  return Object.keys(identityMap)
+    .sort((first, second) => first.localeCompare(second))
+    .map(namespace => {
+      return {
+        namespace,
+        identifiers: identityMap[namespace]
+      };
+    });
 };
 
 const identitiesArrayToMap = identitiesArray => {
@@ -49,10 +54,13 @@ const getInitialValues = ({ initInfo }) => {
     imsAccess: initInfo.tokens.imsAccess
   }).then(response => {
     if (response.length > 0) {
-      const namespaces = response.map(namespace => ({
-        value: namespace.code,
-        label: namespace.code
-      }));
+      const namespaces = response
+        .filter(isNotECID)
+        .map(namespace => ({
+          value: namespace.code,
+          label: namespace.code
+        }))
+        .sort((first, second) => first.value.localeCompare(second.value));
 
       return {
         identities,

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -80,7 +80,7 @@ const validateDuplicateValue = (
   message,
   validateBooleanTrue
 ) => {
-  const values = identities.map(identity => identity[key]);
+  const values = identities.map(identity => identity[key].toUpperCase());
   const duplicateIndex = values.findIndex(
     (value, index) =>
       values.indexOf(value) < index && (!validateBooleanTrue || value === true)

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -20,6 +20,7 @@ import IdentityWrapper from "../components/identityWrapper";
 import getDefaultIdentity from "../utils/getDefaultIdentity";
 import "./identityMap.styl";
 import { AMBIGUOUS } from "../utils/authenticatedState";
+import fetchNamespaces from "./identityMap/fetchNamespaces";
 
 const identitiesMapToArray = identityMap => {
   return Object.keys(identityMap).map(namespace => {
@@ -43,9 +44,29 @@ const getInitialValues = ({ initInfo }) => {
     ? identitiesMapToArray(initInfo.settings)
     : [getDefaultIdentity()];
 
-  return {
-    identities
-  };
+  return fetchNamespaces({
+    orgId: initInfo.company.orgId,
+    imsAccess: initInfo.tokens.imsAccess
+  }).then(response => {
+    if (response.length > 0) {
+      const namespaces = response.map(namespace => {
+        return {
+          value: namespace.code,
+          label: namespace.code
+        };
+      });
+
+      return {
+        identities,
+        namespaces
+      };
+    }
+
+    return {
+      identities,
+      namespaces: []
+    };
+  });
 };
 
 const getSettings = ({ values }) => {

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -49,12 +49,10 @@ const getInitialValues = ({ initInfo }) => {
     imsAccess: initInfo.tokens.imsAccess
   }).then(response => {
     if (response.length > 0) {
-      const namespaces = response.map(namespace => {
-        return {
-          value: namespace.code,
-          label: namespace.code
-        };
-      });
+      const namespaces = response.map(namespace => ({
+        value: namespace.code,
+        label: namespace.code
+      }));
 
       return {
         identities,
@@ -105,7 +103,7 @@ const validationSchema = object()
             name: "notECID",
             message: "ECID is not allowed",
             test(value) {
-              return value !== "ECID";
+              return value.toUpperCase() !== "ECID";
             }
           }),
         identifiers: array().of(

--- a/src/view/dataElements/identityMap/fetchNamespaces.js
+++ b/src/view/dataElements/identityMap/fetchNamespaces.js
@@ -16,9 +16,12 @@ import platform from "../xdmObject/helpers/platform";
 export default ({ orgId, imsAccess }) => {
   const headers = getBaseRequestHeaders({ orgId, imsAccess });
 
-  return fetch(`${platform.getHost()}/data/core/idnamespace/identities`, {
-    headers
-  })
+  return fetch(
+    `${platform.getHost({ imsAccess })}/data/core/idnamespace/identities`,
+    {
+      headers
+    }
+  )
     .then(response => {
       if (!response.ok) {
         return [];
@@ -26,5 +29,6 @@ export default ({ orgId, imsAccess }) => {
 
       return response.json();
     })
-    .then(responseBody => responseBody);
+    .then(responseBody => responseBody)
+    .catch(() => []);
 };

--- a/src/view/dataElements/identityMap/fetchNamespaces.js
+++ b/src/view/dataElements/identityMap/fetchNamespaces.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import getBaseRequestHeaders from "../../utils/getBaseRequestHeaders";
+import platform from "../xdmObject/helpers/platform";
+
+export default ({ orgId, imsAccess }) => {
+  const headers = getBaseRequestHeaders({ orgId, imsAccess });
+
+  return fetch(`${platform.getHost()}/data/core/idnamespace/identities`, {
+    headers
+  })
+    .then(response => {
+      if (!response.ok) {
+        return [];
+      }
+
+      return response.json();
+    })
+    .then(responseBody => responseBody);
+};

--- a/test/functional/dataElements/identityMap/identityMap.spec.js
+++ b/test/functional/dataElements/identityMap/identityMap.spec.js
@@ -44,7 +44,7 @@ const addIdentityButton = spectrum.button("addIdentityButton");
 const accordion = spectrum.accordion("identitiesAccordion");
 
 const identities = [];
-for (let i = 0; i < 2; i += 1) {
+for (let i = 0; i < 3; i += 1) {
   const identifiers = [];
   for (let j = 0; j < 2; j += 1) {
     identifiers.push({
@@ -76,7 +76,6 @@ fixture("Identity Map Data Element View")
 test("initializes Identity map with default settings", async () => {
   await initializeExtensionView();
 
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[0].namespace.expectValue("");
   await identities[0].identifiers[0].id.expectValue("");
   await identities[0].identifiers[0].authenticatedState.expectSelectedOptionLabel(
@@ -87,10 +86,10 @@ test("initializes Identity map with default settings", async () => {
   await identities[0].deleteButton.expectDisabled();
 });
 
-test("initializes Identity map with full settings", async () => {
+test("initializes Identity map with sorted namespaces", async () => {
   await initializeExtensionView({
     settings: {
-      CUSTOM_IDENTITY: [
+      S_CUSTOM_IDENTITY: [
         {
           id: "test1",
           authenticatedState: "loggedOut",
@@ -102,7 +101,14 @@ test("initializes Identity map with full settings", async () => {
           primary: true
         }
       ],
-      CUSTOM_IDENTITY2: [
+      W_CUSTOM_IDENTITY2: [
+        {
+          id: "test3",
+          authenticatedState: "authenticated",
+          primary: false
+        }
+      ],
+      B_CUSTOM_IDENTITY2: [
         {
           id: "test3",
           authenticatedState: "authenticated",
@@ -112,34 +118,74 @@ test("initializes Identity map with full settings", async () => {
     }
   });
 
-  await accordion.clickHeader("CUSTOM_IDENTITY");
-  await identities[0].namespace.expectValue("CUSTOM_IDENTITY");
-  await identities[0].identifiers[0].id.expectValue("test1");
+  await accordion.clickHeader("B_CUSTOM_IDENTITY2");
+  await identities[0].namespace.expectValue("B_CUSTOM_IDENTITY2");
+  await identities[0].identifiers[0].id.expectValue("test3");
   await identities[0].identifiers[0].authenticatedState.expectSelectedOptionLabel(
-    "Logged Out"
-  );
-  await identities[0].identifiers[0].primary.expectUnchecked();
-  await identities[0].identifiers[0].deleteButton.expectEnabled();
-
-  await identities[0].identifiers[1].id.expectValue("test2");
-  await identities[0].identifiers[1].authenticatedState.expectSelectedOptionLabel(
-    "Ambiguous"
-  );
-  await identities[0].identifiers[1].primary.expectChecked();
-  await identities[0].identifiers[1].deleteButton.expectEnabled();
-
-  await identities[0].deleteButton.expectEnabled();
-
-  await accordion.clickHeader("CUSTOM_IDENTITY2");
-  await identities[1].namespace.expectValue("CUSTOM_IDENTITY2");
-  await identities[1].identifiers[0].id.expectValue("test3");
-  await identities[1].identifiers[0].authenticatedState.expectSelectedOptionLabel(
     "Authenticated"
   );
+  await identities[0].identifiers[0].primary.expectUnchecked();
+  await identities[0].identifiers[0].deleteButton.expectDisabled();
+  await identities[0].deleteButton.expectEnabled();
+
+  await accordion.clickHeader("S_CUSTOM_IDENTITY");
+  await identities[1].namespace.expectValue("S_CUSTOM_IDENTITY");
+
+  await identities[1].identifiers[0].id.expectValue("test1");
+  await identities[1].identifiers[0].authenticatedState.expectSelectedOptionLabel(
+    "Logged Out"
+  );
   await identities[1].identifiers[0].primary.expectUnchecked();
-  await identities[1].identifiers[0].deleteButton.expectDisabled();
+  await identities[1].identifiers[0].deleteButton.expectEnabled();
+
+  await identities[1].identifiers[1].id.expectValue("test2");
+  await identities[1].identifiers[1].authenticatedState.expectSelectedOptionLabel(
+    "Ambiguous"
+  );
+  await identities[1].identifiers[1].primary.expectChecked();
+  await identities[1].identifiers[1].deleteButton.expectEnabled();
 
   await identities[1].deleteButton.expectEnabled();
+
+  await accordion.clickHeader("W_CUSTOM_IDENTITY2");
+  await identities[2].namespace.expectValue("W_CUSTOM_IDENTITY2");
+  await identities[2].identifiers[0].id.expectValue("test3");
+  await identities[2].identifiers[0].authenticatedState.expectSelectedOptionLabel(
+    "Authenticated"
+  );
+  await identities[2].identifiers[0].primary.expectUnchecked();
+  await identities[2].identifiers[0].deleteButton.expectDisabled();
+  await identities[2].deleteButton.expectEnabled();
+
+  await identityMapViewController.expectIsValid();
+  await identityMapViewController.expectSettings({
+    B_CUSTOM_IDENTITY2: [
+      {
+        id: "test3",
+        authenticatedState: "authenticated",
+        primary: false
+      }
+    ],
+    S_CUSTOM_IDENTITY: [
+      {
+        id: "test1",
+        authenticatedState: "loggedOut",
+        primary: false
+      },
+      {
+        id: "test2",
+        authenticatedState: "ambiguous",
+        primary: true
+      }
+    ],
+    W_CUSTOM_IDENTITY2: [
+      {
+        id: "test3",
+        authenticatedState: "authenticated",
+        primary: false
+      }
+    ]
+  });
 });
 test("adds a new Identity and new Identifier with minimal settings", async () => {
   await initializeExtensionView({
@@ -154,7 +200,6 @@ test("adds a new Identity and new Identifier with minimal settings", async () =>
     }
   });
 
-  await accordion.clickHeader("CUSTOM_IDENTITY");
   await identities[0].namespace.expectValue("CUSTOM_IDENTITY");
   await identities[0].identifiers[0].id.expectValue("test1");
   await identities[0].identifiers[0].authenticatedState.expectSelectedOptionLabel(
@@ -171,7 +216,6 @@ test("adds a new Identity and new Identifier with minimal settings", async () =>
   await identities[0].identifiers[1].primary.click();
 
   await addIdentityButton.click();
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[1].namespace.typeText("CUSTOM_IDENTITY2");
   await identities[1].identifiers[0].id.typeText("test3");
   await identities[1].identifiers[0].authenticatedState.selectOption(
@@ -250,7 +294,6 @@ test("removing Identifier returns the correct settings", async () => {
 test("invalid Identity trigger validation error", async () => {
   await initializeExtensionView();
 
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[0].identifiers[0].id.typeText("test3");
   await identities[0].identifiers[0].authenticatedState.selectOption(
     "Authenticated"
@@ -262,7 +305,6 @@ test("invalid Identity trigger validation error", async () => {
 test("invalid Identifier trigger validation error", async () => {
   await initializeExtensionView();
 
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[0].namespace.typeText("CUSTOM_IDENTITY");
   await identities[0].identifiers[0].authenticatedState.selectOption(
     "Authenticated"
@@ -285,7 +327,6 @@ test("double Identity namespace trigger validation error", async () => {
     }
   });
   await addIdentityButton.click();
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[1].namespace.typeText("CUSTOM_IDENTITY");
   await identities[1].identifiers[0].id.typeText("test3");
   await identities[1].identifiers[0].authenticatedState.selectOption(
@@ -303,7 +344,6 @@ test("initialization of namespaces as dropdown with values", async () => {
 
   await initializeExtensionView();
 
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[0].namespaceSelect.selectOption("AAID");
   await identities[0].identifiers[0].id.typeText("test3");
 
@@ -326,6 +366,5 @@ test("when namespaces call fails instantiate form with textfield", async () => {
 
   await initializeExtensionView();
 
-  await accordion.clickHeader("UNNAMED IDENTITY");
   await identities[0].namespace.expectValue("");
 });

--- a/test/functional/dataElements/xdmObject/helpers/platformMocks.js
+++ b/test/functional/dataElements/xdmObject/helpers/platformMocks.js
@@ -72,8 +72,62 @@ const schemasMeta = RequestMock()
     { "Access-Control-Allow-Origin": "*" }
   );
 
+const namespaces = RequestMock()
+  .onRequestTo("https://platform.adobe.io/data/core/idnamespace/identities")
+  .respond(
+    [
+      {
+        updateTime: 1551688425455,
+        code: "CORE",
+        status: "ACTIVE",
+        description: "Adobe Audience Manger UUID"
+      },
+      {
+        updateTime: 1551688425455,
+        code: "AAID",
+        status: "ACTIVE",
+        description: "Adobe Analytics (Legacy ID)",
+        id: 10
+      },
+      {
+        updateTime: 1551688425455,
+        code: "ECID",
+        status: "ACTIVE",
+        description: "Adobe Experience Cloud ID",
+        id: 4
+      },
+      {
+        updateTime: 1551688425455,
+        code: "Email",
+        status: "ACTIVE",
+        description: "Email",
+        id: 6
+      },
+      {
+        updateTime: 1551688425455,
+        code: "WAID",
+        status: "ACTIVE",
+        description: "Windows AID",
+        id: 8
+      }
+    ],
+    200,
+    { "Access-Control-Allow-Origin": "*" }
+  );
+
+const namespacesEmpty = RequestMock()
+  .onRequestTo("https://platform.adobe.io/data/core/idnamespace/identities")
+  .respond([], 200, { "Access-Control-Allow-Origin": "*" });
+
+const namespacesError = RequestMock()
+  .onRequestTo("https://platform.adobe.io/data/core/idnamespace/identities")
+  .respond({}, 403, { "Access-Control-Allow-Origin": "*" });
+
 export default {
   sandboxes,
   sandboxesEmpty,
-  schemasMeta
+  schemasMeta,
+  namespaces,
+  namespacesError,
+  namespacesEmpty
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Now for the Identity Map data element, the user should enter the namespace code manually.
We should fetch namespaces from the platform and expose them in a dropdown. If there are no namespaces or the call failed we should allow the user to enter namespace code manually.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
