### PR TITLE
Add "out" as a configuration option for default consent, Reword options.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -57,7 +57,7 @@
                   },
                   {
                     "type": "string",
-                    "enum": ["in", "pending"]
+                    "enum": ["in", "out", "pending"]
                   }
                 ]
               },

--- a/src/lib/.eslintrc.js
+++ b/src/lib/.eslintrc.js
@@ -1,7 +1,6 @@
 module.exports = {
   rules: {
     "no-var": "off",
-    "func-names": "off""
     "func-names": "off",
     "import/no-default-export": 2,
     "import/no-named-export": 2

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -772,7 +772,7 @@ const Configuration = ({
                             }
                           ]}
                           label="Default Consent"
-                          infoTip="How to handle sending events when the SDK does not have the user's consent preferences. This setting is not persisted to a new user's profile."
+                          infoTip="How to handle sending events when the SDK does not have the user's consent preferences. This setting is not persisted to users' profiles. If provided through a data element, it should resolve to 'in', 'out', or 'pending'."
                           id="generalDefaultConsent"
                           data-test-id="defaultConsent"
                           name={`instances.${index}.defaultConsent`}

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -755,24 +755,24 @@ const Configuration = ({
                             {
                               value: consentLevels.IN,
                               label:
-                                "In - Send events even without the user's explicit consent.",
+                                "In - Collect events that occur before the user provides consent preferences.",
                               testId: "In"
                             },
                             {
                               value: consentLevels.OUT,
                               label:
-                                "Out - Drop events that occur before the user provides explicit consent.",
+                                "Out - Drop events that occur before the user provides consent preferences.",
                               testId: "Out"
                             },
                             {
                               value: consentLevels.PENDING,
                               label:
-                                "Pending - Queue events until the user provides consent preferences.",
+                                "Pending - Queue events that occur before the user provides consent preferences.",
                               testId: "Pending"
                             }
                           ]}
                           label="Default Consent"
-                          infoTip="How to handle sending events when the SDK does not have the user's consent preferences. This setting is not persisted to users' profiles. If provided through a data element, it should resolve to 'in', 'out', or 'pending'."
+                          infoTip="How to handle events that occur before the user provides consent preferences. This setting is not persisted to users' profiles. If provided through a data element, it should resolve to 'in', 'out', or 'pending'."
                           id="generalDefaultConsent"
                           data-test-id="defaultConsent"
                           name={`instances.${index}.defaultConsent`}

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -236,7 +236,7 @@ const getSettings = ({ values, initInfo }) => {
 
       if (instance.defaultConsent.radio === DATA_ELEMENT) {
         trimmedInstance.defaultConsent = instance.defaultConsent.dataElement;
-      } else {
+      } else if (instance.defaultConsent.radio !== consentLevels.IN) {
         trimmedInstance.defaultConsent = instance.defaultConsent.radio;
       }
 
@@ -754,12 +754,14 @@ const Configuration = ({
                           options={[
                             {
                               value: consentLevels.IN,
-                              label: "In - Send events even without the user's explicit consent.",
+                              label:
+                                "In - Send events even without the user's explicit consent.",
                               testId: "In"
                             },
                             {
                               value: consentLevels.OUT,
-                              label: "Out - Drop events that occur before the user provides explicit consent.",
+                              label:
+                                "Out - Drop events that occur before the user provides explicit consent.",
                               testId: "Out"
                             },
                             {

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -119,7 +119,7 @@ const defaultInitInfo = {
   }
 };
 
-test.only("initializes form fields with full settings", async () => {
+test("initializes form fields with full settings", async () => {
   await extensionViewController.init(
     Object.assign({}, defaultInitInfo, {
       settings: {

--- a/test/functional/configuration/configuration.spec.js
+++ b/test/functional/configuration/configuration.spec.js
@@ -36,7 +36,7 @@ const environmentFields = env => {
   };
 };
 
-for (let i = 0; i < 2; i += 1) {
+for (let i = 0; i < 3; i += 1) {
   instances.push({
     nameField: spectrum.textfield("nameField"),
     nameChangeAlert: spectrum.alert("nameChangeAlert"),
@@ -58,6 +58,7 @@ for (let i = 0; i < 2; i += 1) {
     edgeBasePathRestoreButton: spectrum.button("edgeBasePathRestoreButton"),
     defaultConsent: {
       inRadio: spectrum.radio("defaultConsentInRadio"),
+      outRadio: spectrum.radio("defaultConsentOutRadio"),
       pendingRadio: spectrum.radio("defaultConsentPendingRadio"),
       dataElementRadio: spectrum.radio("defaultConsentDataElementRadio"),
       dataElementField: spectrum.textfield("defaultConsentDataElementField")
@@ -118,7 +119,7 @@ const defaultInitInfo = {
   }
 };
 
-test("initializes form fields with full settings", async () => {
+test.only("initializes form fields with full settings", async () => {
   await extensionViewController.init(
     Object.assign({}, defaultInitInfo, {
       settings: {
@@ -147,6 +148,11 @@ test("initializes form fields with full settings", async () => {
             idMigrationEnabled: false,
             thirdPartyCookiesEnabled: false,
             context: []
+          },
+          {
+            name: "alloy3",
+            edgeConfigId: "PR789",
+            defaultConsent: "out"
           }
         ]
       }
@@ -182,6 +188,7 @@ test("initializes form fields with full settings", async () => {
   await instances[0].edgeDomainField.expectValue("testedge.com");
   await instances[0].edgeBasePathField.expectValue("ee-beta");
   await instances[0].defaultConsent.inRadio.expectUnchecked();
+  await instances[0].defaultConsent.outRadio.expectUnchecked();
   await instances[0].defaultConsent.pendingRadio.expectChecked();
   await instances[0].defaultConsent.dataElementRadio.expectUnchecked();
   await instances[0].defaultConsent.dataElementField.expectNotExists();
@@ -218,6 +225,7 @@ test("initializes form fields with full settings", async () => {
   await instances[1].edgeDomainField.expectValue(defaultEdgeDomain);
   await instances[1].edgeBasePathField.expectValue(defaultEdgeBasePath);
   await instances[1].defaultConsent.inRadio.expectUnchecked();
+  await instances[1].defaultConsent.outRadio.expectUnchecked();
   await instances[1].defaultConsent.pendingRadio.expectUnchecked();
   await instances[1].defaultConsent.dataElementRadio.expectChecked();
   await instances[1].defaultConsent.dataElementField.expectValue(
@@ -234,6 +242,14 @@ test("initializes form fields with full settings", async () => {
   await instances[1].specificContext.deviceField.expectUnchecked();
   await instances[1].specificContext.environmentField.expectUnchecked();
   await instances[1].specificContext.placeContextField.expectUnchecked();
+
+  await accordion.clickHeader("ALLOY3");
+
+  await instances[2].defaultConsent.inRadio.expectUnchecked();
+  await instances[2].defaultConsent.outRadio.expectChecked();
+  await instances[2].defaultConsent.pendingRadio.expectUnchecked();
+  await instances[2].defaultConsent.dataElementRadio.expectUnchecked();
+  await instances[2].defaultConsent.dataElementField.expectNotExists();
 });
 
 test("initializes form fields with minimal settings", async () => {
@@ -258,6 +274,7 @@ test("initializes form fields with minimal settings", async () => {
   await instances[0].edgeDomainField.expectValue(defaultEdgeDomain);
   await instances[0].edgeBasePathField.expectValue(defaultEdgeBasePath);
   await instances[0].defaultConsent.inRadio.expectChecked();
+  await instances[0].defaultConsent.outRadio.expectUnchecked();
   await instances[0].defaultConsent.pendingRadio.expectUnchecked();
   await instances[0].defaultConsent.dataElementRadio.expectUnchecked();
   await instances[0].defaultConsent.dataElementField.expectNotExists();
@@ -293,6 +310,7 @@ test("initializes form fields with no settings", async () => {
   await instances[0].edgeDomainField.expectValue(defaultEdgeDomain);
   await instances[0].edgeBasePathField.expectValue(defaultEdgeBasePath);
   await instances[0].defaultConsent.inRadio.expectChecked();
+  await instances[0].defaultConsent.outRadio.expectUnchecked();
   await instances[0].defaultConsent.pendingRadio.expectUnchecked();
   await instances[0].defaultConsent.dataElementRadio.expectUnchecked();
   await instances[0].defaultConsent.dataElementField.expectNotExists();
@@ -339,7 +357,7 @@ test("returns full valid settings", async () => {
   await instances[0].developmentEnvironment.manualField.typeText("PR123:dev1");
   await instances[0].edgeDomainField.typeText("2");
   await instances[0].edgeBasePathField.typeText("-alpha");
-  await instances[0].defaultConsent.pendingRadio.click();
+  await instances[0].defaultConsent.outRadio.click();
   await instances[0].idMigrationEnabled.click();
   await instances[0].thirdPartyCookiesEnabled.click();
   await instances[0].prehidingStyleEditorButton.click();
@@ -361,6 +379,12 @@ test("returns full valid settings", async () => {
   await instances[1].downloadLinkQualifierField.typeText("[]");
   await instances[1].contextGranularity.specificField.click();
 
+  await addInstanceButton.click();
+  await instances[2].nameField.typeText("3");
+  await instances[2].productionEnvironment.manualField.typeText("PR789");
+  await instances[2].orgIdField.typeText("3");
+  await instances[2].defaultConsent.pendingRadio.click();
+
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
     instances: [
@@ -371,7 +395,7 @@ test("returns full valid settings", async () => {
         developmentEdgeConfigId: "PR123:dev1",
         edgeDomain: `${defaultEdgeDomain}2`,
         edgeBasePath: `${defaultEdgeBasePath}-alpha`,
-        defaultConsent: "pending",
+        defaultConsent: "out",
         idMigrationEnabled: false,
         thirdPartyCookiesEnabled: false,
         prehidingStyle:
@@ -390,6 +414,12 @@ test("returns full valid settings", async () => {
           'language=javascript;code=// Modify content.xdm as necessary. There is no need to wrap the code in a function\n// or return a value. For example:\n// content.xdm.web.webPageDetails.name = "Checkout";',
         context: ["web", "device", "environment", "placeContext"],
         downloadLinkQualifier: "[]"
+      },
+      {
+        name: "alloy3",
+        edgeConfigId: "PR789",
+        orgId: "ABC123@AdobeOrg3",
+        defaultConsent: "pending"
       }
     ]
   });
@@ -498,6 +528,23 @@ test("shows error for duplicate IMS org ID", async () => {
   await accordion.clickHeader("ALLOY");
   await extensionViewController.expectIsNotValid();
   await instances[1].orgIdField.expectError();
+});
+
+test("shows error for bad default consent data element", async () => {
+  await extensionViewController.init(defaultInitInfo);
+  await instances[0].defaultConsent.dataElementRadio.click();
+  await instances[0].defaultConsent.dataElementField.typeText(
+    "notadataelement"
+  );
+  await extensionViewController.expectIsNotValid();
+  await instances[0].defaultConsent.dataElementField.expectError();
+});
+
+test("shows error for empty default consent data element", async () => {
+  await extensionViewController.init(defaultInitInfo);
+  await instances[0].defaultConsent.dataElementRadio.click();
+  await extensionViewController.expectIsNotValid();
+  await instances[0].defaultConsent.dataElementField.expectError();
 });
 
 test("shows error for invalid download link qualifier", async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new option for default consent "out". Make the default consent options less confusing.

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-1074 Update Launch extension for Consent 2.0
https://jira.corp.adobe.com/browse/PDCL-1161 Add a tooltip to the DefaultConsent data element
https://jira.corp.adobe.com/browse/PDCL-4435 Clarify how defaultConsent behaves

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
