### PR TITLE
Fix export of clone utility.

### DIFF
--- a/src/lib/utils/clone.js
+++ b/src/lib/utils/clone.js
@@ -15,4 +15,4 @@ governing permissions and limitations under the License.
  * @param {*} value
  * @returns {any}
  */
-export default value => JSON.parse(JSON.stringify(value));
+module.exports = value => JSON.parse(JSON.stringify(value));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We're using ES5 to import modules so we have to use ES5 to export the modules (you don't _have_ to, but the process to import the module is a little more involved). In this case, I did an ES6 `export default`, resulting an error being thrown at runtime. This PR switches it to an ES5 export. I've logged a separate issue to add a lint rule so we can catch this type of thing earlier: https://jira.corp.adobe.com/browse/CORE-54412
<!--- Describe your changes in detail -->

## Related Issue
It doesn't resolve this issue, but it is related: https://jira.corp.adobe.com/browse/CORE-54412
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The send event action was throwing an error.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
