### PR TITLE
Fix broken test helper where off-screen pickers couldn't be clicked

### DIFF
--- a/test/functional/helpers/spectrum3.js
+++ b/test/functional/helpers/spectrum3.js
@@ -28,6 +28,10 @@ const invalidAttribute = "aria-invalid";
 // a similar approach when using Cypress or React Testing Library
 const compatibleClick = async selector => {
   await t.expect(selector.exists).ok();
+  // Normally TestCafe will automatically scroll the target into view,
+  // but since we are using a client function to perform the click
+  // TestCafe doesn't automatically scroll.
+  await t.scrollIntoView(selector);
   await ClientFunction(() => {
     const element = selector();
     element.click();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Aaron was getting two test failures, but locally I was only getting one. Watching the failed test run, I could see that the picker wasn't being scrolled into view. I'm guessing that Aaron was getting another failure based upon the window size of his test runner. This change ensures the picker is scrolled into view before it is clicked on.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
