### PR TITLE
Add data field for sendEvent

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -154,6 +154,10 @@
             "type": "string",
             "pattern": "^%[^%]+%$"
           },
+          "data": {
+            "type": "string",
+            "pattern": "^%[^%]+%$"
+          },
           "type": {
             "type": "string",
             "minLength": 1

--- a/src/lib/actions/sendEvent/createSendEvent.js
+++ b/src/lib/actions/sendEvent/createSendEvent.js
@@ -25,12 +25,15 @@ module.exports = ({
     );
   }
 
-  // If the customer modifies the xdm object (or anything nested in the object) after this action runs, we want to
-  // make sure those modifications are not reflected in the data sent to the server. By cloning the object here,
-  // we ensure we use a snapshot that will remain unchanged during the time period between when sendEvent
-  // is called and the network request is made.
+  // If the customer modifies the xdm or data object (or anything nested in the object) after this action runs,
+  // we want to make sure those modifications are not reflected in the data sent to the server. By cloning the
+  // objects here, we ensure we use a snapshot that will remain unchanged during the time period between when
+  // sendEvent is called and the network request is made.
   if (otherSettings.xdm) {
     otherSettings.xdm = clone(otherSettings.xdm);
+  }
+  if (otherSettings.data) {
+    otherSettings.data = clone(otherSettings.data);
   }
 
   return instance("sendEvent", otherSettings).then(result => {

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -84,6 +84,7 @@ const getInitialValues = ({ initInfo }) => {
     renderDecisions = false,
     decisionScopes = null,
     xdm = "",
+    data = "",
     type = "",
     mergeId = "",
     datasetId = "",
@@ -97,6 +98,7 @@ const getInitialValues = ({ initInfo }) => {
     instanceName,
     renderDecisions,
     xdm,
+    data,
     type,
     mergeId,
     datasetId,
@@ -112,6 +114,9 @@ const getSettings = ({ values }) => {
 
   if (values.xdm) {
     settings.xdm = values.xdm;
+  }
+  if (values.data) {
+    settings.data = values.data;
   }
   if (values.type) {
     settings.type = values.type;
@@ -140,6 +145,10 @@ const getSettings = ({ values }) => {
 
 const validationSchema = object().shape({
   xdm: string().matches(
+    singleDataElementRegex,
+    "Please specify a data element"
+  ),
+  data: string().matches(
     singleDataElementRegex,
     "Please specify a data element"
   ),
@@ -233,6 +242,24 @@ const SendEvent = () => {
                   data-test-id="xdmField"
                   id="xdmField"
                   name="xdm"
+                  component={Textfield}
+                  componentClassName="u-fieldLong"
+                  supportDataElement="replace"
+                />
+              </div>
+            </div>
+            <div className="u-gapTop">
+              <InfoTipLayout
+                tip="Optionally specify a data element that will return a JavaScript
+                  object to send as free-form data."
+              >
+                <FieldLabel labelFor="dataField" label="Data" />
+              </InfoTipLayout>
+              <div>
+                <WrappedField
+                  data-test-id="dataField"
+                  id="dataField"
+                  name="data"
                   component={Textfield}
                   componentClassName="u-fieldLong"
                   supportDataElement="replace"

--- a/test/functional/actions/sendEvent.spec.js
+++ b/test/functional/actions/sendEvent.spec.js
@@ -20,6 +20,7 @@ const extensionViewController = createExtensionViewController(
 const instanceNameField = spectrum.select("instanceNameField");
 const renderDecisionsField = spectrum.checkbox("renderDecisionsField");
 const xdmField = spectrum.textfield("xdmField");
+const dataField = spectrum.textfield("dataField");
 const typeField = spectrum.textfield("typeField");
 const mergeIdField = spectrum.textfield("mergeIdField");
 const datasetIdField = spectrum.textfield("datasetIdField");
@@ -54,9 +55,8 @@ const mockExtensionSettings = {
 
 // disablePageReloads is not a publicized feature, but it sure helps speed up tests.
 // https://github.com/DevExpress/testcafe/issues/1770
-fixture("Send Event View").disablePageReloads.page(
-  "http://localhost:3000/viewSandbox.html"
-);
+fixture("Send Event View")
+  .disablePageReloads.page("http://localhost:3000/viewSandbox.html");
 
 test("initializes form fields with full settings, when decision scopes is data element", async () => {
   await extensionViewController.init({
@@ -65,6 +65,7 @@ test("initializes form fields with full settings, when decision scopes is data e
       instanceName: "alloy2",
       renderDecisions: true,
       xdm: "%myDataLayer%",
+      data: "%myData%",
       type: "myType1",
       mergeId: "%myMergeId%",
       decisionScopes: "%myDecisionScope%",
@@ -75,6 +76,7 @@ test("initializes form fields with full settings, when decision scopes is data e
   await instanceNameField.expectValue("alloy2");
   await renderDecisionsField.expectChecked();
   await xdmField.expectValue("%myDataLayer%");
+  await dataField.expectValue("%myData%");
   await typeField.expectValue("myType1");
   await mergeIdField.expectValue("%myMergeId%");
   await datasetIdField.expectValue("%myDatasetId%");
@@ -151,6 +153,7 @@ test("returns full valid settings with decision scopes as data element", async (
   await instanceNameField.selectOption("alloy2");
   await renderDecisionsField.click();
   await xdmField.typeText("%myDataLayer%");
+  await dataField.typeText("%myData%");
   await typeField.typeText("mytype1");
   await mergeIdField.typeText("%myMergeId%");
   await datasetIdField.typeText("%myDatasetId%");
@@ -162,6 +165,7 @@ test("returns full valid settings with decision scopes as data element", async (
     instanceName: "alloy2",
     renderDecisions: true,
     xdm: "%myDataLayer%",
+    data: "%myData%",
     type: "mytype1",
     mergeId: "%myMergeId%",
     datasetId: "%myDatasetId%",
@@ -208,6 +212,15 @@ test("shows error for xdm value that is not a data element", async () => {
   await xdmField.expectError();
 });
 
+test("shows error for data value that is not a data element", async () => {
+  await extensionViewController.init({
+    extensionSettings: mockExtensionSettings
+  });
+  await dataField.typeText("myData");
+  await extensionViewController.expectIsNotValid();
+  await dataField.expectError();
+});
+
 test("shows error for decision scope value that is not a data element", async () => {
   await extensionViewController.init({
     extensionSettings: mockExtensionSettings
@@ -225,6 +238,15 @@ test("shows error for xdm value that is more than one data element", async () =>
   await xdmField.typeText("%a%%b%");
   await extensionViewController.expectIsNotValid();
   await xdmField.expectError();
+});
+
+test("shows error for data value that is more than one data element", async () => {
+  await extensionViewController.init({
+    extensionSettings: mockExtensionSettings
+  });
+  await dataField.typeText("%a%%b%");
+  await extensionViewController.expectIsNotValid();
+  await dataField.expectError();
 });
 
 testInstanceNameOptions(extensionViewController, instanceNameField);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a field on sendEvent to specify a data element for data.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-5942
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is to support sending target profile attributes inside data.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
