### PR TITLE
PDCL-1122 Fixes a cross origin error when running inside Launch UI.

### DIFF
--- a/src/view/dataElements/eventMergeId.html
+++ b/src/view/dataElements/eventMergeId.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Extension View</title>
-</head>
-<body>
-<div id="root"></div>
-<script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
-<script src="eventMergeId.jsx"></script>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <title>Extension View</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
+    <script src="./eventMergeId.jsx"></script>
+  </body>
 </html>

--- a/src/view/dataElements/identityMap.html
+++ b/src/view/dataElements/identityMap.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Extension View</title>
-</head>
-<body>
-<div id="root"></div>
-<script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
-<script src="identityMap.jsx"></script>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <title>Extension View</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
+    <script src="./identityMap.jsx"></script>
+  </body>
 </html>

--- a/src/view/dataElements/xdmObject.html
+++ b/src/view/dataElements/xdmObject.html
@@ -3,15 +3,10 @@
   <head>
     <meta charset="UTF-8">
     <title>Extension View</title>
-    <script>
-      if (window.parent !== window) {
-        window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      }
-    </script>
   </head>
   <body>
     <div id="root"></div>
     <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
-    <script src="xdmObject.jsx"></script>
+    <script src="./xdmObject.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a cross origin error when running inside Launch UI. This cross origin error would only show up when the extension view was running inside the Launch UI because the Launch UI is in a different origin that the extension view. The error, however, never actually impacted the extension view. The code causing the cross-origin error existed to support the React dev tools browser extension. I used this extension for a moment while I was building the XDM Object data element, but I don't think anyone is using it anymore. I removed the offending code, but if someone needs to use the React dev tools extension, we could handle this in other ways.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-1122
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Users were reporting this error, but it's always a red herring to the real underlying problem they're facing.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
