### PR TITLE
Add support for setting Adobe 2.0 consent.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -223,6 +223,14 @@
                     {
                       "type": "object",
                       "properties": {
+                        "standard": { "type": "string", "enum": ["Adobe"] },
+                        "version": { "type": "string" },
+                        "value": { "type": "string", "pattern": "^%[^%]+%$" }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
                         "standard": { "type": "string", "enum": ["IAB TCF"] },
                         "version": { "type": "string" },
                         "value": { "type": "string" },

--- a/src/lib/.eslintrc.js
+++ b/src/lib/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   rules: {
     "no-var": "off",
     "func-names": "off",
-    "func-names": "off",
     "import/no-default-export": 2,
     "import/no-named-export": 2
   },

--- a/src/lib/.eslintrc.js
+++ b/src/lib/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   rules: {
     "no-var": "off",
-    "func-names": "off""
+    "func-names": "off",
     "func-names": "off",
     "import/no-default-export": 2,
     "import/no-named-export": 2

--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -42,12 +42,13 @@ const inputMethodDataElementRadio = spectrum.radio(
 const addConsentButton = spectrum.button("addConsentButton");
 const instances = [];
 
-for (let i = 0; i < 2; i += 1) {
+for (let i = 0; i < 3; i += 1) {
   const container = spectrum.container(`instance${i}`);
   instances.push({
     container,
     standardSelect: container.select("standardSelect"),
     versionField: container.textfield("versionField"),
+    valueField: container.textfield("valueField"),
     ...generateOptionsWithDataElement(container, "general", ["In", "Out"]),
     iabValueField: container.textfield("iabValueField"),
     ...generateOptionsWithDataElement(container, "gdprApplies", ["Yes", "No"]),
@@ -93,7 +94,8 @@ test("initializes form fields with settings containing a static consent array", 
           value: "1234abcd",
           gdprApplies: false,
           gdprContainsPersonalData: true
-        }
+        },
+        { standard: "Adobe", version: "2.0", value: "%dataelement2%" }
       ]
     }
   });
@@ -110,6 +112,7 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[0].generalOutRadio.expectChecked();
   await instances[0].generalDataElementRadio.expectUnchecked();
   await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].valueField.expectNotExists();
   await instances[0].iabValueField.expectNotExists();
   await instances[0].gdprAppliesYesRadio.expectNotExists();
   await instances[0].gdprAppliesNoRadio.expectNotExists();
@@ -126,6 +129,7 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[1].generalOutRadio.expectNotExists();
   await instances[1].generalDataElementRadio.expectNotExists();
   await instances[1].generalDataElementField.expectNotExists();
+  await instances[1].valueField.expectNotExists();
   await instances[1].iabValueField.expectValue("1234abcd");
   await instances[1].gdprAppliesYesRadio.expectUnchecked();
   await instances[1].gdprAppliesNoRadio.expectChecked();
@@ -135,9 +139,26 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[1].gdprContainsPersonalDataNoRadio.expectUnchecked();
   await instances[1].gdprContainsPersonalDataDataElementRadio.expectUnchecked();
   await instances[1].gdprContainsPersonalDataDataElementField.expectNotExists();
+
+  await instances[2].standardSelect.expectValue("adobe");
+  await instances[2].versionField.expectValue("2.0");
+  await instances[2].generalInRadio.expectNotExists();
+  await instances[2].generalOutRadio.expectNotExists();
+  await instances[2].generalDataElementRadio.expectNotExists();
+  await instances[2].generalDataElementField.expectNotExists();
+  await instances[2].valueField.expectValue("%dataelement2%");
+  await instances[2].iabValueField.expectNotExists();
+  await instances[2].gdprAppliesYesRadio.expectNotExists();
+  await instances[2].gdprAppliesNoRadio.expectNotExists();
+  await instances[2].gdprAppliesDataElementRadio.expectNotExists();
+  await instances[2].gdprAppliesDataElementField.expectNotExists();
+  await instances[2].gdprContainsPersonalDataYesRadio.expectNotExists();
+  await instances[2].gdprContainsPersonalDataNoRadio.expectNotExists();
+  await instances[2].gdprContainsPersonalDataDataElementRadio.expectNotExists();
+  await instances[2].gdprContainsPersonalDataDataElementField.expectNotExists();
 });
 
-test("initializes form fields with settings containing many data elements for parts", async () => {
+test("initializes form fields with settings containing data elements for parts", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings,
     settings: {
@@ -168,6 +189,7 @@ test("initializes form fields with settings containing many data elements for pa
   await instances[0].generalOutRadio.expectUnchecked();
   await instances[0].generalDataElementRadio.expectChecked();
   await instances[0].generalDataElementField.expectValue("%data1%");
+  await instances[0].valueField.expectNotExists();
   await instances[0].iabValueField.expectNotExists();
   await instances[0].gdprAppliesYesRadio.expectNotExists();
   await instances[0].gdprAppliesNoRadio.expectNotExists();
@@ -184,6 +206,7 @@ test("initializes form fields with settings containing many data elements for pa
   await instances[1].generalOutRadio.expectNotExists();
   await instances[1].generalDataElementRadio.expectNotExists();
   await instances[1].generalDataElementField.expectNotExists();
+  await instances[0].valueField.expectNotExists();
   await instances[1].iabValueField.expectValue("%data2%");
   await instances[1].gdprAppliesYesRadio.expectUnchecked();
   await instances[1].gdprAppliesNoRadio.expectUnchecked();
@@ -228,10 +251,11 @@ test("initializes form fields with no settings", async () => {
 
   await instances[0].standardSelect.expectValue("adobe");
   await instances[0].versionField.expectValue("");
-  await instances[0].generalInRadio.expectChecked();
-  await instances[0].generalOutRadio.expectUnchecked();
-  await instances[0].generalDataElementRadio.expectUnchecked();
+  await instances[0].generalInRadio.expectNotExists();
+  await instances[0].generalOutRadio.expectNotExists();
+  await instances[0].generalDataElementRadio.expectNotExists();
   await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].valueField.expectValue("");
   await instances[0].iabValueField.expectNotExists();
   await instances[0].gdprAppliesYesRadio.expectNotExists();
   await instances[0].gdprAppliesNoRadio.expectNotExists();
@@ -243,14 +267,23 @@ test("initializes form fields with no settings", async () => {
   await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
   await instances[1].container.expectNotExists();
 
+  await instances[0].versionField.typeText("1.0");
+
+  await instances[0].generalInRadio.expectChecked();
+  await instances[0].generalOutRadio.expectUnchecked();
+  await instances[0].generalDataElementRadio.expectUnchecked();
+  await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].valueField.expectNotExists("");
+
   await instances[0].standardSelect.selectOption("IAB TCF");
 
   await instances[0].standardSelect.expectValue("iab_tcf");
-  await instances[0].versionField.expectValue("");
+  await instances[0].versionField.expectValue("1.0");
   await instances[0].generalInRadio.expectNotExists();
   await instances[0].generalOutRadio.expectNotExists();
   await instances[0].generalDataElementRadio.expectNotExists();
   await instances[0].generalDataElementField.expectNotExists();
+  await instances[0].valueField.expectNotExists();
   await instances[0].iabValueField.expectValue("");
   await instances[0].gdprAppliesYesRadio.expectChecked();
   await instances[0].gdprAppliesNoRadio.expectUnchecked();
@@ -267,11 +300,14 @@ test("returns minimal valid settings", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1.1");
+  await instances[0].versionField.typeText("1.0");
   await addConsentButton.click();
   await instances[1].standardSelect.selectOption("IAB TCF");
   await instances[1].versionField.typeText("2.1");
   await instances[1].iabValueField.typeText("1234abcd");
+  await addConsentButton.click();
+  await instances[2].versionField.typeText("2.1");
+  await instances[2].valueField.typeText("%dataelement2%");
 
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
@@ -279,7 +315,7 @@ test("returns minimal valid settings", async () => {
     consent: [
       {
         standard: "Adobe",
-        version: "1.1",
+        version: "1.0",
         value: { general: "in" }
       },
       {
@@ -288,6 +324,11 @@ test("returns minimal valid settings", async () => {
         value: "1234abcd",
         gdprApplies: true,
         gdprContainsPersonalData: false
+      },
+      {
+        standard: "Adobe",
+        version: "2.1",
+        value: "%dataelement2%"
       }
     ]
   });
@@ -305,7 +346,7 @@ test("returns full valid settings", async () => {
   await instances[0].gdprAppliesNoRadio.click();
   await instances[0].gdprContainsPersonalDataYesRadio.click();
   await addConsentButton.click();
-  await instances[1].versionField.typeText("1.2");
+  await instances[1].versionField.typeText("1.0");
   await instances[1].generalOutRadio.click();
 
   await extensionViewController.expectIsValid();
@@ -322,7 +363,7 @@ test("returns full valid settings", async () => {
       },
       {
         standard: "Adobe",
-        version: "1.2",
+        version: "1.0",
         value: { general: "out" }
       }
     ]
@@ -333,7 +374,7 @@ test("returns valid setting for guided form data elements", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1.3");
+  await instances[0].versionField.typeText("1.0");
   await instances[0].generalDataElementRadio.click();
   await instances[0].generalDataElementField.typeText("%data1%");
   await addConsentButton.click();
@@ -353,7 +394,7 @@ test("returns valid setting for guided form data elements", async () => {
     consent: [
       {
         standard: "Adobe",
-        version: "1.3",
+        version: "1.0",
         value: { general: "%data1%" }
       },
       {
@@ -404,26 +445,29 @@ test("shows errors for empty values", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].generalDataElementRadio.click();
   await addConsentButton.click();
   await instances[1].standardSelect.selectOption("IAB TCF");
   await instances[1].gdprAppliesDataElementRadio.click();
   await instances[1].gdprContainsPersonalDataDataElementRadio.click();
+  await addConsentButton.click();
+  await instances[2].versionField.typeText("1.0");
+  await instances[2].generalDataElementRadio.click();
 
   await extensionViewController.expectIsNotValid();
   await instances[0].versionField.expectError();
-  await instances[0].generalDataElementField.expectError();
+  await instances[0].valueField.expectError();
   await instances[1].versionField.expectError();
   await instances[1].iabValueField.expectError();
   await instances[1].gdprAppliesDataElementField.expectError();
   await instances[1].gdprContainsPersonalDataDataElementField.expectError();
+  await instances[2].generalDataElementField.expectError();
 });
 
 test("shows errors for things that aren't data elements and does not show errors for hidden invalid fields", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1");
+  await instances[0].versionField.typeText("1.0");
   await instances[0].generalDataElementRadio.click();
   await instances[0].generalDataElementField.typeText("notadataelement");
   await addConsentButton.click();
@@ -436,12 +480,16 @@ test("shows errors for things that aren't data elements and does not show errors
   await instances[1].gdprContainsPersonalDataDataElementField.typeText(
     "%notadataelement"
   );
+  await addConsentButton.click();
+  await instances[2].versionField.typeText("2.0");
+  await instances[2].valueField.typeText("notadataelement");
 
   await extensionViewController.expectIsNotValid();
   await instances[0].generalDataElementField.expectError();
   await instances[1].iabValueField.expectNoError();
   await instances[1].gdprAppliesDataElementField.expectError();
   await instances[1].gdprContainsPersonalDataDataElementField.expectError();
+  await instances[2].valueField.expectError();
 
   await inputMethodDataElementRadio.click();
   await dataElementField.typeText("%dataelement%");
@@ -455,6 +503,7 @@ test("shows errors for things that aren't data elements and does not show errors
   await instances[0].generalInRadio.click();
   await instances[1].gdprAppliesYesRadio.click();
   await instances[1].gdprContainsPersonalDataYesRadio.click();
+  await instances[2].valueField.typeText("%dataelement%", { replace: true });
   await extensionViewController.expectIsValid();
 });
 

--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -47,7 +47,8 @@ for (let i = 0; i < 3; i += 1) {
   instances.push({
     container,
     standardSelect: container.select("standardSelect"),
-    versionField: container.textfield("versionField"),
+    adobeVersionSelect: container.select("adobeVersionSelect"),
+    iabVersionField: container.textfield("iabVersionField"),
     valueField: container.textfield("valueField"),
     ...generateOptionsWithDataElement(container, "general", ["In", "Out"]),
     iabValueField: container.textfield("iabValueField"),
@@ -76,7 +77,7 @@ const mockExtensionSettings = {
 
 // disablePageReloads is not a publicized feature, but it sure helps speed up tests.
 // https://github.com/DevExpress/testcafe/issues/1770
-fixture("Set Consent View").disablePageReloads.page(
+fixture.only("Set Consent View").disablePageReloads.page(
   "http://localhost:3000/viewSandbox.html"
 );
 
@@ -107,12 +108,13 @@ test("initializes form fields with settings containing a static consent array", 
   await addConsentButton.expectExists();
 
   await instances[0].standardSelect.expectValue("adobe");
-  await instances[0].versionField.expectValue("1.0");
+  await instances[0].adobeVersionSelect.expectValue("1.0");
   await instances[0].generalInRadio.expectUnchecked();
   await instances[0].generalOutRadio.expectChecked();
   await instances[0].generalDataElementRadio.expectUnchecked();
   await instances[0].generalDataElementField.expectNotExists();
   await instances[0].valueField.expectNotExists();
+  await instances[0].iabVersionField.expectNotExists();
   await instances[0].iabValueField.expectNotExists();
   await instances[0].gdprAppliesYesRadio.expectNotExists();
   await instances[0].gdprAppliesNoRadio.expectNotExists();
@@ -124,12 +126,13 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
 
   await instances[1].standardSelect.expectValue("iab_tcf");
-  await instances[1].versionField.expectValue("2.0");
+  await instances[1].adobeVersionSelect.expectNotExists();
   await instances[1].generalInRadio.expectNotExists();
   await instances[1].generalOutRadio.expectNotExists();
   await instances[1].generalDataElementRadio.expectNotExists();
   await instances[1].generalDataElementField.expectNotExists();
   await instances[1].valueField.expectNotExists();
+  await instances[1].iabVersionField.expectValue("2.0");
   await instances[1].iabValueField.expectValue("1234abcd");
   await instances[1].gdprAppliesYesRadio.expectUnchecked();
   await instances[1].gdprAppliesNoRadio.expectChecked();
@@ -141,12 +144,13 @@ test("initializes form fields with settings containing a static consent array", 
   await instances[1].gdprContainsPersonalDataDataElementField.expectNotExists();
 
   await instances[2].standardSelect.expectValue("adobe");
-  await instances[2].versionField.expectValue("2.0");
+  await instances[2].adobeVersionSelect.expectValue("2.0");
   await instances[2].generalInRadio.expectNotExists();
   await instances[2].generalOutRadio.expectNotExists();
   await instances[2].generalDataElementRadio.expectNotExists();
   await instances[2].generalDataElementField.expectNotExists();
   await instances[2].valueField.expectValue("%dataelement2%");
+  await instances[2].iabVersionField.expectNotExists();
   await instances[2].iabValueField.expectNotExists();
   await instances[2].gdprAppliesYesRadio.expectNotExists();
   await instances[2].gdprAppliesNoRadio.expectNotExists();
@@ -184,12 +188,13 @@ test("initializes form fields with settings containing data elements for parts",
   await addConsentButton.expectExists();
 
   await instances[0].standardSelect.expectValue("adobe");
-  await instances[0].versionField.expectValue("1.0");
+  await instances[0].adobeVersionSelect.expectValue("1.0");
   await instances[0].generalInRadio.expectUnchecked();
   await instances[0].generalOutRadio.expectUnchecked();
   await instances[0].generalDataElementRadio.expectChecked();
   await instances[0].generalDataElementField.expectValue("%data1%");
   await instances[0].valueField.expectNotExists();
+  await instances[0].iabVersionField.expectNotExists();
   await instances[0].iabValueField.expectNotExists();
   await instances[0].gdprAppliesYesRadio.expectNotExists();
   await instances[0].gdprAppliesNoRadio.expectNotExists();
@@ -201,12 +206,13 @@ test("initializes form fields with settings containing data elements for parts",
   await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
 
   await instances[1].standardSelect.expectValue("iab_tcf");
-  await instances[1].versionField.expectValue("2.0");
+  await instances[1].adobeVersionSelect.expectNotExists();
   await instances[1].generalInRadio.expectNotExists();
   await instances[1].generalOutRadio.expectNotExists();
   await instances[1].generalDataElementRadio.expectNotExists();
   await instances[1].generalDataElementField.expectNotExists();
-  await instances[0].valueField.expectNotExists();
+  await instances[1].valueField.expectNotExists();
+  await instances[1].iabVersionField.expectValue("2.0");
   await instances[1].iabValueField.expectValue("%data2%");
   await instances[1].gdprAppliesYesRadio.expectUnchecked();
   await instances[1].gdprAppliesNoRadio.expectUnchecked();
@@ -250,12 +256,14 @@ test("initializes form fields with no settings", async () => {
   await addConsentButton.expectExists();
 
   await instances[0].standardSelect.expectValue("adobe");
-  await instances[0].versionField.expectValue("");
+  await instances[0].adobeVersionSelect.expectValue("1.0");
+  await instances[0].adobeVersionSelect.selectOption("2.0");
   await instances[0].generalInRadio.expectNotExists();
   await instances[0].generalOutRadio.expectNotExists();
   await instances[0].generalDataElementRadio.expectNotExists();
   await instances[0].generalDataElementField.expectNotExists();
   await instances[0].valueField.expectValue("");
+  await instances[0].iabVersionField.expectNotExists();
   await instances[0].iabValueField.expectNotExists();
   await instances[0].gdprAppliesYesRadio.expectNotExists();
   await instances[0].gdprAppliesNoRadio.expectNotExists();
@@ -267,7 +275,7 @@ test("initializes form fields with no settings", async () => {
   await instances[0].gdprContainsPersonalDataDataElementField.expectNotExists();
   await instances[1].container.expectNotExists();
 
-  await instances[0].versionField.typeText("1.0");
+  await instances[0].adobeVersionSelect.selectOption("1.0");
 
   await instances[0].generalInRadio.expectChecked();
   await instances[0].generalOutRadio.expectUnchecked();
@@ -278,12 +286,13 @@ test("initializes form fields with no settings", async () => {
   await instances[0].standardSelect.selectOption("IAB TCF");
 
   await instances[0].standardSelect.expectValue("iab_tcf");
-  await instances[0].versionField.expectValue("1.0");
+  await instances[0].adobeVersionSelect.expectNotExists();
   await instances[0].generalInRadio.expectNotExists();
   await instances[0].generalOutRadio.expectNotExists();
   await instances[0].generalDataElementRadio.expectNotExists();
   await instances[0].generalDataElementField.expectNotExists();
   await instances[0].valueField.expectNotExists();
+  await instances[0].iabVersionField.expectValue("2.0");
   await instances[0].iabValueField.expectValue("");
   await instances[0].gdprAppliesYesRadio.expectChecked();
   await instances[0].gdprAppliesNoRadio.expectUnchecked();
@@ -300,13 +309,12 @@ test("returns minimal valid settings", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1.0");
   await addConsentButton.click();
   await instances[1].standardSelect.selectOption("IAB TCF");
-  await instances[1].versionField.typeText("2.1");
+  await instances[1].iabVersionField.typeText("2.1", { replace: true });
   await instances[1].iabValueField.typeText("1234abcd");
   await addConsentButton.click();
-  await instances[2].versionField.typeText("2.1");
+  await instances[2].adobeVersionSelect.selectOption("2.0");
   await instances[2].valueField.typeText("%dataelement2%");
 
   await extensionViewController.expectIsValid();
@@ -327,7 +335,7 @@ test("returns minimal valid settings", async () => {
       },
       {
         standard: "Adobe",
-        version: "2.1",
+        version: "2.0",
         value: "%dataelement2%"
       }
     ]
@@ -341,12 +349,12 @@ test("returns full valid settings", async () => {
   await instanceNameSelect.selectOption("alloy2");
   await identityMapField.typeText("%data0%");
   await instances[0].standardSelect.selectOption("IAB TCF");
-  await instances[0].versionField.typeText("2.2");
+  await instances[0].iabVersionField.typeText("2.2", { replace: true });
   await instances[0].iabValueField.typeText("a");
   await instances[0].gdprAppliesNoRadio.click();
   await instances[0].gdprContainsPersonalDataYesRadio.click();
   await addConsentButton.click();
-  await instances[1].versionField.typeText("1.0");
+  await instances[1].adobeVersionSelect.selectOption("1.0");
   await instances[1].generalOutRadio.click();
 
   await extensionViewController.expectIsValid();
@@ -374,12 +382,11 @@ test("returns valid setting for guided form data elements", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1.0");
   await instances[0].generalDataElementRadio.click();
   await instances[0].generalDataElementField.typeText("%data1%");
   await addConsentButton.click();
   await instances[1].standardSelect.selectOption("IAB TCF");
-  await instances[1].versionField.typeText("2.3");
+  await instances[1].iabVersionField.typeText("2.3", { replace: true });
   await instances[1].iabValueField.typeText("%data2%");
   await instances[1].gdprAppliesDataElementRadio.click();
   await instances[1].gdprAppliesDataElementField.typeText("%data3%");
@@ -425,20 +432,23 @@ test("deletes consent objects", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1");
+  await instances[0].standardSelect.selectOption("IAB TCF");
+  await instances[0].iabVersionField.typeText("1", { replace: true });
   await instances[0].deleteConsentButton.expectDisabled();
   await instances[1].container.expectNotExists();
   await addConsentButton.click();
   await instances[0].deleteConsentButton.expectEnabled();
-  await instances[1].versionField.typeText("2");
+  await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].iabVersionField.typeText("2", { replace: true });
   await instances[0].deleteConsentButton.click();
-  await instances[0].versionField.expectValue("2");
+  await instances[0].iabVersionField.expectValue("2");
   await instances[1].container.expectNotExists();
   await addConsentButton.click();
-  await instances[1].versionField.typeText("3");
+  await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].iabVersionField.typeText("3");
   await instances[1].deleteConsentButton.click();
   await instances[1].container.expectNotExists();
-  await instances[0].versionField.expectValue("2");
+  await instances[0].iabVersionField.expectValue("2");
 });
 
 test("shows errors for empty values", async () => {
@@ -446,17 +456,16 @@ test("shows errors for empty values", async () => {
     extensionSettings: mockExtensionSettings
   });
   await addConsentButton.click();
+  await instances[0].adobeVersionSelect.selectOption("2.0");
   await instances[1].standardSelect.selectOption("IAB TCF");
+  await instances[1].iabVersionField.clear();
   await instances[1].gdprAppliesDataElementRadio.click();
   await instances[1].gdprContainsPersonalDataDataElementRadio.click();
   await addConsentButton.click();
-  await instances[2].versionField.typeText("1.0");
   await instances[2].generalDataElementRadio.click();
 
   await extensionViewController.expectIsNotValid();
-  await instances[0].versionField.expectError();
   await instances[0].valueField.expectError();
-  await instances[1].versionField.expectError();
   await instances[1].iabValueField.expectError();
   await instances[1].gdprAppliesDataElementField.expectError();
   await instances[1].gdprContainsPersonalDataDataElementField.expectError();
@@ -467,12 +476,11 @@ test("shows errors for things that aren't data elements and does not show errors
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await instances[0].versionField.typeText("1.0");
   await instances[0].generalDataElementRadio.click();
   await instances[0].generalDataElementField.typeText("notadataelement");
   await addConsentButton.click();
   await instances[1].standardSelect.selectOption("IAB TCF");
-  await instances[1].versionField.typeText("2");
+  await instances[1].iabVersionField.typeText("2");
   await instances[1].iabValueField.typeText("notadataelement");
   await instances[1].gdprAppliesDataElementRadio.click();
   await instances[1].gdprAppliesDataElementField.typeText("%data1%%data2%");
@@ -481,7 +489,7 @@ test("shows errors for things that aren't data elements and does not show errors
     "%notadataelement"
   );
   await addConsentButton.click();
-  await instances[2].versionField.typeText("2.0");
+  await instances[2].adobeVersionSelect.selectOption("2.0");
   await instances[2].valueField.typeText("notadataelement");
 
   await extensionViewController.expectIsNotValid();

--- a/test/functional/helpers/spectrum.js
+++ b/test/functional/helpers/spectrum.js
@@ -173,9 +173,9 @@ const componentWrappers = {
       expectNoError: createExpectNoError(selector),
       expectValue: createExpectValue(selector),
       expectMatch: createExpectMatch(selector),
-      async typeText(text) {
+      async typeText(text, options) {
         await switchToIframe();
-        await t.typeText(selector, text);
+        await t.typeText(selector, text, options);
       },
       async clear() {
         await switchToIframe();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change allows customers to specify Adobe 2.0 consent objects to the Set Consent action. When the standard is set to Adobe, the UI shows "version", and "value". If "1.0" is typed into the version, the in/out/dataelement options are shown. Otherwise a data element can be specified for the value.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-1074

## Motivation and Context

The new Adobe 2.0 standard uses an XDM object to specify consent and preferences. The previous Adobe 1.0 standard expected an object like { general: "in" }. At this time we didn't want to create a custom UI for the consent XDM, and so it can only be specified with a data element.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
