### PR TITLE
Remove 'only' qualifier on setConsent test

### DIFF
--- a/test/functional/actions/setConsent.spec.js
+++ b/test/functional/actions/setConsent.spec.js
@@ -77,9 +77,9 @@ const mockExtensionSettings = {
 
 // disablePageReloads is not a publicized feature, but it sure helps speed up tests.
 // https://github.com/DevExpress/testcafe/issues/1770
-fixture
-  .only("Set Consent View")
-  .disablePageReloads.page("http://localhost:3000/viewSandbox.html");
+fixture("Set Consent View").disablePageReloads.page(
+  "http://localhost:3000/viewSandbox.html"
+);
 
 test("initializes form fields with settings containing a static consent array", async () => {
   await extensionViewController.init({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
