### PR TITLE
PDCL-5957 Fixes issue where error was thrown if sandboxes were returned but without a default.

### DIFF
--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -248,14 +248,10 @@ const XdmExtensionView = () => {
           imsAccess: initInfo.tokens.imsAccess
         })
           .then(response => {
-            let sandbox = { name: null };
+            let sandbox;
             // if sandboxes are returned from the api call
             if (response.sandboxes && response.sandboxes.length) {
               setSandboxes(response);
-              // default to the first item in the list
-              sandbox = response.sandboxes.find(
-                _sandbox => _sandbox.isDefault === true
-              );
 
               // if a sandbox exists in settings and is in the list, choose that item
               if (initInfo.settings && initInfo.settings.sandbox) {
@@ -263,8 +259,24 @@ const XdmExtensionView = () => {
                   _sandbox => _sandbox.name === initInfo.settings.sandbox.name
                 );
               }
-              setSelectedSandbox(sandbox);
+
+              // default to the first item in the list
+              if (!sandbox) {
+                sandbox = response.sandboxes.find(
+                  _sandbox => _sandbox.isDefault
+                );
+              }
+
+              if (!sandbox) {
+                [sandbox] = response.sandboxes;
+              }
             }
+
+            if (!sandbox) {
+              sandbox = { name: null };
+            }
+
+            setSelectedSandbox(sandbox);
 
             return sandbox;
           })

--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -272,10 +272,6 @@ const XdmExtensionView = () => {
               }
             }
 
-            if (!sandbox) {
-              sandbox = { name: null };
-            }
-
             setSelectedSandbox(sandbox);
 
             return sandbox;

--- a/test/functional/dataElements/identityMap/identityMap.spec.js
+++ b/test/functional/dataElements/identityMap/identityMap.spec.js
@@ -14,7 +14,7 @@ import { t } from "testcafe";
 import createExtensionViewController from "../../helpers/createExtensionViewController";
 import spectrum from "../../helpers/spectrum";
 import getAdobeIOAccessToken from "../../helpers/getAdobeIOAccessToken";
-import platformMocks from "../xdmObject/helpers/platformMocks";
+import * as platformMocks from "../xdmObject/helpers/platformMocks";
 import credentials from "../../helpers/adobeIOClientCredentials";
 
 const identityMapViewController = createExtensionViewController(

--- a/test/functional/dataElements/xdmObject.spec.js
+++ b/test/functional/dataElements/xdmObject.spec.js
@@ -154,12 +154,12 @@ test.requestHooks(
   }
 );
 
-test.requestHooks(platformMocks.sandboxes, platformMocks.schemasMetaEmpty)(
+test.requestHooks(platformMocks.schemasMetaEmpty)(
   "checks sandbox with no schemas",
   async () => {
     await initializeExtensionView();
     await sandboxField.expectEnabled();
-    await sandboxField.selectOption("PRODUCTION Alloy Test (FOO)");
+    await sandboxField.selectOption("PRODUCTION Prod (VA7)");
     await spectrum.alert("selectedSandboxWarning").expectExists();
   }
 );

--- a/test/functional/dataElements/xdmObject/helpers/platformMocks.js
+++ b/test/functional/dataElements/xdmObject/helpers/platformMocks.js
@@ -78,37 +78,6 @@ export const sandboxesWithoutDefault = RequestMock()
   );
 
 /**
- * Mocks a response from the platform sandboxes endpoint
- * @type {RequestMock}
- */
-export const sandboxes = RequestMock()
-  .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
-  .respond(
-    {
-      sandboxes: [
-        {
-          name: "prod",
-          title: "Prod",
-          type: "production",
-          isDefault: true,
-          region: "VA7",
-          state: "active"
-        },
-        {
-          name: "alloy-test",
-          title: "Alloy Test",
-          type: "production",
-          isDefault: false,
-          region: "FOO",
-          state: "active"
-        }
-      ]
-    },
-    200,
-    responseHeaders
-  );
-
-/**
  * Mocks a response from the platform schema meta endpoint
  * @type {RequestMock}
  */

--- a/test/functional/dataElements/xdmObject/helpers/platformMocks.js
+++ b/test/functional/dataElements/xdmObject/helpers/platformMocks.js
@@ -6,7 +6,7 @@ const responseHeaders = { "Access-Control-Allow-Origin": "*" };
  * Mocks a sandboxes management user region missing response (e.g. not an AEP customer)
  * @type {RequestMock}
  */
-const unauthorized = RequestMock()
+export const unauthorized = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond(
     {
@@ -21,7 +21,7 @@ const unauthorized = RequestMock()
  * Mocks a sandboxes management user region missing response (e.g. not an AEP customer)
  * @type {RequestMock}
  */
-const userRegionMissing = RequestMock()
+export const userRegionMissing = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond(
     {
@@ -36,7 +36,7 @@ const userRegionMissing = RequestMock()
  * Mocks a sandboxes management user region missing response (e.g. not an AEP customer)
  * @type {RequestMock}
  */
-const nonJsonBody = RequestMock()
+export const nonJsonBody = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond("non-json body", 401, responseHeaders);
 
@@ -44,7 +44,7 @@ const nonJsonBody = RequestMock()
  * Mocks an empty response from the platform sandboxes endpoint
  * @type {RequestMock}
  */
-const sandboxesEmpty = RequestMock()
+export const sandboxesEmpty = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond(
     {
@@ -58,7 +58,30 @@ const sandboxesEmpty = RequestMock()
  * Mocks a response from the platform sandboxes endpoint
  * @type {RequestMock}
  */
-const sandboxes = RequestMock()
+export const sandboxesWithoutDefault = RequestMock()
+  .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
+  .respond(
+    {
+      sandboxes: [
+        {
+          name: "prod",
+          title: "Prod",
+          type: "production",
+          isDefault: false,
+          region: "VA7",
+          state: "active"
+        }
+      ]
+    },
+    200,
+    responseHeaders
+  );
+
+/**
+ * Mocks a response from the platform sandboxes endpoint
+ * @type {RequestMock}
+ */
+export const sandboxes = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/foundation/sandbox-management/")
   .respond(
     {
@@ -89,7 +112,7 @@ const sandboxes = RequestMock()
  * Mocks a response from the platform schema meta endpoint
  * @type {RequestMock}
  */
-const schemasMeta = RequestMock()
+export const schemasMeta = RequestMock()
   .onRequestTo({
     url:
       "https://platform.adobe.io/data/foundation/schemaregistry/tenant/schemas?orderby=title&property=meta%3Aextends%3D%3Dhttps%253A%252F%252Fns.adobe.com%252Fxdm%252Fcontext%252Fexperienceevent",
@@ -120,7 +143,7 @@ const schemasMeta = RequestMock()
  * Mocks a response from the platform schema meta endpoint
  * @type {RequestMock}
  */
-const schemasMetaEmpty = RequestMock()
+export const schemasMetaEmpty = RequestMock()
   .onRequestTo({
     url:
       "https://platform.adobe.io/data/foundation/schemaregistry/tenant/schemas?orderby=title&property=meta%3Aextends%3D%3Dhttps%253A%252F%252Fns.adobe.com%252Fxdm%252Fcontext%252Fexperienceevent",
@@ -136,7 +159,7 @@ const schemasMetaEmpty = RequestMock()
     responseHeaders
   );
 
-const namespaces = RequestMock()
+export const namespaces = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/core/idnamespace/identities")
   .respond(
     [
@@ -179,23 +202,10 @@ const namespaces = RequestMock()
     responseHeaders
   );
 
-const namespacesEmpty = RequestMock()
+export const namespacesEmpty = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/core/idnamespace/identities")
   .respond([], 200, responseHeaders);
 
-const namespacesError = RequestMock()
+export const namespacesError = RequestMock()
   .onRequestTo("https://platform.adobe.io/data/core/idnamespace/identities")
   .respond({}, 403, responseHeaders);
-
-export default {
-  sandboxes,
-  sandboxesEmpty,
-  unauthorized,
-  userRegionMissing,
-  nonJsonBody,
-  schemasMeta,
-  schemasMetaEmpty,
-  namespaces,
-  namespacesError,
-  namespacesEmpty
-};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a customer has access to at least one sandbox but not sandbox configured as the default for the org, the following error would be thrown: `Cannot read property 'name' of undefined`. This fixes that issue.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-5957
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
