### PR TITLE
Make spacing between elements consistent

### DIFF
--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { object, string } from "yup";
-import { Form, Item } from "@adobe/react-spectrum";
+import { Item } from "@adobe/react-spectrum";
 import {
   ComboBox,
   Picker,
@@ -28,6 +28,7 @@ import singleDataElementRegex from "../constants/singleDataElementRegex";
 import DecisionScopes from "../components/decisionScopes";
 import ExtensionViewForm from "../components/extensionViewForm";
 import { DATA_ELEMENT_REQUIRED } from "../constants/validationErrorMessages";
+import FormElementContainer from "../components/formElementContainer";
 
 const getInitialValues = ({ initInfo }) => {
   const {
@@ -129,7 +130,7 @@ const SendEvent = ({ initInfo, formikProps, registerImperativeFormApi }) => {
   }
 
   return (
-    <Form>
+    <FormElementContainer>
       <Picker
         data-test-id="instanceNameField"
         name="instanceName"
@@ -207,7 +208,7 @@ const SendEvent = ({ initInfo, formikProps, registerImperativeFormApi }) => {
         Render visual personalization decisions
       </Checkbox>
       <DecisionScopes />
-    </Form>
+    </FormElementContainer>
   );
 };
 

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -14,15 +14,7 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { FieldArray } from "formik";
 import { object, string, array, mixed } from "yup";
-import {
-  Flex,
-  Form,
-  Item,
-  Radio,
-  Button,
-  Well,
-  Text
-} from "@adobe/react-spectrum";
+import { Item, Radio, Button, Well, Text } from "@adobe/react-spectrum";
 import Delete from "@spectrum-icons/workflow/Delete";
 import render from "../spectrum3Render";
 import ExtensionView from "../components/spectrum3ExtensionView";
@@ -39,6 +31,7 @@ import {
   RadioGroup
 } from "../components/formikReactSpectrum3";
 import DataElementSelector from "../components/dataElementSelector";
+import FormElementContainer from "../components/formElementContainer";
 
 const FORM = { value: "form", label: "Fill out a form" };
 const DATA_ELEMENT = { value: "dataElement", label: "Use a data element" };
@@ -222,7 +215,7 @@ const validationSchema = object().shape({
 
 const ConsentObject = ({ value, index }) => {
   return (
-    <Flex direction="column">
+    <>
       <Picker
         data-test-id="standardPicker"
         name={`consent[${index}].standard`}
@@ -331,7 +324,7 @@ const ConsentObject = ({ value, index }) => {
           </RadioGroupWithDataElement>
         </>
       )}
-    </Flex>
+    </>
   );
 };
 
@@ -357,7 +350,7 @@ const SetConsent = ({ initInfo, formikProps, registerImperativeFormApi }) => {
   const { values } = formikProps;
 
   return (
-    <Form>
+    <FormElementContainer>
       <Picker
         data-test-id="instanceNamePicker"
         name="instanceName"
@@ -397,38 +390,43 @@ const SetConsent = ({ initInfo, formikProps, registerImperativeFormApi }) => {
           name="consent"
           render={arrayHelpers => (
             <>
-              <Flex>
-                <Button
-                  variant="primary"
-                  data-test-id="addConsentButton"
-                  onPress={() => {
-                    arrayHelpers.push(createBlankConsentObject());
-                  }}
-                  marginStart="auto"
-                >
-                  Add Consent Object
-                </Button>
-              </Flex>
-              {values.consent.map((value, index) => (
-                <Well data-test-id={`consentObject${index}`} key={index}>
-                  <ConsentObject value={value} index={index} />
-                  {values.consent.length > 1 && (
-                    <div className="u-gapTop">
-                      <Button
-                        variant="secondary"
-                        onPress={() => {
-                          arrayHelpers.remove(index);
-                        }}
-                        aria-label="Delete"
-                        data-test-id="deleteConsentButton"
-                      >
-                        <Delete />
-                        <Text>Delete Consent Object</Text>
-                      </Button>
-                    </div>
-                  )}
-                </Well>
-              ))}
+              <Button
+                variant="primary"
+                data-test-id="addConsentButton"
+                onPress={() => {
+                  arrayHelpers.push(createBlankConsentObject());
+                }}
+                marginStart="auto"
+              >
+                Add Consent Object
+              </Button>
+              <div>
+                {values.consent.map((value, index) => (
+                  <Well
+                    data-test-id={`consentObject${index}`}
+                    key={`consentObject${index}`}
+                    marginBottom="size-250"
+                  >
+                    <FormElementContainer>
+                      <ConsentObject value={value} index={index} />
+                      {values.consent.length > 1 && (
+                        <Button
+                          variant="secondary"
+                          onPress={() => {
+                            arrayHelpers.remove(index);
+                          }}
+                          aria-label="Delete"
+                          data-test-id="deleteConsentButton"
+                          alignSelf="flex-start"
+                        >
+                          <Delete />
+                          <Text>Delete Consent Object</Text>
+                        </Button>
+                      )}
+                    </FormElementContainer>
+                  </Well>
+                ))}
+              </div>
             </>
           )}
         />
@@ -443,7 +441,7 @@ const SetConsent = ({ initInfo, formikProps, registerImperativeFormApi }) => {
           />
         </DataElementSelector>
       )}
-    </Form>
+    </FormElementContainer>
   );
 };
 

--- a/src/view/components/decisionScopes.jsx
+++ b/src/view/components/decisionScopes.jsx
@@ -102,20 +102,18 @@ const DecisionScopes = ({
 
   return (
     <Fragment>
-      <div className="u-gapBottom">
-        <RadioGroup
-          name="decisionsInputMethod"
-          orientation="horizontal"
-          label="Decision Scopes"
-        >
-          <Radio data-test-id="constantOptionField" value={CONSTANT}>
-            Manually enter scopes
-          </Radio>
-          <Radio data-test-id="dataElementOptionField" value={DATA_ELEMENT}>
-            Provide data element returning array of scopes
-          </Radio>
-        </RadioGroup>
-      </div>
+      <RadioGroup
+        name="decisionsInputMethod"
+        orientation="horizontal"
+        label="Decision Scopes"
+      >
+        <Radio data-test-id="constantOptionField" value={CONSTANT}>
+          Manually enter scopes
+        </Radio>
+        <Radio data-test-id="dataElementOptionField" value={DATA_ELEMENT}>
+          Provide data element returning array of scopes
+        </Radio>
+      </RadioGroup>
       {decisionsInputMethod === DATA_ELEMENT && (
         <div className="FieldSubset">
           <DataElementSelector>

--- a/src/view/components/formElementContainer.jsx
+++ b/src/view/components/formElementContainer.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Flex } from "@adobe/react-spectrum";
+import PropTypes from "prop-types";
+import "./formElementContainer.styl";
+
+const FormElementContainer = ({ children, ...otherProps }) => {
+  return (
+    <Flex
+      direction="column"
+      UNSAFE_className="FormElementContainer"
+      {...otherProps}
+    >
+      {children}
+    </Flex>
+  );
+};
+
+FormElementContainer.propTypes = {
+  children: PropTypes.node
+};
+
+export default FormElementContainer;

--- a/src/view/components/formElementContainer.styl
+++ b/src/view/components/formElementContainer.styl
@@ -1,0 +1,7 @@
+.FormElementContainer > * {
+  margin-top: var(--spectrum-global-dimension-size-100);
+}
+
+.FormElementContainer > :first-child {
+  margin-top: 0;
+}

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -16,7 +16,6 @@ import { FieldArray } from "formik";
 import { array, boolean, object, string } from "yup";
 import {
   Button,
-  Form,
   Heading,
   Item,
   ProgressCircle,
@@ -35,6 +34,7 @@ import FillParentAndCenterChildren from "../components/fillParentAndCenterChildr
 import NamespaceComponent from "../components/namespaceComponent";
 import getDefaultIdentifier from "./identityMap/utils/getDefaultIdentifier";
 import DataElementSelector from "../components/dataElementSelector";
+import FormElementContainer from "../components/formElementContainer";
 import {
   Checkbox,
   Picker,
@@ -300,7 +300,7 @@ function IdentityMap({ initInfo, formikProps, registerImperativeFormApi }) {
                                       marginTop="size-250"
                                       marginBottom="size-250"
                                     >
-                                      <Form>
+                                      <FormElementContainer>
                                         <DataElementSelector>
                                           <TextField
                                             data-test-id={`identity${index}idField${identifierIndex}`}
@@ -346,7 +346,7 @@ function IdentityMap({ initInfo, formikProps, registerImperativeFormApi }) {
                                         >
                                           Primary
                                         </Checkbox>
-                                      </Form>
+                                      </FormElementContainer>
                                       {values.identities[index].identifiers
                                         .length > 1 && (
                                         <Button

--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 
 import React, { useEffect, useReducer } from "react";
 import PropTypes from "prop-types";
-import { Form, ProgressCircle, Flex } from "@adobe/react-spectrum";
+import { ProgressCircle, Flex } from "@adobe/react-spectrum";
+import FormElementContainer from "../components/formElementContainer";
 import ExtensionView from "../components/spectrum3ExtensionView";
 import getValueFromFormState from "./xdmObject/helpers/getValueFromFormState";
 import validate from "./xdmObject/helpers/validate";
@@ -201,7 +202,7 @@ const XdmObject = ({ initInfo, formikProps, registerImperativeFormApi }) => {
 
   return (
     <div>
-      <Form>
+      <FormElementContainer>
         <SandboxSelector
           defaultSelectedSandbox={defaultSelectedSandbox}
           onSelectionChange={onSandboxSelectionChange}
@@ -223,7 +224,7 @@ const XdmObject = ({ initInfo, formikProps, registerImperativeFormApi }) => {
             }
           />
         ) : null}
-      </Form>
+      </FormElementContainer>
       {editorAreaContent}
     </div>
   );

--- a/src/view/dataElements/xdmObject/components/booleanEdit.jsx
+++ b/src/view/dataElements/xdmObject/components/booleanEdit.jsx
@@ -14,10 +14,10 @@ import { useField } from "formik";
 import React, { useEffect, useState } from "react";
 import {
   Radio,
-  RadioGroup as ReactSpectrumRadioGroup,
-  Form
+  RadioGroup as ReactSpectrumRadioGroup
 } from "@adobe/react-spectrum";
 import PropTypes from "prop-types";
+import FormElementContainer from "../../../components/formElementContainer";
 import {
   TextField,
   RadioGroup as FormikRadioGroup
@@ -55,7 +55,7 @@ const BooleanEdit = props => {
   }, [fieldName]);
 
   return (
-    <Form>
+    <FormElementContainer>
       <ReactSpectrumRadioGroup
         label="Input Method"
         orientation="horizontal"
@@ -104,7 +104,7 @@ const BooleanEdit = props => {
           />
         </DataElementSelector>
       )}
-    </Form>
+    </FormElementContainer>
   );
 };
 

--- a/src/view/global.styl
+++ b/src/view/global.styl
@@ -67,3 +67,5 @@ body,
 .AdvancedSettings {
   margin-top: 0;
 }
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have been using Form to get the margin between elements, but sometimes the width:100% was messing up other things (like the width of Wells). Additionally the first element in a form would have extra margin above it. And beyond that, the browser would give warnings for nested form elements. This PR replaces that need with FormElementContainer

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
