### PR TITLE
Segregated "user-reportable errors" from errors whose messages really…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,19 @@ module.exports = {
       {
         allow: ["error"]
       }
+    ],
+    // This rule typically shows an error if a Link component
+    // doesn't have an href. We use React-Spectrum's Link
+    // component, however, which doesn't have an href prop
+    // (Link expects a anchor element as a child). We have
+    // to provide an empty components array here to get around
+    // eslint complaining about this. eslint still checks
+    // anchor elements though.
+    "jsx-a11y/anchor-is-valid": [
+      "error",
+      {
+        components: []
+      }
     ]
   },
   parser: "babel-eslint"

--- a/scripts/functional.js
+++ b/scripts/functional.js
@@ -59,13 +59,7 @@ const adobeIOClientCredentials = require("../test/functional/helpers/adobeIOClie
       return true;
     })
     .browsers("chrome")
-    .run({
-      // When using React's ErrorBoundary, even if the boundary catches an error, it doesn't swallow the
-      // error. Because the error isn't swallowed, TestCafe would typically immediately make the test fail,
-      // making it difficult to have a test that passes after asserting that the ErrorBoundary displayed
-      // a proper message.
-      skipJsErrors: true
-    });
+    .run();
   testcafe.close();
   process.exit(failedCount ? 1 : 0);
 })();

--- a/src/view/components/spectrum3ErrorBoundary.jsx
+++ b/src/view/components/spectrum3ErrorBoundary.jsx
@@ -12,7 +12,9 @@ governing permissions and limitations under the License.
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Link } from "@adobe/react-spectrum";
 import ErrorMessage from "./spectrum3ErrorMessage";
+import UserReportableError from "../errors/userReportableError";
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -27,11 +29,36 @@ export default class ErrorBoundary extends Component {
   render() {
     const { error } = this.state;
     const { children } = this.props;
+
+    let content = "An unexpected error occurred. Please try again later.";
+
+    if (error instanceof UserReportableError) {
+      content = (
+        <>
+          {error.message}
+          {error.additionalInfoUrl && (
+            <span>
+              {" "}
+              Click{" "}
+              <Link>
+                <a
+                  href={error.additionalInfoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  here
+                </a>
+              </Link>{" "}
+              for more information.
+            </span>
+          )}
+        </>
+      );
+    }
+
     if (error) {
       return (
-        <ErrorMessage dataTestId="errorBoundaryMessage">
-          {error.message}
-        </ErrorMessage>
+        <ErrorMessage dataTestId="errorBoundaryMessage">{content}</ErrorMessage>
       );
     }
 

--- a/src/view/components/spectrum3ErrorMessage.jsx
+++ b/src/view/components/spectrum3ErrorMessage.jsx
@@ -20,7 +20,7 @@ const ErrorMessage = ({ children, dataTestId }) => {
     <FillParentAndCenterChildren>
       <IllustratedMessage data-test-id={dataTestId}>
         <Error />
-        <Heading>An error occurred</Heading>
+        <Heading>An error occurred.</Heading>
         <Content>{children}</Content>
       </IllustratedMessage>
     </FillParentAndCenterChildren>

--- a/src/view/dataElements/xdmObject/components/sandboxSelector.jsx
+++ b/src/view/dataElements/xdmObject/components/sandboxSelector.jsx
@@ -18,6 +18,7 @@ import FieldDescriptionAndError from "../../../components/fieldDescriptionAndErr
 import useReportAsyncError from "../../../utils/useReportAsyncError";
 import useIsFirstRender from "../../../utils/useIsFirstRender";
 import ExtensionViewContext from "../../../components/extensionViewContext";
+import UserReportableError from "../../../errors/userReportableError";
 
 const getKey = sandbox => sandbox && sandbox.name;
 const getLabel = sandbox => {
@@ -53,8 +54,11 @@ const SandboxSelector = ({
         }));
       } catch (e) {
         if (e.name !== "AbortError") {
-          console.error(e);
-          reportAsyncError(new Error(`Failed to load sandboxes. ${e.message}`));
+          reportAsyncError(
+            new UserReportableError(`Failed to load sandboxes.`, {
+              originatingError: e
+            })
+          );
           return undefined;
         }
       }

--- a/src/view/dataElements/xdmObject/components/schemaMetaSelector.jsx
+++ b/src/view/dataElements/xdmObject/components/schemaMetaSelector.jsx
@@ -20,6 +20,7 @@ import useReportAsyncError from "../../../utils/useReportAsyncError";
 import useIsFirstRender from "../../../utils/useIsFirstRender";
 import usePrevious from "../../../utils/usePrevious";
 import ExtensionViewContext from "../../../components/extensionViewContext";
+import UserReportableError from "../../../errors/userReportableError";
 
 const SchemaMetaSelector = ({
   defaultSelectedSchemaMeta,
@@ -54,9 +55,10 @@ const SchemaMetaSelector = ({
         }));
       } catch (e) {
         if (e.name !== "AbortError") {
-          console.error(e);
           reportAsyncError(
-            new Error(`Failed to load schema metadata. ${e.message}`)
+            new UserReportableError("Failed to load schema metadata.", {
+              originatingError: e
+            })
           );
         }
         throw e;

--- a/src/view/dataElements/xdmObject/helpers/schemaSelection/fetchSchemaUsingAsyncErrorReporting.js
+++ b/src/view/dataElements/xdmObject/helpers/schemaSelection/fetchSchemaUsingAsyncErrorReporting.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import fetchSchema from "../fetchSchema";
+import UserReportableError from "../../../../errors/userReportableError";
 
 const fetchSchemaUsingAsyncErrorReporting = async ({
   orgId,
@@ -34,8 +35,11 @@ const fetchSchemaUsingAsyncErrorReporting = async ({
     });
   } catch (e) {
     if (e.name !== "AbortError") {
-      console.error(e);
-      reportAsyncError(new Error(`Failed to load schema. ${e.message}`));
+      reportAsyncError(
+        new UserReportableError("Failed to load schema.", {
+          originatingError: e
+        })
+      );
     }
   }
 

--- a/src/view/dataElements/xdmObject/helpers/schemaSelection/getInitialFormStateUsingAsyncErrorReporting.js
+++ b/src/view/dataElements/xdmObject/helpers/schemaSelection/getInitialFormStateUsingAsyncErrorReporting.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import getInitialFormState from "../getInitialFormState";
+import UserReportableError from "../../../../errors/userReportableError";
 
 const getInitialFormStateUsingAsyncErrorReporting = ({
   schema,
@@ -25,8 +26,11 @@ const getInitialFormStateUsingAsyncErrorReporting = ({
       schema
     });
   } catch (e) {
-    console.error(e);
-    reportAsyncError(new Error(`Failed to process schema. ${e.message}`));
+    reportAsyncError(
+      new UserReportableError("Failed to process schema.", {
+        originatingError: e
+      })
+    );
   }
 
   return initialValues;

--- a/src/view/dataElements/xdmObject/helpers/schemaSelection/loadDefaultSandbox.js
+++ b/src/view/dataElements/xdmObject/helpers/schemaSelection/loadDefaultSandbox.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import fetchSandboxes from "../fetchSandboxes";
 import DEFAULT_SANDBOX_NAME from "../../constants/defaultSandboxName";
+import UserReportableError from "../../../../errors/userReportableError";
 
 const loadDefaultSandbox = async ({
   orgId,
@@ -27,15 +28,21 @@ const loadDefaultSandbox = async ({
       imsAccess
     }));
   } catch (e) {
-    console.error(e);
-    reportAsyncError(new Error(`Failed to load sandboxes. ${e.message}`));
+    reportAsyncError(
+      new UserReportableError("Failed to load sandboxes.", {
+        originatingError: e
+      })
+    );
     return undefined;
   }
 
   if (!sandboxes.length) {
     reportAsyncError(
-      new Error(
-        "You do not have access to any sandboxes. Please contact your administrator to be assigned appropriate rights."
+      new UserReportableError(
+        "You do not have access to any sandboxes. Please contact your administrator to be assigned appropriate rights.",
+        {
+          additionalInfoUrl: "https://adobe.ly/3gHkqLF"
+        }
       )
     );
     return undefined;
@@ -60,7 +67,7 @@ const loadDefaultSandbox = async ({
 
     if (!defaultSandbox) {
       reportAsyncError(
-        new Error(
+        new UserReportableError(
           "The sandbox used to build the XDM object no longer exists. You will need to re-create this data element using a schema from a different sandbox."
         )
       );

--- a/src/view/dataElements/xdmObject/helpers/schemaSelection/loadDefaultSchemaMetaForSandbox.js
+++ b/src/view/dataElements/xdmObject/helpers/schemaSelection/loadDefaultSchemaMetaForSandbox.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import fetchSchemasMeta from "../fetchSchemasMeta";
+import UserReportableError from "../../../../errors/userReportableError";
 
 const loadDefaultSchemaMetaForSandbox = async ({
   orgId,
@@ -31,9 +32,10 @@ const loadDefaultSchemaMetaForSandbox = async ({
     }));
   } catch (e) {
     if (e.name !== "AbortError") {
-      console.error(e);
       reportAsyncError(
-        new Error(`Failed to load schema metadata. ${e.message}`)
+        new UserReportableError(`Failed to load schema metadata.`, {
+          originatingError: e
+        })
       );
     }
     return undefined;

--- a/src/view/errors/userReportableError.js
+++ b/src/view/errors/userReportableError.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * This error class should be used to report a specific error
+ * message to the user at the nearest ErrorBoundary. If an error
+ * is thrown that is not a UserReportableError, the ErrorBoundary
+ * will instead show a generic message.
+ */
+class UserReportableError extends Error {
+  constructor(message, { originatingError, additionalInfoUrl } = {}) {
+    if (originatingError) {
+      // Log the originating error so that
+      // we can still see its stack trace.
+      console.error(originatingError);
+    }
+
+    if (originatingError instanceof UserReportableError) {
+      message = `${message} ${originatingError.message}`;
+      additionalInfoUrl =
+        additionalInfoUrl ?? originatingError.additionalInfoUrl;
+    }
+
+    super(message);
+    this.name = "UserReportableError";
+    this.message = message;
+    this.additionalInfoUrl = additionalInfoUrl;
+  }
+}
+
+export default UserReportableError;

--- a/src/view/utils/fetchFromPlatform.js
+++ b/src/view/utils/fetchFromPlatform.js
@@ -23,11 +23,14 @@ const IMS_HOST_PREFIX_STAGING = "ims-na1-stg1";
 const ERROR_CODE_INVALID_ACCESS_TOKEN = "401013";
 const ERROR_CODE_USER_REGION_MISSING = "403027";
 
+// The internet connection may not actually be the problem here. There could
+// be other problems with the SSL handshake, CORS preflight request, etc.
 const ERROR_UNABLE_TO_CONNECT_TO_SERVER =
-  "A connection to the server could not be established.";
+  "A connection to the server could not be established. You may be disconnected from the internet. Please check your connection and try again.";
 const ERROR_UNEXPECTED_SERVER_RESPONSE =
   "An unexpected server response was received.";
-const ERROR_INVALID_ACCESS_TOKEN = "Your access token appears to be invalid.";
+const ERROR_INVALID_ACCESS_TOKEN =
+  "Your access token appears to be invalid. Please try logging in again.";
 const ERROR_NO_AEP_ACCESS =
   "Your organization is not provisioned for Adobe Experience Platform. Please contact your organization administrator.";
 const ERROR_RESOURCE_NOT_FOUND = "The resource was not found.";

--- a/src/view/utils/fetchFromPlatform.js
+++ b/src/view/utils/fetchFromPlatform.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import getBaseRequestHeaders from "./getBaseRequestHeaders";
 import * as HTTP_STATUS from "../constants/httpStatus";
+import UserReportableError from "../errors/userReportableError";
 
 const PLATFORM_HOST_PROD = "https://platform.adobe.io";
 const PLATFORM_HOST_STAGING = "https://platform-stage.adobe.io";
@@ -22,11 +23,14 @@ const IMS_HOST_PREFIX_STAGING = "ims-na1-stg1";
 const ERROR_CODE_INVALID_ACCESS_TOKEN = "401013";
 const ERROR_CODE_USER_REGION_MISSING = "403027";
 
-const ERROR_UNEXPECTED_SERVER_RESPONSE = "Unexpected server response.";
+const ERROR_UNABLE_TO_CONNECT_TO_SERVER =
+  "A connection to the server could not be established.";
+const ERROR_UNEXPECTED_SERVER_RESPONSE =
+  "An unexpected server response was received.";
 const ERROR_INVALID_ACCESS_TOKEN = "Your access token appears to be invalid.";
 const ERROR_NO_AEP_ACCESS =
-  "Your user account is not enabled for AEP access. Please contact your organization administrator.";
-const ERROR_RESOURCE_NOT_FOUND = "Resource not found.";
+  "Your organization is not provisioned for Adobe Experience Platform. Please contact your organization administrator.";
+const ERROR_RESOURCE_NOT_FOUND = "The resource was not found.";
 
 /**
  * Returns the platform hostname appropriate for the token IMS environment
@@ -63,17 +67,25 @@ export default async ({ orgId, imsAccess, path, params, headers, signal }) => {
   const host = getHost({ imsAccess });
   const baseRequestHeaders = getBaseRequestHeaders({ orgId, imsAccess });
   const queryString = params ? `?${params.toString()}` : "";
+  let response;
 
-  const response = await fetch(`${host}${path}${queryString}`, {
-    headers: {
-      ...baseRequestHeaders,
-      ...headers
-    },
-    signal
-  });
+  try {
+    response = await fetch(`${host}${path}${queryString}`, {
+      headers: {
+        ...baseRequestHeaders,
+        ...headers
+      },
+      signal
+    });
+  } catch (e) {
+    if (e.name === "AbortError") {
+      throw e;
+    }
+    throw new UserReportableError(ERROR_UNABLE_TO_CONNECT_TO_SERVER);
+  }
 
   if (response.status === HTTP_STATUS.NOT_FOUND) {
-    throw new Error(ERROR_RESOURCE_NOT_FOUND);
+    throw new UserReportableError(ERROR_RESOURCE_NOT_FOUND);
   }
 
   let parsedBody;
@@ -86,25 +98,25 @@ export default async ({ orgId, imsAccess, path, params, headers, signal }) => {
     if (e.name === "AbortError") {
       throw e;
     }
-    throw new Error(ERROR_UNEXPECTED_SERVER_RESPONSE);
+    throw new UserReportableError(ERROR_UNEXPECTED_SERVER_RESPONSE);
   }
 
   if (
     response.status === HTTP_STATUS.UNAUTHORIZED &&
     parsedBody.error_code === ERROR_CODE_INVALID_ACCESS_TOKEN
   ) {
-    throw new Error(ERROR_INVALID_ACCESS_TOKEN);
+    throw new UserReportableError(ERROR_INVALID_ACCESS_TOKEN);
   }
 
   if (
     response.status === HTTP_STATUS.FORBIDDEN &&
     parsedBody.error_code === ERROR_CODE_USER_REGION_MISSING
   ) {
-    throw new Error(ERROR_NO_AEP_ACCESS);
+    throw new UserReportableError(ERROR_NO_AEP_ACCESS);
   }
 
   if (!response.ok) {
-    throw new Error(ERROR_UNEXPECTED_SERVER_RESPONSE);
+    throw new UserReportableError(ERROR_UNEXPECTED_SERVER_RESPONSE);
   }
 
   return {

--- a/test/functional/dataElements/xdmObject/helpers/platformMocks.js
+++ b/test/functional/dataElements/xdmObject/helpers/platformMocks.js
@@ -36,7 +36,7 @@ export const sandboxesUserRegionMissing = RequestMock()
   );
 
 export const sandboxesNonJsonBody = RequestMock()
-  .onRequestTo(SANDBOXES_ENDPOINT_REGEX)
+  .onRequestTo({ url: SANDBOXES_ENDPOINT_REGEX, method: HTTP_METHOD_GET })
   .respond("non-json body", 200, responseHeaders);
 
 export const sandboxesEmpty = RequestMock()
@@ -157,9 +157,6 @@ export const sandboxesMultipleWithoutDefault = RequestMock()
 export const schemasMetaSingle = RequestMock()
   .onRequestTo({
     url: SCHEMAS_ENDPOINT_REGEX,
-    headers: {
-      "x-sandbox-name": "prod"
-    },
     method: HTTP_METHOD_GET
   })
   .respond(
@@ -182,9 +179,6 @@ export const schemasMetaSingle = RequestMock()
 export const schemasMetaMultiple = RequestMock()
   .onRequestTo({
     url: SCHEMAS_ENDPOINT_REGEX,
-    headers: {
-      "x-sandbox-name": "prod"
-    },
     method: HTTP_METHOD_GET
   })
   .respond(
@@ -314,9 +308,6 @@ export const schemasMetaPagingTitles = [
 export const schemasMetaPagingMock = RequestMock()
   .onRequestTo({
     url: SCHEMAS_ENDPOINT_REGEX,
-    headers: {
-      "x-sandbox-name": "prod"
-    },
     method: HTTP_METHOD_GET
   })
   .respond((req, res) => {

--- a/test/functional/dataElements/xdmObject/xdmObjectSchemaSelection.spec.js
+++ b/test/functional/dataElements/xdmObject/xdmObjectSchemaSelection.spec.js
@@ -46,11 +46,11 @@ test.requestHooks(platformMocks.sandboxesUnauthorized)(
 );
 
 test.requestHooks(platformMocks.sandboxesUserRegionMissing)(
-  "displays error when user is not provisioned for AEP",
+  "displays error when org is not provisioned for AEP",
   async () => {
     await initializeExtensionView();
     await errorBoundaryMessage.expectMessage(
-      /Your user account is not enabled for AEP access\. Please contact your organization administrator\./
+      /Your organization is not provisioned for Adobe Experience Platform\. Please contact your organization administrator\./
     );
   }
 );
@@ -240,7 +240,7 @@ test("attempts to load a schema that has been deleted", async () => {
       data: {}
     }
   });
-  await errorBoundaryMessage.expectMessage(/Resource not found/);
+  await errorBoundaryMessage.expectMessage(/The resource was not found\./);
 });
 
 test.requestHooks(

--- a/test/functional/helpers/clientScripts/preventSpecificErrorsFromFailingTests.js
+++ b/test/functional/helpers/clientScripts/preventSpecificErrorsFromFailingTests.js
@@ -22,8 +22,20 @@ governing permissions and limitations under the License.
  * only want the test to fail if there's something wrong with our code.
  */
 window.addEventListener("error", event => {
-  // UserReportableErrors are for error cases we often test for, so they should not
-  // go unhandled because that would automatically fail the test.
+  // UserReportableErrors are intended to be shown to the user within an error boundary.
+  // Error boundaries, however, do not change the error from being considered unhandled to
+  // handled. Because of this, the unhandled error would typically make TestCafe fail
+  // the test. We often test these error cases though, so the fact that the error went
+  // unhandled really shouldn't fail the test. This code prevents the error from failing
+  // the test. Note that if the error is a UserReportableError but was _not_ displayed inside an
+  // error boundary (for example, the error was thrown within async code and reportAsyncError
+  // was not used), we would really prefer that it fail the test, but this is unfeasible
+  // because the error boundary only exposes the error to our application code _after_ our
+  // event listener here as been called. In other words, there's no robust way to know
+  // whether the error will end up being reported in the error boundary. We're left to
+  // assume it will.
+  // https://github.com/facebook/react/issues/10474
+  // https://github.com/facebook/react/issues/13681
   if (event.error && event.error.name === "UserReportableError") {
     console.error(event.error);
     event.preventDefault();

--- a/test/functional/helpers/clientScripts/preventSpecificErrorsFromFailingTests.js
+++ b/test/functional/helpers/clientScripts/preventSpecificErrorsFromFailingTests.js
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * This script is loaded by TestCafe onto the page that's under test. TestCafe by default
+ * fails tests if it sees there were unhandled errors. In our case, we want to test foreseeable
+ * error cases, like when the user doesn't have access to Adobe Experience Platform. In these cases,
+ * we throw a UserReportableError, which is displayed by the ErrorBoundary with an appropriate message.
+ * From a functional test, we then assert that the ErrorBoundary displays the error we expected to be
+ * shown. The ErrorBoundary, however, does not prevent the error from continuing to bubble up through
+ * the stack trace, so TestCafe would typically see that as an unhandled error. This script helps
+ * ensure that errors we've foreseen and appropriately handled are not considered unhandled. We typically
+ * only want the test to fail if there's something wrong with our code.
+ */
+window.addEventListener("error", event => {
+  // UserReportableErrors are errors that we've
+  if (event.error && event.error.name === "UserReportableError") {
+    console.error(event.error);
+    event.preventDefault();
+  }
+
+  // This error comes through React-Spectrum but can be safely ignored.
+  // https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120
+  if (event.message === "ResizeObserver loop limit exceeded") {
+    event.preventDefault();
+  }
+});

--- a/test/functional/helpers/clientScripts/preventSpecificErrorsFromFailingTests.js
+++ b/test/functional/helpers/clientScripts/preventSpecificErrorsFromFailingTests.js
@@ -22,13 +22,15 @@ governing permissions and limitations under the License.
  * only want the test to fail if there's something wrong with our code.
  */
 window.addEventListener("error", event => {
-  // UserReportableErrors are errors that we've
+  // UserReportableErrors are for error cases we often test for, so they should not
+  // go unhandled because that would automatically fail the test.
   if (event.error && event.error.name === "UserReportableError") {
     console.error(event.error);
     event.preventDefault();
   }
 
-  // This error comes through React-Spectrum but can be safely ignored.
+  // This error comes through React-Spectrum but can be safely ignored and should
+  // not automatically fail the test.
   // https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120
   if (event.message === "ResizeObserver loop limit exceeded") {
     event.preventDefault();

--- a/test/functional/helpers/createFixture.js
+++ b/test/functional/helpers/createFixture.js
@@ -14,6 +14,11 @@ import path from "path";
 import fs from "fs";
 import { RequestMock } from "testcafe";
 
+const preventSpecificErrorsFromFailingTestsPath = path.join(
+  __dirname,
+  "clientScripts/preventSpecificErrorsFromFailingTests.js"
+);
+
 const extensionBridgeMockContent = fs.readFileSync(
   path.join(__dirname, "../helpers/extensionBridgeMock.js")
 );
@@ -32,7 +37,8 @@ const createFixture = ({
 }) => {
   let fixt = fixture(title)
     .page(path.join(__dirname, "../../../dist/view", viewPath))
-    .requestHooks(extensionBridgeRequestMock, ...requestHooks);
+    .requestHooks(extensionBridgeRequestMock, ...requestHooks)
+    .clientScripts(preventSpecificErrorsFromFailingTestsPath);
 
   if (requiresAdobeIOIntegration) {
     fixt = fixt.meta("requiresAdobeIOIntegration", true);


### PR DESCRIPTION
… shouldn't be exposed to customers.

<!--- Provide a general summary of your changes in the Title above -->

## Description
When an error occurs, sometimes we catch that error and throw a different error with a message that's appropriately customer-facing (e.g., `Your organization is not provisioned for Adobe Experience Platform. Please contact your organization administrator.`). Unless our code is 100% bulletproof, there are likely other errors that are thrown as well that we don't catch and throw a new error for (e.g., `ReferenceError: nonexistent is not defined`). The messages from these latter errors were previously being displayed to the user. We don't want to be exposing these types of error messages to customers though because they're daunting and the user can't do anything about them anyway.

This PR segregates the two types of errors by providing a UserReportableError class that we can use to throw the former types of errors. When the error boundary sees an error that is not a UserReportableError, it will just display `An unexpected error occurred. Please try again later.` rather than the error's actual message.

Also note that TestCafe by default fails a test if it sees there are any unhandled errors that occur during the test. Because our error boundary doesn't prevent errors from bubbling up the stack (they aren't "caught" in the literal sense), TestCafe would see them as unhandled and fail the test, even if we were trying to test an error case (e.g., that we were telling the user that they didn't have AEP access when they didn't). To get around this issue, we had configured TestCafe with `ignoreJsErrors: true`. Unforunately, this made it so that _unforseen_ errors were not causing tests to fail, when really it would be great if those types of errors failed the test. This PR makes it so that UserReportableError errors are not considered unhandled, so only the errors that are not UserReportableError instances will be seen as unhandled by TestCafe and fail the tests. This allows up to remove the `ignoreJsErrors: true` TestCafe configuration.

Clear as mud?

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Better error reporting for our customers.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
