### PR TITLE
CORE-53044 Clone XDM data before calling sendEvent.

### DIFF
--- a/src/lib/actions/sendEvent/createSendEvent.js
+++ b/src/lib/actions/sendEvent/createSendEvent.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const clone = require("../../utils/clone");
+
 module.exports = ({
   instanceManager,
   decisionsCallbackStorage
@@ -21,6 +23,14 @@ module.exports = ({
     throw new Error(
       `Failed to send event for instance "${instanceName}". No matching instance was configured with this name.`
     );
+  }
+
+  // If the customer modifies the xdm object (or anything nested in the object) after this action runs, we want to
+  // make sure those modifications are not reflected in the data sent to the server. By cloning the object here,
+  // we ensure we use a snapshot that will remain unchanged during the time period between when sendEvent
+  // is called and the network request is made.
+  if (otherSettings.xdm) {
+    otherSettings.xdm = clone(otherSettings.xdm);
   }
 
   return instance("sendEvent", otherSettings).then(result => {

--- a/src/lib/utils/clone.js
+++ b/src/lib/utils/clone.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Clones a value by serializing then deserializing the value.
+ * @param {*} value
+ * @returns {any}
+ */
+export default value => JSON.parse(JSON.stringify(value));

--- a/test/unit/lib/actions/sendEvent/createSendEvent.spec.js
+++ b/test/unit/lib/actions/sendEvent/createSendEvent.spec.js
@@ -29,21 +29,44 @@ describe("Send Event", () => {
       instanceManager,
       decisionsCallbackStorage
     });
+    const dataLayer = {
+      fruits: [
+        {
+          name: "banana",
+          calories: 105
+        },
+        {
+          name: "blueberry",
+          calories: 5
+        }
+      ]
+    };
     const promiseReturnedFromAction = action({
       instanceName: "myinstance",
       renderDecisions: true,
-      xdm: {
-        foo: "bar"
-      }
+      xdm: dataLayer
     });
 
     expect(instanceManager.getInstance).toHaveBeenCalledWith("myinstance");
     expect(instance).toHaveBeenCalledWith("sendEvent", {
       renderDecisions: true,
       xdm: {
-        foo: "bar"
+        fruits: [
+          {
+            name: "banana",
+            calories: 105
+          },
+          {
+            name: "blueberry",
+            calories: 5
+          }
+        ]
       }
     });
+    // Ensure the XDM object was cloned
+    const xdmOption = instance.calls.argsFor(0)[1].xdm;
+    expect(xdmOption).not.toBe(dataLayer);
+    expect(xdmOption.fruits[0]).not.toBe(dataLayer.fruits[0]);
 
     return promiseReturnedFromAction.then(() => {
       expect(decisionsCallbackStorage.triggerEvent).toHaveBeenCalledWith({

--- a/test/unit/lib/utils/clone.spec.js
+++ b/test/unit/lib/utils/clone.spec.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import clone from "../../../../src/lib/utils/clone";
+
+describe("clone", () => {
+  it("clones the object using JSON serialization/deserialization", () => {
+    const obj = {
+      toJSON() {
+        return { foo: "bar" };
+      }
+    };
+
+    const result = clone(obj);
+
+    expect(result).toEqual({
+      foo: "bar"
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Clone XDM data before calling sendEvent.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-53044
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We want to avoid the issue where a customer sends an XDM object into the sendEvent command and then modifies that XDM object before it gets sent to the server, resulting in the modifications being included in the XDM object that gets sent in the network request.

To help prevent this from happening for Launch users, we clone the data before executing the sendEvent command.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation. **(I'm going to work on adding something to the docs explaining the situation in both standalone and Launch worlds.)**
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
