### PR TITLE
PDCL-6586 Cleanse identity map of invalid IDs.

### DIFF
--- a/src/lib/dataElements/identityMap/createIdentityMap.js
+++ b/src/lib/dataElements/identityMap/createIdentityMap.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Provided an identity map, returns a new identity map that excludes any
+ * identifiers whose ID values are not populated strings. Namespaces
+ * without identifiers are also excluded.
+ */
+module.exports = ({ logger }) => {
+  return settings => {
+    // settings _are_ the identity map
+    return Object.keys(settings).reduce((newIdentityMap, namespace) => {
+      const filteredIdentifiers = settings[namespace].filter(({ id }, i) => {
+        const isValidId = typeof id === "string" && id.length;
+        if (!isValidId) {
+          logger.log(
+            `The identifier at ${namespace}[${i}] was removed from the identity map because its ID is not a populated string. Its ID value is:`,
+            id
+          );
+        }
+        return isValidId;
+      });
+
+      if (filteredIdentifiers.length) {
+        newIdentityMap[namespace] = filteredIdentifiers;
+      } else {
+        logger.log(
+          `The ${namespace} namespace was removed from the identity map because it contains no identifiers.`
+        );
+      }
+      return newIdentityMap;
+    }, {});
+  };
+};

--- a/src/lib/dataElements/identityMap/index.js
+++ b/src/lib/dataElements/identityMap/index.js
@@ -10,4 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = settings => settings;
+const createIdentityMap = require("./createIdentityMap");
+
+const identityMap = createIdentityMap({ logger: turbine.logger });
+
+module.exports = settings => {
+  return identityMap(settings);
+};

--- a/src/view/dataElements/identityMap.jsx
+++ b/src/view/dataElements/identityMap.jsx
@@ -294,6 +294,7 @@ const IdentityMap = () => {
                                                 data-test-id={`identity${index}idField${identifierIndex}`}
                                                 label="ID"
                                                 name={`identities.${index}.identifiers.${identifierIndex}.id`}
+                                                description="If the ID value is not a populated string, this identifier will automatically be removed from the identity map."
                                                 isRequired
                                                 width="size-5000"
                                               />

--- a/test/unit/lib/dataElements/identityMap/createIdentityMap.spec.js
+++ b/test/unit/lib/dataElements/identityMap/createIdentityMap.spec.js
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import cleanseIdentityMap from "../../../../../src/lib/dataElements/identityMap/createIdentityMap";
+
+describe("createIdentityMap", () => {
+  let logger;
+  let identityMap;
+
+  beforeEach(() => {
+    logger = jasmine.createSpyObj("logger", ["log"]);
+    identityMap = cleanseIdentityMap({
+      logger
+    });
+  });
+
+  it("returns identity map after removing identifiers without IDs and namespaces without identifiers", () => {
+    const input = {
+      EMAIL: [
+        {
+          id: undefined,
+          authenticatedState: "loggedOut",
+          primary: true
+        },
+        {
+          id: null
+        },
+        {
+          id: true
+        },
+        {
+          id: false
+        },
+        {
+          id: {}
+        },
+        {
+          id: ""
+        },
+        {
+          id() {}
+        },
+        {
+          id: "example@example.com"
+        }
+      ],
+      PHONE: [
+        {
+          id: undefined,
+          authenticatedState: "authenticated"
+        }
+      ],
+      AAID: [],
+      CORE: [
+        {
+          id: "ABC123",
+          authenticatedState: "ambiguous"
+        }
+      ]
+    };
+    const result = identityMap(input);
+
+    expect(result).toEqual({
+      EMAIL: [
+        {
+          id: "example@example.com"
+        }
+      ],
+      CORE: [{ id: "ABC123", authenticatedState: "ambiguous" }]
+    });
+
+    const expectedLogArgsByCallIndex = [];
+
+    input.EMAIL.forEach((identifier, i) => {
+      if (identifier.id !== "example@example.com") {
+        expectedLogArgsByCallIndex.push([
+          `The identifier at EMAIL[${i}] was removed from the identity map because its ID is not a populated string. Its ID value is:`,
+          identifier.id
+        ]);
+      }
+    });
+
+    expectedLogArgsByCallIndex.push([
+      "The identifier at PHONE[0] was removed from the identity map because its ID is not a populated string. Its ID value is:",
+      undefined
+    ]);
+
+    expectedLogArgsByCallIndex.push([
+      "The PHONE namespace was removed from the identity map because it contains no identifiers."
+    ]);
+
+    expectedLogArgsByCallIndex.push([
+      "The AAID namespace was removed from the identity map because it contains no identifiers."
+    ]);
+
+    expect(logger.log).toHaveBeenCalledTimes(10);
+
+    // It's not only important that log() was called with the right arguments, but also
+    // that it was called in the right order. For example, for a given namespace, it looks
+    // cleaner if the removal of an identifier at index 0 is logged to the console before
+    // the removal of an identifier at index 1. This assertion helps ensure we don't implement
+    // a reverse loop to slice identifiers off the identity map and inadvertently log the
+    // removals in reverse order.
+    expect(logger.log.calls.allArgs()).toEqual(expectedLogArgsByCallIndex);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This removes identifiers from the identity map whose values are not populated strings. Namespaces without identifiers are also excluded.

Documentation changes can be found [here](https://git.corp.adobe.com/AdobeDocs/experience-platform.en/pull/1881).
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-5871
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Customers using our IdentityMap data element in the Launch extension are finding it hard to conditionally remove the identity item from the map when the visitor logs out and the `id` field is empty (as an example).

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
