### PR TITLE
CORE-54412: Adds eslint rule to disable default exports

### DIFF
--- a/src/lib/.eslintrc.js
+++ b/src/lib/.eslintrc.js
@@ -1,7 +1,10 @@
 module.exports = {
   rules: {
     "no-var": "off",
-    "func-names": "off"
+    "func-names": "off""
+    "func-names": "off",
+    "import/no-default-export": 2,
+    "import/no-named-export": 2
   },
   globals: {
     turbine: "readonly"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We would like to prevent using default exports in js,jsx files in src/lib. This will ensure better es5 compatibility with launch

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
