### PR TITLE
Use sentence-case in labels, titles, descriptions, etc.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "AEP Web SDK",
+  "displayName": "Adobe Experience Platform Web SDK",
   "name": "adobe-alloy",
   "iconPath": "resources/images/icon.svg",
   "exchangeUrl": "https://exchange.adobe.com/experiencecloud.details.106387.aep-web-sdk.html",
@@ -113,7 +113,7 @@
   },
   "actions": [
     {
-      "displayName": "Reset Event Merge ID",
+      "displayName": "Reset event merge ID",
       "name": "reset-event-merge-id",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -131,7 +131,7 @@
       "viewPath": "actions/resetEventMergeId.html"
     },
     {
-      "displayName": "Send Event",
+      "displayName": "Send event",
       "name": "send-event",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -182,7 +182,7 @@
       "viewPath": "actions/sendEvent.html"
     },
     {
-      "displayName": "Set Consent",
+      "displayName": "Set consent",
       "name": "set-consent",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -277,20 +277,20 @@
   "events": [
     {
       "name": "decisions-received",
-      "displayName": "Decisions Received (DEPRECATED)",
+      "displayName": "Decisions received (DEPRECATED)",
       "libPath": "dist/lib/events/decisionsReceived/index.js",
       "schema": {}
     },
     {
       "name": "send-event-complete",
-      "displayName": "Send Event Complete",
+      "displayName": "Send event complete",
       "libPath": "dist/lib/events/sendEventComplete/index.js",
       "schema": {}
     }
   ],
   "dataElements": [
     {
-      "displayName": "Event Merge ID",
+      "displayName": "Event merge ID",
       "name": "event-merge-id",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -308,7 +308,7 @@
       "viewPath": "dataElements/eventMergeId.html"
     },
     {
-      "displayName": "Identity Map",
+      "displayName": "Identity map",
       "name": "identity-map",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -337,7 +337,7 @@
       "viewPath": "dataElements/identityMap.html"
     },
     {
-      "displayName": "XDM Object",
+      "displayName": "XDM object",
       "name": "xdm-object",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",

--- a/src/view/actions/resetEventMergeId.jsx
+++ b/src/view/actions/resetEventMergeId.jsx
@@ -49,7 +49,7 @@ const ResetEventMergeId = () => {
             <FormikTextField
               data-test-id="eventMergeIdField"
               name="eventMergeId"
-              label="Event Merge ID"
+              label="Event merge ID"
               description="Please specify the data element that represents the event merge ID you would like to reset."
               width="size-5000"
               isRequired

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -146,7 +146,7 @@ const SendEvent = () => {
             <FormikTextField
               data-test-id="xdmField"
               name="xdm"
-              label="XDM Data"
+              label="XDM data"
               description="Provide a data element which returns an object matching your XDM schema."
               width="size-5000"
             />
@@ -174,7 +174,7 @@ const SendEvent = () => {
             <FormikTextField
               data-test-id="datasetIdField"
               name="datasetId"
-              description="Send data to a different dataset than what's been provided in the Edge configuration."
+              description="Send data to a different dataset than what's been provided in the datastream."
               label="Dataset ID"
               width="size-5000"
             />

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -240,7 +240,7 @@ const ConsentObject = ({ value, index }) => {
           <FormikRadioGroupWithDataElement
             dataTestIdPrefix="general"
             name={`consent[${index}].general`}
-            label="General Consent"
+            label="General consent"
             dataElementDescription={
               'This data element should resolve to "in" or "out".'
             }
@@ -340,7 +340,7 @@ const SetConsent = () => {
             <FormikTextField
               data-test-id="identityMapField"
               name="identityMap"
-              label="Identity Map"
+              label="Identity map"
               description="Provide a data element which returns a custom identity map object as part of the setConsent command."
               width="size-5000"
             />
@@ -348,7 +348,7 @@ const SetConsent = () => {
           <FormikRadioGroup
             name="inputMethod"
             orientation="horizontal"
-            label="Consent Information"
+            label="Consent information"
           >
             <Radio data-test-id="inputMethodFormRadio" value={FORM.value}>
               {FORM.label}
@@ -373,7 +373,7 @@ const SetConsent = () => {
                     }}
                     marginStart="auto"
                   >
-                    Add Consent Object
+                    Add consent object
                   </Button>
                   <Flex direction="column" gap="size-250">
                     {values.consent.map((value, index) => (
@@ -394,7 +394,7 @@ const SetConsent = () => {
                               alignSelf="flex-start"
                             >
                               <Delete />
-                              <Text>Delete Consent Object</Text>
+                              <Text>Delete consent object</Text>
                             </Button>
                           )}
                         </FormElementContainer>
@@ -409,7 +409,7 @@ const SetConsent = () => {
             <DataElementSelector>
               <FormikTextField
                 data-test-id="dataElementField"
-                label="Data Element"
+                label="Data element"
                 name="dataElement"
                 isRequired
                 width="size-5000"

--- a/src/view/components/codeField.jsx
+++ b/src/view/components/codeField.jsx
@@ -24,7 +24,7 @@ import CodePreview from "./codePreview";
 const CodeField = ({
   "data-test-id": dataTestId,
   label,
-  buttonLabelSuffix = label,
+  buttonLabelSuffix,
   name,
   description,
   language,

--- a/src/view/components/decisionScopes.jsx
+++ b/src/view/components/decisionScopes.jsx
@@ -86,7 +86,7 @@ const DecisionScopes = () => {
       <FormikRadioGroup
         name="decisionsInputMethod"
         orientation="horizontal"
-        label="Decision Scopes"
+        label="Decision scopes"
       >
         <Radio data-test-id="constantOptionField" value={CONSTANT}>
           Manually enter scopes
@@ -100,7 +100,7 @@ const DecisionScopes = () => {
           <DataElementSelector>
             <FormikTextField
               data-test-id="scopeDataElementField"
-              label="Data Element"
+              label="Data element"
               name="decisionScopesDataElement"
               description="This data element should resolve to an array of scopes."
               width="size-5000"

--- a/src/view/components/formikReactSpectrum3/formikRadioGroupWithDataElement.jsx
+++ b/src/view/components/formikReactSpectrum3/formikRadioGroupWithDataElement.jsx
@@ -136,7 +136,7 @@ const FormikRadioGroupWithDataElement = ({
               error={dataElementTouched && error ? error : undefined}
             >
               <TextField
-                label="Data Element"
+                label="Data element"
                 value={dataElementText}
                 data-test-id={`${dataTestIdPrefix}DataElementField`}
                 onChange={newValue => setValues("dataElement", newValue)}

--- a/src/view/configuration/advancedSection.jsx
+++ b/src/view/configuration/advancedSection.jsx
@@ -65,9 +65,9 @@ const AdvancedSection = ({ instanceFieldName }) => {
           <DataElementSelector>
             <FormikTextField
               data-test-id="edgeBasePathField"
-              label="Edge Base Path"
+              label="Edge base path"
               name={`${instanceFieldName}.edgeBasePath`}
-              description="Specifies the base path of the endpoint used to interact with Adobe Services. This setting should only be changed if you are not intending to use the default production environment."
+              description="Specifies the base path of the endpoint used to interact with Adobe services. This setting should only be changed if you are not intending to use the default production environment."
               width="size-5000"
               isRequired
             />

--- a/src/view/configuration/basicSection.jsx
+++ b/src/view/configuration/basicSection.jsx
@@ -137,7 +137,7 @@ const BasicSection = ({ instanceFieldName, initInfo }) => {
       instanceValues.name !== instanceValues.persistedName ? (
         <Alert
           data-test-id="nameChangeAlert"
-          title="Potential Problems Due to Name Change"
+          title="Potential problems due to name change"
           variant="notice"
           width="size-5000"
         >
@@ -151,7 +151,7 @@ const BasicSection = ({ instanceFieldName, initInfo }) => {
         <DataElementSelector>
           <FormikTextField
             data-test-id="orgIdField"
-            label="IMS Organization ID"
+            label="IMS organization ID"
             name={`${instanceFieldName}.orgId`}
             description="Your assigned Experience Cloud organization ID."
             isRequired
@@ -168,12 +168,12 @@ const BasicSection = ({ instanceFieldName, initInfo }) => {
         <DataElementSelector>
           <FormikTextField
             data-test-id="edgeDomainField"
-            label="Edge Domain"
+            label="Edge domain"
             name={`${instanceFieldName}.edgeDomain`}
             description="The domain that will be used to interact with
-                        Adobe Services. Update this setting if you have
-                        mapped one of your first party domains (using
-                        CNAME) to an Adobe provisioned domain."
+                        Adobe services. Update this setting if you have
+                        mapped one of your first-party domains (using
+                        CNAME) to an Adobe-provisioned domain."
             isRequired
             width="size-5000"
           />

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -158,7 +158,7 @@ const Configuration = ({ initInfo }) => {
           return (
             <div>
               <Flex alignItems="center">
-                <Heading level={3}>SDK Instances</Heading>
+                <Heading level={3}>SDK instances</Heading>
                 <Button
                   data-test-id="addInstanceButton"
                   variant="secondary"
@@ -172,11 +172,11 @@ const Configuration = ({ initInfo }) => {
                   }}
                   marginStart="auto"
                 >
-                  Add Instance
+                  Add instance
                 </Button>
               </Flex>
               <Tabs
-                aria-label="SDK Instances"
+                aria-label="SDK instances"
                 items={instances}
                 selectedKey={selectedTabKey}
                 onSelectionChange={setSelectedTabKey}
@@ -185,7 +185,7 @@ const Configuration = ({ initInfo }) => {
                   {instances.map((instance, index) => {
                     return (
                       <Item key={index}>
-                        {instance.name || "Unnamed Instance"}
+                        {instance.name || "Unnamed instance"}
                       </Item>
                     );
                   })}
@@ -226,7 +226,7 @@ const Configuration = ({ initInfo }) => {
                                 variant="secondary"
                                 disabled={instances.length === 1}
                               >
-                                Delete Instance
+                                Delete instance
                               </Button>
                               {close => (
                                 <Dialog data-test-id="resourceUsageDialog">

--- a/src/view/configuration/dataCollectionSection.jsx
+++ b/src/view/configuration/dataCollectionSection.jsx
@@ -49,7 +49,7 @@ const contextOptions = [
     testId: "contextEnvironmentField"
   },
   {
-    label: "Place Context (information about the user's location)",
+    label: "Place context (information about the user's location)",
     value: "placeContext",
     testId: "contextPlaceContextField"
   }
@@ -139,8 +139,8 @@ const DataCollectionSection = ({ instanceFieldName }) => {
       <FormElementContainer>
         <CodeField
           data-test-id="onBeforeEventSendEditButton"
-          label="On Before Event Send Callback"
-          buttonLabelSuffix="On Before Event Send Callback Code"
+          label="On before event send callback"
+          buttonLabelSuffix="on before event send callback code"
           name={`${instanceFieldName}.onBeforeEventSend`}
           description='Callback function for modifying data before each event is sent to the server. A variable named "content" will be available for use within your custom code. Modify "content.xdm" as needed to transform data before it is sent to the server.'
           language="javascript"
@@ -162,7 +162,7 @@ const DataCollectionSection = ({ instanceFieldName }) => {
               <Flex gap="size-100">
                 <FormikTextField
                   data-test-id="downloadLinkQualifierField"
-                  label="Download Link Qualifier"
+                  label="Download link qualifier"
                   name={`${instanceFieldName}.downloadLinkQualifier`}
                   description="Regular expression that qualifies a link URL as a download link."
                   width="size-5000"
@@ -184,7 +184,7 @@ const DataCollectionSection = ({ instanceFieldName }) => {
                   }}
                   marginTop="size-300"
                 >
-                  Test Regex
+                  Test regex
                 </ActionButton>
                 <RestoreDefaultValueButton
                   data-test-id="downloadLinkQualifierRestoreButton"
@@ -218,7 +218,7 @@ const DataCollectionSection = ({ instanceFieldName }) => {
             CONTEXT_GRANULARITY.SPECIFIC && (
             <FieldSubset>
               <FormikCheckboxGroup
-                aria-label="Context Data Categories"
+                aria-label="Context data categories"
                 name={`${instanceFieldName}.context`}
               >
                 {contextOptions.map(contextOption => {

--- a/src/view/configuration/edgeConfigurationFreeformInputMethod.jsx
+++ b/src/view/configuration/edgeConfigurationFreeformInputMethod.jsx
@@ -21,7 +21,7 @@ const EdgeConfigurationFreeformInputMethod = ({ name }) => {
       <DataElementSelector>
         <FormikTextField
           data-test-id="productionEnvironmentTextfield"
-          label="Production Environment ID"
+          label="Production environment ID"
           name={`${name}.edgeConfigId`}
           description="This datastream environment will be used when the Launch library is in a production environment."
           isRequired
@@ -31,7 +31,7 @@ const EdgeConfigurationFreeformInputMethod = ({ name }) => {
       <DataElementSelector>
         <FormikTextField
           data-test-id="stagingEnvironmentTextfield"
-          label="Staging Environment ID"
+          label="Staging environment ID"
           name={`${name}.stagingEdgeConfigId`}
           description="This datastream environment will be used when the Launch library is in a staging environment."
           width="size-5000"
@@ -40,7 +40,7 @@ const EdgeConfigurationFreeformInputMethod = ({ name }) => {
       <DataElementSelector>
         <FormikTextField
           data-test-id="developmentEnvironmentTextfield"
-          label="Development Environment ID"
+          label="Development environment ID"
           name={`${name}.developmentEdgeConfigId`}
           description="This datastream environment will be used when the Launch library is in a development environment."
           width="size-5000"

--- a/src/view/configuration/edgeConfigurationSelector.jsx
+++ b/src/view/configuration/edgeConfigurationSelector.jsx
@@ -62,7 +62,7 @@ const EdgeConfigurationSelector = ({
   }
 
   return (
-    <Alert variant="negative" title="No Datastreams" width="size-5000">
+    <Alert variant="negative" title="No datastreams" width="size-5000">
       No datastreams exist for your organization. See{" "}
       <Link>
         <a
@@ -70,7 +70,7 @@ const EdgeConfigurationSelector = ({
           target="_blank"
           rel="noopener noreferrer"
         >
-          Configuring a Datastream
+          Configuring a datastream
         </a>
       </Link>{" "}
       for more information.

--- a/src/view/configuration/edgeConfigurationsSection.jsx
+++ b/src/view/configuration/edgeConfigurationsSection.jsx
@@ -380,7 +380,7 @@ const EdgeConfigurationsSection = ({
         // To prevent this confusion, we'll hide the radios on all but the first instance.
         instanceIndex === 0 && (
           <FormikRadioGroup
-            label="Input Method"
+            label="Input method"
             name={`${instanceFieldName}.edgeConfigInputMethod`}
             orientation="horizontal"
           >

--- a/src/view/configuration/environmentsSelector.jsx
+++ b/src/view/configuration/environmentsSelector.jsx
@@ -26,7 +26,7 @@ const EnvironmentsSelector = ({
       {firstPageOfEachEnvironmentType.production.length > 0 ? (
         <EnvironmentField
           data-test-id="productionEnvironmentComboBox"
-          label="Production Environment"
+          label="Production environment"
           name={`${name}.productionEnvironment`}
           description="This datastream environment will be used when the Launch library is in a production environment."
           type="production"
@@ -48,7 +48,7 @@ const EnvironmentsSelector = ({
       {firstPageOfEachEnvironmentType.staging.length > 0 ? (
         <EnvironmentField
           data-test-id="stagingEnvironmentComboBox"
-          label="Staging Environment"
+          label="Staging environment"
           name={`${name}.stagingEnvironment`}
           description="This datastream environment will be used when the Launch library is in a staging environment."
           type="staging"
@@ -69,7 +69,7 @@ const EnvironmentsSelector = ({
       {firstPageOfEachEnvironmentType.development.length > 0 ? (
         <EnvironmentField
           data-test-id="developmentEnvironmentComboBox"
-          label="Development Environment"
+          label="Development environment"
           name={`${name}.developmentEnvironment`}
           description="This datastream environment will be used when the Launch library is in a development environment."
           type="development"

--- a/src/view/configuration/personalizationSection.jsx
+++ b/src/view/configuration/personalizationSection.jsx
@@ -60,7 +60,8 @@ const PersonalizationSection = ({ instanceFieldName }) => {
       <FormElementContainer>
         <CodeField
           data-test-id="prehidingStyleEditButton"
-          label="Prehiding Style"
+          label="Prehiding style"
+          buttonLabelSuffix="prehiding style"
           name={`${instanceFieldName}.prehidingStyle`}
           description="A CSS style definition that will be used to hide content areas of your web page while personalized content is being loaded from the server."
           language="css"
@@ -71,8 +72,8 @@ const PersonalizationSection = ({ instanceFieldName }) => {
         <CodePreview
           data-test-id="copyToClipboardPrehidingSnippetButton"
           value={prehidingSnippet}
-          label="Prehiding Snippet"
-          buttonLabel="Copy Prehiding Snippet To Clipboard"
+          label="Prehiding snippet"
+          buttonLabel="Copy prehiding snippet to clipboard"
           description="To avoid flicker from occurring while the Launch library is being loaded, place this prehiding snippet within the <head> tag of your HTML page."
           onPress={() => {
             copyToClipboard(prehidingSnippet);

--- a/src/view/configuration/privacySection.jsx
+++ b/src/view/configuration/privacySection.jsx
@@ -73,7 +73,7 @@ const PrivacySection = ({ instanceFieldName }) => {
         <FormikRadioGroupWithDataElement
           dataTestIdPrefix="defaultConsent"
           name={`${instanceFieldName}.defaultConsent`}
-          label="Default Consent (not persisted to user's profile)"
+          label="Default consent (not persisted to user's profile)"
           dataElementDescription={
             'This data element should resolve to "in", "out", or "pending".'
           }

--- a/src/view/dataElements/eventMergeId.jsx
+++ b/src/view/dataElements/eventMergeId.jsx
@@ -40,14 +40,14 @@ const EventMergeId = () => {
         <FillParentAndCenterChildren>
           <Alert
             variant="informative"
-            title="Event Merge ID Caching"
+            title="Event merge ID caching"
             width="size-6000"
           >
             This data element will provide an event merge ID. Regardless of what
             you choose for the data element storage duration in Launch, the
             value of this data element will remain the same until either the
             visitor to your website leaves the current page or the event merge
-            ID is reset using the Reset Event Merge ID action.
+            ID is reset using the <b>Reset event merge ID</b> action.
           </Alert>
           <View
             marginTop="size-200"

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -216,7 +216,7 @@ const IdentityMap = () => {
                   }}
                   marginStart="auto"
                 >
-                  Add Identity
+                  Add identity
                 </Button>
               </Flex>
               {/*
@@ -236,7 +236,7 @@ const IdentityMap = () => {
                   {identities.map((identity, index) => {
                     return (
                       <Item key={index}>
-                        {identity.namespaceCode || "Unnamed Identity"}
+                        {identity.namespaceCode || "Unnamed identity"}
                       </Item>
                     );
                   })}
@@ -274,7 +274,7 @@ const IdentityMap = () => {
                                         );
                                       }}
                                     >
-                                      Add Identifier
+                                      Add identifier
                                     </Button>
                                   </Flex>
                                   <Flex direction="column" gap="size-250">
@@ -295,7 +295,7 @@ const IdentityMap = () => {
                                             </DataElementSelector>
                                             <FormikPicker
                                               data-test-id={`identity${index}authenticatedStateField${identifierIndex}`}
-                                              label="Authenticated State"
+                                              label="Authenticated state"
                                               name={`identities.${index}.identifiers.${identifierIndex}.authenticatedState`}
                                               width="size-5000"
                                             >
@@ -347,7 +347,7 @@ const IdentityMap = () => {
                                               marginTop="size-150"
                                             >
                                               <DeleteIcon />
-                                              <Text>Delete Identifier</Text>
+                                              <Text>Delete identifier</Text>
                                             </Button>
                                           )}
                                         </Well>
@@ -369,7 +369,7 @@ const IdentityMap = () => {
                                 }}
                               >
                                 <DeleteIcon />
-                                Delete Identity
+                                Delete identity
                               </Button>
                             </View>
                           )}

--- a/src/view/dataElements/xdmObject/components/arrayEdit.jsx
+++ b/src/view/dataElements/xdmObject/components/arrayEdit.jsx
@@ -34,7 +34,7 @@ const WholePopulationStrategyForm = ({ fieldName }) => (
     <FormikTextField
       data-test-id="valueField"
       name={`${fieldName}.value`}
-      label="Data Element"
+      label="Data element"
       description="This data element should resolve to an array."
       width="size-5000"
     />
@@ -111,7 +111,7 @@ const PartsPopulationStrategyForm = ({
             }}
             variant="primary"
           >
-            Add Item
+            Add item
           </Button>
         </Flex>
       );
@@ -144,7 +144,7 @@ const ArrayEdit = props => {
     <FormElementContainer>
       {isPartsPopulationStrategySupported && (
         <FormikRadioGroup
-          label="Population Strategy"
+          label="Population strategy"
           name={`${fieldName}.populationStrategy`}
           orientation="horizontal"
         >

--- a/src/view/dataElements/xdmObject/components/autoPopulationAlert.jsx
+++ b/src/view/dataElements/xdmObject/components/autoPopulationAlert.jsx
@@ -23,44 +23,44 @@ const AutoPopulationAlert = ({ formStateNode }) => {
   const { autoPopulationSource, contextKey, schema } = formStateNode;
 
   return (
-    <Alert variant="informative" title="Auto-populated Field">
+    <Alert variant="informative" title="Auto-populated field">
       {autoPopulationSource === ALWAYS && (
         <p>
           The value for this field will be auto-populated when this data element
-          is provided as the XDM object for a &quot;Send Event&quot; action.
-          This value cannot be overwritten.
+          is provided as the XDM object for a <b>Send event</b> action. This
+          value cannot be overwritten.
         </p>
       )}
       {autoPopulationSource === COMMAND && (
         <p>
-          The value for this field may be specified as an option to the
-          &quot;Send Event&quot; action. You can provide a value here, but it
-          will be overwritten if this field is also specified in the action.
+          The value for this field may be specified as an option to the{" "}
+          <b>Send event</b> action. You can provide a value here, but it will be
+          overwritten if this field is also specified in the action.
         </p>
       )}
       {autoPopulationSource === CONTEXT && schema.type !== OBJECT && (
         <p>
           The value for this field will be auto-populated when this data element
-          is provided as the XDM object for a &quot;Send Event&quot; action if
-          the &quot;{contextKey}&quot; context is configured. If you provide a
-          value here, it will overwrite the auto-populated value.
+          is provided as the XDM object for a <b>Send event</b> action if the{" "}
+          <b>{contextKey}</b> context is configured. If you provide a value
+          here, it will overwrite the auto-populated value.
         </p>
       )}
       {autoPopulationSource === CONTEXT && schema.type === OBJECT && (
         <p>
           Some of the attributes of this field will be auto-populated when this
-          data element is provided as the XDM object for a &quot;Send
-          Event&quot; action if the &quot;{contextKey}&quot; context is
-          configured. If you provide a data element here, it will overwrite the
-          auto-populated value.
+          data element is provided as the XDM object for a <b>Send event</b>{" "}
+          action if the <b>{contextKey}</b> context is configured. If you
+          provide a data element here, it will overwrite the auto-populated
+          value.
         </p>
       )}
       {autoPopulationSource === CONTEXT && (
         <p>
-          You can configure which contexts are enabled in the AEP Web SDK
-          extension configuration in the section &quot;Data Collection&quot;
-          under the options labeled &quot;When sending event data, automatically
-          include&quot;.
+          You can configure which contexts are enabled in the Adobe Experience
+          Platform Web SDK extension configuration in the <b>Data collection</b>{" "}
+          section under the options labeled{" "}
+          <b>When sending event data, automatically include</b>.
         </p>
       )}
     </Alert>

--- a/src/view/dataElements/xdmObject/components/booleanEdit.jsx
+++ b/src/view/dataElements/xdmObject/components/booleanEdit.jsx
@@ -52,7 +52,7 @@ const BooleanEdit = props => {
   return (
     <FormElementContainer>
       <RadioGroup
-        label="Input Method"
+        label="Input method"
         orientation="horizontal"
         value={inputMethod}
         onChange={newInputMethod => {
@@ -64,13 +64,13 @@ const BooleanEdit = props => {
           data-test-id="dataElementInputMethodField"
           value={inputMethods.DATA_ELEMENT}
         >
-          Provide Data Element
+          Provide data element
         </Radio>
         <Radio
           data-test-id="valueInputMethodField"
           value={inputMethods.CONSTANT}
         >
-          Select Value
+          Select value
         </Radio>
       </RadioGroup>
       {inputMethod === inputMethods.CONSTANT ? (
@@ -80,7 +80,7 @@ const BooleanEdit = props => {
           orientation="horizontal"
         >
           <Radio data-test-id="constantNoValueField" value="">
-            No Value
+            No value
           </Radio>
           <Radio data-test-id="constantTrueField" value>
             True

--- a/src/view/dataElements/xdmObject/components/noSelectedNodeView.jsx
+++ b/src/view/dataElements/xdmObject/components/noSelectedNodeView.jsx
@@ -36,7 +36,7 @@ const NoSelectedNodeView = ({ schema, previouslySavedSchemaInfo }) => {
     <div>
       {isSchemaMismatched && (
         <View marginBottom="size-100">
-          <Alert variant="notice" title="Schema Changed">
+          <Alert variant="notice" title="Schema changed">
             The XDM schema has changed since the XDM object was last saved.
             After the next save, any fields that no longer exist on the XDM
             schema will also no longer be included on the XDM object.
@@ -67,9 +67,9 @@ const NoSelectedNodeView = ({ schema, previouslySavedSchemaInfo }) => {
           </IndicatorDescription>
           <IndicatorDescription indicator={<AsteriskIcon size="XS" />}>
             Fields that may be auto-populated when this data element is passed
-            to the XDM option of the &quot;Send Event&quot; action have this
-            icon. Hovering over the icon shows a popup explaining when the field
-            will be auto-populated.
+            to the XDM option of the <b>Send event</b> action have this icon.
+            Hovering over the icon shows a popup explaining when the field will
+            be auto-populated.
           </IndicatorDescription>
         </Flex>
       </div>

--- a/src/view/dataElements/xdmObject/components/objectEdit.jsx
+++ b/src/view/dataElements/xdmObject/components/objectEdit.jsx
@@ -35,7 +35,7 @@ const ObjectEdit = ({ fieldName }) => {
     <FormElementContainer>
       {isPartsPopulationStrategySupported && (
         <FormikRadioGroup
-          label="Population Strategy"
+          label="Population strategy"
           name={`${fieldName}.populationStrategy`}
           orientation="horizontal"
         >
@@ -52,7 +52,7 @@ const ObjectEdit = ({ fieldName }) => {
           <FormikTextField
             data-test-id="valueField"
             name={`${fieldName}.value`}
-            label="Data Element"
+            label="Data element"
             description="This data element should resolve to an object."
             width="size-5000"
           />

--- a/src/view/dataElements/xdmObject/constants/contextKey.js
+++ b/src/view/dataElements/xdmObject/constants/contextKey.js
@@ -14,6 +14,6 @@ governing permissions and limitations under the License.
 export const WEB = "Web";
 export const DEVICE = "Device";
 export const ENVIRONMENT = "Environment";
-export const PLACE_CONTEXT = "Place Context";
+export const PLACE_CONTEXT = "Place context";
 // Not Applicable - Meaning this field is not autopopulated by a context configuration
 export const NA = "NA";

--- a/src/view/dataElements/xdmObject/helpers/computePopulationNote.js
+++ b/src/view/dataElements/xdmObject/helpers/computePopulationNote.js
@@ -20,16 +20,16 @@ export default ({ formStateNode, isAncestorUsingWholePopulationStrategy }) => {
     return "";
   }
   if (autoPopulationSource === ALWAYS) {
-    return "This field will be auto-populated when this data element is provided as the XDM object for a Send Event action";
+    return 'This field will be auto-populated when this data element is provided as the XDM object for a "Send event" action';
   }
   if (autoPopulationSource === COMMAND) {
-    return "This field may be specified as an option to the Send Event action";
+    return 'This field may be specified as an option to the "Send event" action';
   }
   if (autoPopulationSource === CONTEXT && schema.type !== OBJECT) {
-    return "This field may be auto-populated when provided as the XDM object for a Send Event action";
+    return 'This field may be auto-populated when provided as the XDM object for a "Send event" action';
   }
   if (autoPopulationSource === CONTEXT && schema.type === OBJECT) {
-    return "Some of the attributes of this field may be auto-populated when provided as the XDM object for a Send Event action";
+    return 'Some of the attributes of this field may be auto-populated when provided as the XDM object for a "Send event" action';
   }
   return "";
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
@jonsnyder noticed that Spectrum indicates that sentence case should be used "for all aspects of designing Adobe product experiences, including titles and UI elements (e.g., tooltips, tabs, menu items)." More info [here](https://spectrum.adobe.com/page/grammar-and-mechanics/#Sentence-case).

There's also this guidance:

> Use quotation marks (“”) only when quoting someone’s words or when referring to a file or asset name.
> Don’t use them when directly referring to interface elements. See the Typography page for guidance on using bold text to do so.

I tried to make appropriate updates throughout the extension. I also changed the display name of the extension from AEP Web SDK to Adobe Experience Platform Web SDK. We had used the acronym previously because there wasn't enough space in the Launch UI to show the full name, but that has since been changed in Launch to accommodate.


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. - Not yet. I'll do this after tomorrow's test fest.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
