### PR TITLE
PDCL-4413 Fix validation for required fields to take into considerati…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10197,7 +10197,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -15984,8 +15983,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "7.4.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "formik": "^1.5.8",
+    "once": "^1.4.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-copy-to-clipboard": "^5.0.3",

--- a/src/view/dataElements/xdmObject/helpers/array/validate.js
+++ b/src/view/dataElements/xdmObject/helpers/array/validate.js
@@ -34,11 +34,21 @@ export default ({
 
   if (items) {
     const itemErrors = items.map(itemFormStateNode => {
-      return validate({
+      let itemIsPopulated = false;
+      let itemError = validate({
         formStateNode: itemFormStateNode,
-        isParentAnArray: true,
-        notifyParentOfDataPopulation: confirmDataPopulatedAtCurrentOrDescendantNode
+        confirmDataPopulatedAtCurrentOrDescendantNode() {
+          itemIsPopulated = true;
+          confirmDataPopulatedAtCurrentOrDescendantNode();
+        }
       });
+      if (!itemIsPopulated && !itemError) {
+        itemError = {
+          value:
+            "Items within arrays must not be empty. Please populate or remove the item."
+        };
+      }
+      return itemError;
     });
     if (itemErrors.filter(error => error).length) {
       return { items: itemErrors };

--- a/src/view/dataElements/xdmObject/helpers/generateTreeStructure.js
+++ b/src/view/dataElements/xdmObject/helpers/generateTreeStructure.js
@@ -32,13 +32,12 @@ import getTypeSpecificHelpers from "./getTypeSpecificHelpers";
  * Generates an object representing a node on the XDM tree. The node
  * may contain child nodes.
  * @param {FormStateNode} formStateNode A node from the form state.
+ * @param {Function} treeNodeComponent A React component that renders a node
+ * on the XDM tree.
  * @param {string} [displayName] A user-friendly display name for the node.
  * @param {boolean} [isAncestorUsingWholePopulationStrategy=false] Whether any ancestor
  * node is using the WHOLE population strategy. If this is true, this node will
  * be disabled.
- * @param {Function} [notifyParentOfDataPopulation] When called, notifies the
- * parent node that this node or a descendant of this node has been populated
- * with a value by the user.
  * @param {Function} [notifyParentOfTouched] When called, notifies the parent
  * node that the "whole value" field of this node or a descendant node has
  * been touched by the user. This helps determine if validation errors should

--- a/src/view/dataElements/xdmObject/helpers/object/validate.js
+++ b/src/view/dataElements/xdmObject/helpers/object/validate.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import { WHOLE } from "../../constants/populationStrategy";
 import isFormStateValuePopulated from "../isFormStateValuePopulated";
 import singleDataElementRegex from "../../../../constants/singleDataElementRegex";
+import { NONE } from "../../constants/autoPopulationSource";
 
 export default ({
   formStateNode,
@@ -33,20 +34,62 @@ export default ({
   }
 
   if (properties) {
+    const namesOfPopulatedProperties = new Set();
     const propertyNames = Object.keys(properties);
-    const propertyErrors = propertyNames.reduce((memo, propertyName) => {
-      const propertyFormStateNode = properties[propertyName];
-      const error = validate({
-        formStateNode: propertyFormStateNode,
-        isParentAnArray: false,
-        notifyParentOfDataPopulation: confirmDataPopulatedAtCurrentOrDescendantNode
-      });
+    let propertyErrors = propertyNames.reduce(
+      (propertyErrorsMemo, propertyName) => {
+        const propertyFormStateNode = properties[propertyName];
+        const error = validate({
+          formStateNode: propertyFormStateNode,
+          confirmDataPopulatedAtCurrentOrDescendantNode() {
+            namesOfPopulatedProperties.add(propertyName);
+            confirmDataPopulatedAtCurrentOrDescendantNode();
+          }
+        });
 
-      if (error) {
-        memo[propertyName] = error;
-      }
-      return memo;
-    }, {});
+        if (error) {
+          propertyErrorsMemo[propertyName] = error;
+        }
+        return propertyErrorsMemo;
+      },
+      {}
+    );
+
+    // Properties marked required are only actually required if the property's owning
+    // object exists in the XDM payload. The owning object will only be included in
+    // in the XDM payload if the object has at least one property with a populated value.
+    // At this point in the code, we know the names of the object properties that
+    // have a populated value. If at least one property has a populated value,
+    // we know the owning object will exist in the XDM payload, so we need to
+    // find any other properties in the object's schema that are required but
+    // don't yet have values. We'll ensure that these properties are given an error
+    // stating that the property is required.
+    // https://jira.corp.adobe.com/browse/PDCL-4413
+    if (namesOfPopulatedProperties.size) {
+      propertyErrors = propertyNames.reduce(
+        (propertyErrorsMemo, propertyName) => {
+          if (
+            // If the property is already populated, it won't qualify for an error.
+            !namesOfPopulatedProperties.has(propertyName) &&
+            // If the property already has some other type of error, we won't
+            // override it with a "required" error.
+            !propertyErrorsMemo[propertyName]
+          ) {
+            const propertyFormStateNode = properties[propertyName];
+            if (
+              propertyFormStateNode.schema.isRequired &&
+              propertyFormStateNode.autoPopulationSource === NONE
+            ) {
+              propertyErrorsMemo[propertyName] = {
+                value: "This is a required field and must be populated."
+              };
+            }
+          }
+          return propertyErrorsMemo;
+        },
+        propertyErrors
+      );
+    }
 
     if (Object.keys(propertyErrors).length) {
       return { properties: propertyErrors };

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -315,24 +315,6 @@ test("initializes form fields with whole array value", async () => {
   await arrayEdit.expectValue("%industries%");
 });
 
-test("arrays with no values are invalid", async () => {
-  await initializeExtensionView();
-  await selectSchemaFromSchemasMeta();
-  await xdmTree.toggleExpansion("_unifiedjsqeonly");
-  await xdmTree.toggleExpansion("vendor");
-  await xdmTree.click("industries");
-  await arrayEdit.selectPartsPopulationStrategy();
-  await arrayEdit.addItem();
-  await arrayEdit.addItem();
-  await arrayEdit.clickItem(0);
-  await arrayEdit.enterValue("%item1%");
-  await xdmTree.toggleExpansion("industries");
-
-  await extensionViewController.expectIsNotValid();
-  await xdmTree.expectIsValid("Item 1");
-  await xdmTree.expectIsNotValid("Item 2");
-});
-
 test("arrays using whole population strategy do not have children", async () => {
   await initializeExtensionView();
   await selectSchemaFromSchemasMeta();

--- a/test/functional/dataElements/xdmObjectValidation.spec.js
+++ b/test/functional/dataElements/xdmObjectValidation.spec.js
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import initializeExtensionView from "./xdmObject/helpers/initializeExtensionView";
+import xdmTree from "./xdmObject/helpers/xdmTree";
+import arrayEdit from "./xdmObject/helpers/arrayEdit";
+import stringEdit from "./xdmObject/helpers/stringEdit";
+import spectrum from "../helpers/spectrum";
+import createExtensionViewController from "../helpers/createExtensionViewController";
+
+const schemaTitle = "XDM Object Data Element Tests";
+const schemaSelectField = spectrum.combobox("schemaField");
+const selectSchemaFromSchemasMeta = async () => {
+  await schemaSelectField.selectOption(schemaTitle);
+};
+
+const extensionViewController = createExtensionViewController(
+  "dataElements/xdmObject.html"
+);
+
+// disablePageReloads is not a publicized feature, but it sure helps speed up tests.
+// https://github.com/DevExpress/testcafe/issues/1770
+fixture("XDM Object Population Indicator")
+  .disablePageReloads.page("http://localhost:3000/viewSandbox.html")
+  .meta("requiresAdobeIOIntegration", true);
+
+test("arrays with no values are invalid", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.toggleExpansion("_unifiedjsqeonly");
+  await xdmTree.toggleExpansion("vendor");
+  await xdmTree.click("industries");
+  await arrayEdit.selectPartsPopulationStrategy();
+  await arrayEdit.addItem();
+  await arrayEdit.addItem();
+  await arrayEdit.clickItem(0);
+  await arrayEdit.enterValue("%item1%");
+  await xdmTree.toggleExpansion("industries");
+
+  await extensionViewController.expectIsNotValid();
+  await xdmTree.expectIsValid("Item 1");
+  await xdmTree.expectIsNotValid("Item 2");
+});
+
+test("a populated required field is valid", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.toggleExpansion("_unifiedjsqeonly");
+  await xdmTree.toggleExpansion("customer");
+  await xdmTree.click("emailAddress");
+  await stringEdit.enterValue("example@adobe.com");
+  await extensionViewController.expectIsValid();
+});
+
+test("an empty required field is valid if parent object is not populated", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await extensionViewController.expectIsValid();
+});
+
+test("an empty required field is invalid if another field on parent object is populated", async () => {
+  await initializeExtensionView();
+  await selectSchemaFromSchemasMeta();
+  await xdmTree.toggleExpansion("_unifiedjsqeonly");
+  await xdmTree.toggleExpansion("customer");
+  // mailingAddress and emailAddress are siblings.
+  await xdmTree.toggleExpansion("mailingAddress");
+  await xdmTree.click("city");
+  await stringEdit.enterValue("San Jose");
+  await extensionViewController.expectIsNotValid();
+  await xdmTree.expectIsNotValid("emailAddress");
+});


### PR DESCRIPTION
…on whether the parent object has been populated.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Consider a schema like this:

![image](https://user-images.githubusercontent.com/210820/112541050-8a406500-8d78-11eb-8d48-c75482ad42e9.png)

In this schema, the `_acopprod3` field is NOT marked as required. Neither is `_acopprod3.reviewText`. However, `_accopprod3.productSku`, `_accopprod3.rating`, and `_accopprod3.reviewerId` ARE marked as required.

If you go to create a data element using the XDM Object data element type, select this schema, don't any values to any fields, then try to save, the XDM Object view prevents us from saving the data element and shows validation errors for `_accopprod3.productSku`, `_accopprod3.rating`, and `_accopprod3.reviewerId` fields.

This behavior is incorrect, because if I don't use the XDM Object data element and send data without those fields, the data passes validation within AEP. AEP's behavior makes sense, because they follow the JSON-schema standard, and the way the JSON-schema standard works is it only flags a required field as invalid if the field's parent object is provided in the JSON being validated. 

This PR changes the validation logic to match how required fields are being validated in Adobe Experience Platform.


<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-4413
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The extension's validation should match Adobe Experience Platform validation for required fields.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
