### PR TITLE
Fix build script so no zombies when there is an error

### DIFF
--- a/scripts/helpers/build.js
+++ b/scripts/helpers/build.js
@@ -85,17 +85,23 @@ module.exports = (options = {}) => {
   ]);
 
   if (watch) {
-    const babelWatchSubprocess = run("babel", [
-      libInDir,
-      "--out-dir",
-      libOutDir,
-      "--watch",
-      "--skip-initial-build",
-      "--ignore",
-      alloyInFile
-    ]);
+    const babelWatchSubprocess = spawn(
+      "babel",
+      [
+        libInDir,
+        "--out-dir",
+        libOutDir,
+        "--watch",
+        "--skip-initial-build",
+        "--ignore",
+        alloyInFile
+      ],
+      { stdio: "inherit" }
+    );
     // cleanup this process on ctrl-c
-    process.on("exit", () => babelWatchSubprocess.kill());
+    process.on("exit", () => {
+      babelWatchSubprocess.kill();
+    });
   }
 
   // The package resolution in launch does not follow dependencies on npm packages, so we need to build our


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I attempted to fix this in #140, but I didn't realize that run returns a promise and not the handle to the subprocess.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
