### PR TITLE
PDCL-6321 Removed auto-population notice from identity map field.

### DIFF
--- a/src/view/dataElements/xdmObject/constants/defaultFormState.js
+++ b/src/view/dataElements/xdmObject/constants/defaultFormState.js
@@ -49,7 +49,6 @@ export default {
 
   eventType: COMMAND,
   eventMergeId: COMMAND,
-  identityMap: COMMAND,
 
   device: CONTEXT_DEVICE,
   "device.screenHeight": CONTEXT_DEVICE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We no longer have an identity map field in the Send Event action.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-6321
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
It's a misleading notice.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
