### PR TITLE
Add a data element option for the default consent

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -50,8 +50,16 @@
                 "minLength": 1
               },
               "defaultConsent": {
-                "type": "string",
-                "enum": ["in", "pending"]
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^%[^%]+%$"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["in", "pending"]
+                  }
+                ]
               },
               "idMigrationEnabled": {
                 "type": "boolean"

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -33,7 +33,9 @@ import getInstanceOptions from "../utils/getInstanceOptions";
 import singleDataElementRegex from "../constants/singleDataElementRegex";
 import "./setConsent.styl";
 import InfoTipLayout from "../components/infoTipLayout";
-import OptionsWithDataElement from "../components/optionsWithDataElement";
+import OptionsWithDataElement, {
+  DATA_ELEMENT as DATA_ELEMENT_OPTION
+} from "../components/optionsWithDataElement";
 
 const IN = { value: "in", label: "In" };
 const OUT = { value: "out", label: "Out" };
@@ -110,7 +112,7 @@ const applyInitialValuesForOptionsWithDataElement = (
   options
 ) => {
   if (singleDataElementRegex.test(value)) {
-    formikValues.radio = DATA_ELEMENT.value;
+    formikValues.radio = DATA_ELEMENT_OPTION;
     formikValues.dataElement = value;
   } else if (options.includes(value)) {
     formikValues.radio = value;
@@ -192,7 +194,7 @@ const getInitialValues = ({ initInfo }) => {
 };
 
 const getSettingsForOptionsWithDataElement = value => {
-  if (value.radio === DATA_ELEMENT.value) {
+  if (value.radio === DATA_ELEMENT_OPTION) {
     return value.dataElement;
   }
   return value.radio;
@@ -284,7 +286,7 @@ const validationSchema = object().shape({
           is: ADOBE.value,
           then: object().shape({
             dataElement: mixed().when("radio", {
-              is: DATA_ELEMENT.value,
+              is: DATA_ELEMENT_OPTION,
               then: string().matches(singleDataElementRegex, invalidDataMessage)
             })
           })
@@ -298,7 +300,7 @@ const validationSchema = object().shape({
           then: object().shape({
             radio: string().required(),
             dataElement: mixed().when("radio", {
-              is: DATA_ELEMENT.value,
+              is: DATA_ELEMENT_OPTION,
               then: string().matches(singleDataElementRegex, invalidDataMessage)
             })
           })
@@ -308,7 +310,7 @@ const validationSchema = object().shape({
           then: object().shape({
             radio: string().required(),
             dataElement: mixed().when("radio", {
-              is: DATA_ELEMENT.value,
+              is: DATA_ELEMENT_OPTION,
               then: string().matches(singleDataElementRegex, invalidDataMessage)
             })
           })

--- a/src/view/components/optionsWithDataElement.jsx
+++ b/src/view/components/optionsWithDataElement.jsx
@@ -19,6 +19,8 @@ import FieldLabel from "@react/react-spectrum/FieldLabel";
 import InfoTipLayout from "./infoTipLayout";
 import WrappedField from "./wrappedField";
 
+export const DATA_ELEMENT = "dataElement";
+
 const OptionsWithDataElement = ({
   label,
   infoTip,
@@ -55,12 +57,12 @@ const OptionsWithDataElement = ({
         )}
         <Radio
           data-test-id={`${dataTestId}DataElementRadio`}
-          value="dataElement"
+          value={DATA_ELEMENT}
           label="Provided by data element"
         />
       </WrappedField>
 
-      {values && values.radio === "dataElement" && (
+      {values && values.radio === DATA_ELEMENT && (
         <div>
           <WrappedField
             id={`${id}DataElement`}

--- a/src/view/components/optionsWithDataElement.jsx
+++ b/src/view/components/optionsWithDataElement.jsx
@@ -39,14 +39,20 @@ const OptionsWithDataElement = ({
         component={RadioGroup}
         componentClassName="u-flexColumn"
       >
-        {options.map(({ value: optionValue, label: optionLabel }) => (
-          <Radio
-            key={optionValue}
-            data-test-id={`${dataTestId}${optionLabel}Radio`}
-            value={optionValue}
-            label={optionLabel}
-          />
-        ))}
+        {options.map(
+          ({
+            value: optionValue,
+            label: optionLabel,
+            testId: optionTestId
+          }) => (
+            <Radio
+              key={optionValue}
+              data-test-id={`${dataTestId}${optionTestId || optionLabel}Radio`}
+              value={optionValue}
+              label={optionLabel}
+            />
+          )
+        )}
         <Radio
           data-test-id={`${dataTestId}DataElementRadio`}
           value="dataElement"

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -45,7 +45,9 @@ import fetchEnvironments from "./utils/fetchEnvironments";
 import prehidingSnippet from "./constants/prehidingSnippet";
 import "./configuration.styl";
 import EnvironmentSelector from "../components/environmentSelector";
-import OptionsWithDataElement from "../components/optionsWithDataElement";
+import OptionsWithDataElement, {
+  DATA_ELEMENT
+} from "../components/optionsWithDataElement";
 import singleDataElementRegex from "../constants/singleDataElementRegex";
 
 const edgeConfigInputMethods = {
@@ -150,7 +152,7 @@ const getInitialValues = ({ initInfo, setConfigs, setEnvironments }) => {
           }
           if (singleDataElementRegex.test(instance.defaultConsent)) {
             instance.defaultConsent = {
-              radio: "dataElement",
+              radio: DATA_ELEMENT,
               dataElement: instance.defaultConsent
             };
           } else {
@@ -231,7 +233,7 @@ const getSettings = ({ values, initInfo }) => {
         copyPropertyKeys
       );
 
-      if (instance.defaultConsent.radio === "dataElement") {
+      if (instance.defaultConsent.radio === DATA_ELEMENT) {
         trimmedInstance.defaultConsent = instance.defaultConsent.dataElement;
       } else if (instance.defaultConsent.radio === consentLevels.PENDING) {
         trimmedInstance.defaultConsent = consentLevels.PENDING;
@@ -749,12 +751,12 @@ const Configuration = ({
                             {
                               value: consentLevels.PENDING,
                               label:
-                                "Pending - Queue privacy-sensitive work unti lthe user gives consent.",
+                                "Pending - Queue privacy-sensitive work until the user provides consent preferences.",
                               testId: "Pending"
                             }
                           ]}
                           label="Default Consent Level"
-                          infoTip="The consent level to be used if the user has not previously provided consent."
+                          infoTip="The consent level to be used if the user has not previously provided consent preferences."
                           id="generalDefaultConsent"
                           data-test-id="defaultConsent"
                           name={`instances.${index}.defaultConsent`}

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -57,8 +57,10 @@ for (let i = 0; i < 2; i += 1) {
     edgeBasePathField: spectrum.textfield("edgeBasePathField"),
     edgeBasePathRestoreButton: spectrum.button("edgeBasePathRestoreButton"),
     defaultConsent: {
-      inField: spectrum.radio("defaultConsentInField"),
-      pendingField: spectrum.radio("defaultConsentOutField")
+      inRadio: spectrum.radio("defaultConsentInRadio"),
+      pendingRadio: spectrum.radio("defaultConsentPendingRadio"),
+      dataElementRadio: spectrum.radio("defaultConsentDataElementRadio"),
+      dataElementField: spectrum.textfield("defaultConsentDataElementField")
     },
     idMigrationEnabled: spectrum.checkbox("idMigrationEnabledField"),
     thirdPartyCookiesEnabled: spectrum.checkbox(
@@ -141,7 +143,7 @@ test("initializes form fields with full settings", async () => {
             edgeConfigId: "PR456",
             stagingEdgeConfigId: "PR456:stage",
             developmentEdgeConfigId: "PR456:dev3",
-            defaultConsent: "in",
+            defaultConsent: "%dataelement123%",
             idMigrationEnabled: false,
             thirdPartyCookiesEnabled: false,
             context: []
@@ -179,8 +181,10 @@ test("initializes form fields with full settings", async () => {
   await instances[0].orgIdField.expectValue("ORG456@OtherCompanyOrg");
   await instances[0].edgeDomainField.expectValue("testedge.com");
   await instances[0].edgeBasePathField.expectValue("ee-beta");
-  await instances[0].defaultConsent.inField.expectUnchecked();
-  await instances[0].defaultConsent.pendingField.expectChecked();
+  await instances[0].defaultConsent.inRadio.expectUnchecked();
+  await instances[0].defaultConsent.pendingRadio.expectChecked();
+  await instances[0].defaultConsent.dataElementRadio.expectUnchecked();
+  await instances[0].defaultConsent.dataElementField.expectNotExists();
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
   await instances[0].clickCollectionEnabledField.expectUnchecked();
@@ -213,8 +217,12 @@ test("initializes form fields with full settings", async () => {
   await instances[1].orgIdField.expectValue("ABC123@AdobeOrg");
   await instances[1].edgeDomainField.expectValue(defaultEdgeDomain);
   await instances[1].edgeBasePathField.expectValue(defaultEdgeBasePath);
-  await instances[1].defaultConsent.inField.expectChecked();
-  await instances[1].defaultConsent.pendingField.expectUnchecked();
+  await instances[1].defaultConsent.inRadio.expectUnchecked();
+  await instances[1].defaultConsent.pendingRadio.expectUnchecked();
+  await instances[1].defaultConsent.dataElementRadio.expectChecked();
+  await instances[1].defaultConsent.dataElementField.expectValue(
+    "%dataelement123%"
+  );
   await instances[1].idMigrationEnabled.expectUnchecked();
   await instances[1].thirdPartyCookiesEnabled.expectUnchecked();
   await instances[1].clickCollectionEnabledField.expectChecked();
@@ -249,8 +257,10 @@ test("initializes form fields with minimal settings", async () => {
   await instances[0].orgIdField.expectValue("ABC123@AdobeOrg");
   await instances[0].edgeDomainField.expectValue(defaultEdgeDomain);
   await instances[0].edgeBasePathField.expectValue(defaultEdgeBasePath);
-  await instances[0].defaultConsent.inField.expectChecked();
-  await instances[0].defaultConsent.pendingField.expectUnchecked();
+  await instances[0].defaultConsent.inRadio.expectChecked();
+  await instances[0].defaultConsent.pendingRadio.expectUnchecked();
+  await instances[0].defaultConsent.dataElementRadio.expectUnchecked();
+  await instances[0].defaultConsent.dataElementField.expectNotExists();
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
   await instances[0].clickCollectionEnabledField.expectChecked();
@@ -282,8 +292,10 @@ test("initializes form fields with no settings", async () => {
   await instances[0].orgIdField.expectValue("ABC123@AdobeOrg");
   await instances[0].edgeDomainField.expectValue(defaultEdgeDomain);
   await instances[0].edgeBasePathField.expectValue(defaultEdgeBasePath);
-  await instances[0].defaultConsent.inField.expectChecked();
-  await instances[0].defaultConsent.pendingField.expectUnchecked();
+  await instances[0].defaultConsent.inRadio.expectChecked();
+  await instances[0].defaultConsent.pendingRadio.expectUnchecked();
+  await instances[0].defaultConsent.dataElementRadio.expectUnchecked();
+  await instances[0].defaultConsent.dataElementField.expectNotExists();
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
   await instances[0].clickCollectionEnabledField.expectChecked();
@@ -327,7 +339,7 @@ test("returns full valid settings", async () => {
   await instances[0].developmentEnvironment.manualField.typeText("PR123:dev1");
   await instances[0].edgeDomainField.typeText("2");
   await instances[0].edgeBasePathField.typeText("-alpha");
-  await instances[0].defaultConsent.pendingField.click();
+  await instances[0].defaultConsent.pendingRadio.click();
   await instances[0].idMigrationEnabled.click();
   await instances[0].thirdPartyCookiesEnabled.click();
   await instances[0].prehidingStyleEditorButton.click();
@@ -338,7 +350,10 @@ test("returns full valid settings", async () => {
   await instances[1].stagingEnvironment.manualField.typeText("PR456:stage");
   await instances[1].developmentEnvironment.manualField.typeText("PR456:dev1");
   await instances[1].orgIdField.typeText("2");
-  await instances[1].defaultConsent.pendingField.click();
+  await instances[1].defaultConsent.dataElementRadio.click();
+  await instances[1].defaultConsent.dataElementField.typeText(
+    "%dataelement123%"
+  );
   await instances[1].idMigrationEnabled.click();
   await instances[1].thirdPartyCookiesEnabled.click();
   await instances[1].onBeforeEventSendEditorButton.click();
@@ -368,7 +383,7 @@ test("returns full valid settings", async () => {
         stagingEdgeConfigId: "PR456:stage",
         developmentEdgeConfigId: "PR456:dev1",
         orgId: "ABC123@AdobeOrg2",
-        defaultConsent: "pending",
+        defaultConsent: "%dataelement123%",
         idMigrationEnabled: false,
         thirdPartyCookiesEnabled: false,
         onBeforeEventSend:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a data element option for the default consent configuration option.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-52502
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

In some consent use cases, the Launch library is loaded after the CMP is loaded. When the CMP loads, it can determine which region a user is in and thus determine what the default consent should be.  By making this configurable through a data element, this workflow can be possible.

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
