### PR TITLE
CORE-48374 include the extension version in implementationDetails

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,10 @@
 {
-  "plugins": ["@babel/plugin-proposal-class-properties"],
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    ["version", {
+      "define": "__EXTENSION_VERSION__"
+    }]
+  ],
   "presets": [["@babel/preset-env"]],
   "env": {
     "production": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2797,6 +2797,12 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-plugin-version": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/babel-plugin-version/-/babel-plugin-version-0.2.3.tgz",
+      "integrity": "sha1-xPxti3FaZjvohQ/edO1poE433ik=",
+      "dev": true
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-eslint": "^10.0.1",
     "babel-plugin-jsx-remove-data-test-id": "^2.1.3",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+    "babel-plugin-version": "^0.2.3",
     "chalk": "^3.0.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Alloy PR: https://github.com/adobe/alloy/pull/592 adds an \_\_EXTENSION_VERSION\_\_ key to the reactor version of alloy.js. This PR replaces that with the extension version in package.json when the extension is built.
<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/CORE-48374
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

We want to know what version of the extension is being used to collect experience events.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
