### PR TITLE
Use namespace name for identity tab labels when possible.

### DIFF
--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -198,6 +198,11 @@ const IdentityMap = () => {
       setSelectedTabKey(String(identityIndexContainingErrors));
     }
   });
+
+  const getNamespaceByCode = code => {
+    return namespaces.find(namespace => namespace.code === code);
+  };
+
   return (
     <>
       <FieldArray
@@ -234,11 +239,11 @@ const IdentityMap = () => {
               >
                 <TabList>
                   {identities.map((identity, index) => {
-                    return (
-                      <Item key={index}>
-                        {identity.namespaceCode || "Unnamed identity"}
-                      </Item>
-                    );
+                    const label =
+                      getNamespaceByCode(identity.namespaceCode)?.name ||
+                      identity.namespaceCode ||
+                      "Unnamed identity";
+                    return <Item key={index}>{label}</Item>;
                   })}
                 </TabList>
                 <TabPanels>

--- a/test/functional/dataElements/identityMap/identityMap.spec.js
+++ b/test/functional/dataElements/identityMap/identityMap.spec.js
@@ -59,6 +59,7 @@ test("initializes identity map with default settings", async () => {
   await identities[0].identifiers[0].primary.expectUnchecked();
   await identities[0].identifiers[0].deleteButton.expectNotExists();
   await identities[0].deleteButton.expectNotExists();
+  await tabs.expectTabLabels(["Unnamed identity"]);
 });
 
 test("initializes identity map with sorted namespaces", async () => {
@@ -332,6 +333,7 @@ test("initialization of namespaces as picker with namespace names", async () => 
 
   await identities[0].namespacePicker.selectOption("Adobe Analytics");
   await identities[0].identifiers[0].id.typeText("test3");
+  await tabs.expectTabLabels(["Adobe Analytics"]);
 
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
@@ -353,6 +355,21 @@ test("when namespaces call fails instantiate form with textfield", async () => {
   await extensionViewController.init();
 
   await identities[0].namespace.expectValue("");
+
+  await identities[0].namespace.typeText("CUSTOM_IDENTITY");
+  await identities[0].identifiers[0].id.typeText("test3");
+  await tabs.expectTabLabels(["CUSTOM_IDENTITY"]);
+
+  await extensionViewController.expectIsValid();
+  await extensionViewController.expectSettings({
+    CUSTOM_IDENTITY: [
+      {
+        id: "test3",
+        authenticatedState: "ambiguous",
+        primary: false
+      }
+    ]
+  });
 });
 
 test("shows error for multiple primary identifiers", async () => {

--- a/test/functional/helpers/spectrum3.js
+++ b/test/functional/helpers/spectrum3.js
@@ -304,18 +304,31 @@ const componentWrappers = {
     };
   },
   tabs() {
+    // Normally we would incorporate the selector for the
+    // parent Tabs component by doing something like
+    // selector.find(tabCssSelector).withExactText(label)
+    // This would allow us to ensure we're searching for a tab
+    // within a specific Tabs instance when multiple Tabs instances
+    // are on the page. Unfortunately, React-Spectrum has a bug where
+    // data attributes added to the Tabs component are never
+    // added to any underlying DOM elements. So, we'll just search
+    // for any tab on the page that contains the label.
+    // https://github.com/adobe/react-spectrum/issues/2002
     return {
+      async expectTabLabels(labels) {
+        for (let i = 0; i < labels.length; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await t
+            .expect(tabSelector.nth(i).withExactText(labels[i]).exists)
+            .ok(
+              `Tab with label ${
+                labels[i]
+              } does not exist when it is expected to exist.`
+            );
+        }
+        await t.expect(tabSelector.count).eql(labels.length);
+      },
       async selectTab(label) {
-        // Normally we would incorporate the selector for the
-        // parent Tabs component by doing something like
-        // selector.find(tabCssSelector).withExactText(label)
-        // This would allow us to ensure we're searching for a tab
-        // within a specific Tabs instance when multiple Tabs instances
-        // are on the page. Unfortunately, React-Spectrum has a bug where
-        // data attributes added to the Tabs component are never
-        // added to any underlying DOM elements. So, we'll just search
-        // for any tab on the page that contains the label.
-        // https://github.com/adobe/react-spectrum/issues/2002
         await t.click(tabSelector.withExactText(label));
       }
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The namespace picker shows the friendly names of the namespaces, but once you select a namespace, the active tab's label changes to the namespace code and not the friendly name. This change makes it so the friendly name of the namespace is shown, when possible.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
