### PR TITLE
Made XDM object edit form sticky.

### DIFF
--- a/src/view/dataElements/xdmObject/components/arrayEdit.jsx
+++ b/src/view/dataElements/xdmObject/components/arrayEdit.jsx
@@ -23,6 +23,7 @@ import getInitialFormState, {
 } from "../helpers/getInitialFormState";
 import { PARTS, WHOLE } from "../constants/populationStrategy";
 import { ARRAY, OBJECT } from "../constants/schemaType";
+import FormElementContainer from "../../../components/formElementContainer";
 
 /**
  * Displayed when the WHOLE population strategy is selected.
@@ -140,7 +141,7 @@ const ArrayEdit = props => {
   } = formStateNode;
 
   return (
-    <div>
+    <FormElementContainer>
       {isPartsPopulationStrategySupported && (
         <FormikRadioGroup
           label="Population Strategy"
@@ -167,7 +168,7 @@ const ArrayEdit = props => {
           />
         )}
       </div>
-    </div>
+    </FormElementContainer>
   );
 };
 

--- a/src/view/dataElements/xdmObject/components/editor.jsx
+++ b/src/view/dataElements/xdmObject/components/editor.jsx
@@ -30,7 +30,16 @@ const Editor = ({
       minHeight={0}
       gap="size-200"
     >
-      <View width="size-3600" flexShrink={0} overflow="auto">
+      {
+        // Minimum of 300px wide, but can expand. This is for when the user
+        // has nodes with really long text or they expand several nodes, making
+        // the tree very wide. Another option is to limit the width, but show a
+        // horizontal scrollbar. Be aware that limiting the width has an interesting
+        // side effect in Safari, because Safari doesn't allow you to scroll the page by
+        // scrolling the scroll wheel or swiping when the cursor is over an element
+        // that has a scrollbar (vertical or horizontal).
+      }
+      <View flex="1 0 300px">
         <XdmTree selectedNodeId={selectedNodeId} onSelect={setSelectedNodeId} />
       </View>
       {
@@ -38,8 +47,11 @@ const Editor = ({
         // flex container. In our case, we want the flex child to shrink
         // to its content so that it can float within the parent using
         // position="sticky". This is why we have alignSelf="flex-start".
+        // We have 450px as min width because the tree can stretch in width
+        // and we don't want to shrink too much. If there isn't enough
+        // space on the page, the page will receive a horizontal scrollbar.
       }
-      <View alignSelf="flex-start" position="sticky" top={0}>
+      <View flex="1 0 450px" alignSelf="flex-start" position="sticky" top={0}>
         {selectedNodeId ? (
           <NodeEdit
             onNodeSelect={setSelectedNodeId}

--- a/src/view/dataElements/xdmObject/components/editor.jsx
+++ b/src/view/dataElements/xdmObject/components/editor.jsx
@@ -33,7 +33,13 @@ const Editor = ({
       <View width="size-3600" flexShrink={0} overflow="auto">
         <XdmTree selectedNodeId={selectedNodeId} onSelect={setSelectedNodeId} />
       </View>
-      <div>
+      {
+        // By default, this flex child will stretch to the height of the
+        // flex container. In our case, we want the flex child to shrink
+        // to its content so that it can float within the parent using
+        // position="sticky". This is why we have alignSelf="flex-start".
+      }
+      <View alignSelf="flex-start" position="sticky" top={0}>
         {selectedNodeId ? (
           <NodeEdit
             onNodeSelect={setSelectedNodeId}
@@ -45,7 +51,7 @@ const Editor = ({
             previouslySavedSchemaInfo={previouslySavedSchemaInfo}
           />
         )}
-      </div>
+      </View>
     </Flex>
   );
 };

--- a/src/view/dataElements/xdmObject/components/objectEdit.jsx
+++ b/src/view/dataElements/xdmObject/components/objectEdit.jsx
@@ -12,12 +12,13 @@ governing permissions and limitations under the License.
 
 import React from "react";
 import PropTypes from "prop-types";
-import { Radio, Flex } from "@adobe/react-spectrum";
+import { Radio } from "@adobe/react-spectrum";
 import { useField } from "formik";
 import FormikRadioGroup from "../../../components/formikReactSpectrum3/formikRadioGroup";
 import FormikTextField from "../../../components/formikReactSpectrum3/formikTextField";
 import DataElementSelector from "../../../components/dataElementSelector";
 import { PARTS, WHOLE } from "../constants/populationStrategy";
+import FormElementContainer from "../../../components/formElementContainer";
 
 /**
  * The form for editing a node that is an object type.
@@ -31,7 +32,7 @@ const ObjectEdit = ({ fieldName }) => {
   } = formStateNode;
 
   return (
-    <Flex gap="size-100">
+    <FormElementContainer>
       {isPartsPopulationStrategySupported && (
         <FormikRadioGroup
           label="Population Strategy"
@@ -57,7 +58,7 @@ const ObjectEdit = ({ fieldName }) => {
           />
         </DataElementSelector>
       )}
-    </Flex>
+    </FormElementContainer>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you expand the schema tree within the XDM Object data element view so that it becomes really long, then you scroll down, the edit form on the right side is scrolled up out of sight. This makes for an awkward experience, especially when you select a node on the XDM tree and expect something to change on the right side of the view. This really bugged me, so I decided to fix. Now the edit form on the right side is "sticky" and won't scroll out of view.

I also fixed a spacing inconsistency between the array edit form and the object edit form.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

This is with the sticky edit form:
![image](https://user-images.githubusercontent.com/210820/126009943-16d5d05c-ed29-4c06-9ce7-f76f466e3a3e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
