### PR TITLE
CORE-53086 - fix the only one primary identity validation test

### DIFF
--- a/test/functional/dataElements/identityMap/identityMap.spec.js
+++ b/test/functional/dataElements/identityMap/identityMap.spec.js
@@ -377,16 +377,18 @@ test("multiple primary identifiers trigger validation error", async () => {
           id: "123",
           authenticatedState: "authenticated",
           primary: true
-        },
-        {
-          id: "12w3",
-          authenticatedState: "authenticated",
-          primary: true
         }
       ]
     }
   });
+  await addIdentityButton.click();
+  await identities[1].namespace.typeText("CUSTOM_IDENTITY2");
+  await identities[1].identifiers[0].id.typeText("test3");
+  await identities[1].identifiers[0].authenticatedState.selectOption(
+    "Authenticated"
+  );
+  await identities[1].identifiers[0].primary.click();
 
   await identityMapViewController.expectIsNotValid();
-  await identities[0].identifiers[1].primary.expectError();
+  await identities[1].identifiers[0].primary.expectError();
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixed the "Identity Map functional test that checks the identity map for only one primary identity".
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
