### PR TITLE
PDCL-1079 Added checkbox for "document unloading" in Send Event action.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -165,6 +165,9 @@
           "datasetId": {
             "type": "string",
             "minLength": 1
+          },
+          "documentUnloading": {
+            "type": "boolean"
           }
         },
         "required": ["instanceName"],

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -86,7 +86,8 @@ const getInitialValues = ({ initInfo }) => {
     xdm = "",
     type = "",
     mergeId = "",
-    datasetId = ""
+    datasetId = "",
+    documentUnloading = false
   } = initInfo.settings || {};
   const initialPersonalizationData = getInitialDecisionScopesData(
     decisionScopes
@@ -99,6 +100,7 @@ const getInitialValues = ({ initInfo }) => {
     type,
     mergeId,
     datasetId,
+    documentUnloading,
     ...initialPersonalizationData
   };
 };
@@ -120,8 +122,11 @@ const getSettings = ({ values }) => {
   if (values.datasetId) {
     settings.datasetId = values.datasetId;
   }
-
-  // Only add renderDecisions if the value is different than the default (false).
+  // Only add if the value is different than the default (false).
+  if (values.documentUnloading) {
+    settings.documentUnloading = true;
+  }
+  // Only add if the value is different than the default (false).
   if (values.renderDecisions) {
     settings.renderDecisions = true;
   }
@@ -275,6 +280,16 @@ const SendEvent = () => {
                   supportDataElement="replace"
                 />
               </div>
+            </div>
+            <div className="u-gapTop">
+              <InfoTipLayout tip="Ensures the event will reach the server even if the user is navigating away from the current document (page), but any response from the server will be ignored.">
+                <WrappedField
+                  data-test-id="documentUnloadingField"
+                  name="documentUnloading"
+                  component={Checkbox}
+                  label="Document will unload"
+                />
+              </InfoTipLayout>
             </div>
             <div className="u-gapTop">
               <InfoTipLayout tip="Influences whether the SDK should automatically render personalization and pre-hide the content to prevent flicker.">

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -23,8 +23,9 @@ const xdmField = spectrum.textfield("xdmField");
 const typeField = spectrum.textfield("typeField");
 const mergeIdField = spectrum.textfield("mergeIdField");
 const datasetIdField = spectrum.textfield("datasetIdField");
+const documentUnloadingField = spectrum.checkbox("documentUnloadingField");
 const scopeDataElementField = spectrum.textfield("scopeDataElementField");
-const radioGroup = {
+const scopesRadioGroup = {
   dataElement: spectrum.radio("dataElementOptionField"),
   values: spectrum.radio("constantOptionField")
 };
@@ -67,7 +68,8 @@ test("initializes form fields with full settings, when decision scopes is data e
       type: "myType1",
       mergeId: "%myMergeId%",
       decisionScopes: "%myDecisionScope%",
-      datasetId: "%myDatasetId%"
+      datasetId: "%myDatasetId%",
+      documentUnloading: true
     }
   });
   await instanceNameField.expectValue("alloy2");
@@ -76,8 +78,9 @@ test("initializes form fields with full settings, when decision scopes is data e
   await typeField.expectValue("myType1");
   await mergeIdField.expectValue("%myMergeId%");
   await datasetIdField.expectValue("%myDatasetId%");
-  await radioGroup.dataElement.expectChecked();
-  await radioGroup.values.expectUnchecked();
+  await documentUnloadingField.expectChecked();
+  await scopesRadioGroup.dataElement.expectChecked();
+  await scopesRadioGroup.values.expectUnchecked();
   await scopeDataElementField.expectValue("%myDecisionScope%");
 });
 
@@ -88,7 +91,7 @@ test("initializes decision scopes form fields, when decision scopes is an array 
       decisionScopes: ["foo1", "foo2", "foo3"]
     }
   });
-  await radioGroup.values.expectChecked();
+  await scopesRadioGroup.values.expectChecked();
   await scopeDataElementField.expectError;
   await scopeArrayValues[0].value.expectValue("foo1");
   await scopeArrayValues[1].value.expectValue("foo2");
@@ -107,9 +110,10 @@ test("initializes form fields with minimal settings", async () => {
   await xdmField.expectValue("");
   await typeField.expectValue("");
   await mergeIdField.expectValue("");
-  await radioGroup.values.expectChecked();
+  await scopesRadioGroup.values.expectChecked();
   await datasetIdField.expectValue("");
-  await radioGroup.dataElement.expectUnchecked();
+  await documentUnloadingField.expectUnchecked();
+  await scopesRadioGroup.dataElement.expectUnchecked();
   await scopeArrayValues[0].value.expectValue("");
 });
 
@@ -123,8 +127,9 @@ test("initializes form fields with no settings", async () => {
   await typeField.expectValue("");
   await mergeIdField.expectValue("");
   await datasetIdField.expectValue("");
-  await radioGroup.values.expectChecked();
-  await radioGroup.dataElement.expectUnchecked();
+  await documentUnloadingField.expectUnchecked();
+  await scopesRadioGroup.values.expectChecked();
+  await scopesRadioGroup.dataElement.expectUnchecked();
   await scopeArrayValues[0].value.expectValue("");
 });
 
@@ -148,7 +153,9 @@ test("returns full valid settings with decision scopes as data element", async (
   await xdmField.typeText("%myDataLayer%");
   await typeField.typeText("mytype1");
   await mergeIdField.typeText("%myMergeId%");
-  await radioGroup.dataElement.click();
+  await datasetIdField.typeText("%myDatasetId%");
+  await documentUnloadingField.click();
+  await scopesRadioGroup.dataElement.click();
   await scopeDataElementField.typeText("%myScope%");
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
@@ -157,6 +164,8 @@ test("returns full valid settings with decision scopes as data element", async (
     xdm: "%myDataLayer%",
     type: "mytype1",
     mergeId: "%myMergeId%",
+    datasetId: "%myDatasetId%",
+    documentUnloading: true,
     decisionScopes: "%myScope%"
   });
 });
@@ -164,7 +173,7 @@ test("returns decision scopes settings as an array", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await radioGroup.values.click();
+  await scopesRadioGroup.values.click();
   await scopeArrayValues[0].value.typeText("foo");
   await addDecisionScopeButton.click();
   await scopeArrayValues[1].value.typeText("foo1");
@@ -181,7 +190,7 @@ test("does not return decision scopes settings when provided with array of empty
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await radioGroup.values.click();
+  await scopesRadioGroup.values.click();
   await addDecisionScopeButton.click();
   await addDecisionScopeButton.click();
   await extensionViewController.expectIsValid();
@@ -203,7 +212,7 @@ test("shows error for decision scope value that is not a data element", async ()
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
   });
-  await radioGroup.dataElement.click();
+  await scopesRadioGroup.dataElement.click();
   await scopeDataElementField.typeText("fooScope");
   await extensionViewController.expectIsNotValid();
   await scopeDataElementField.expectError();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added checkbox for "document unloading" in Send Event action.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-1079
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
There was no way of enabling this option previously.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
