### PR TITLE
Fixing breadcrumb alignment.

### DIFF
--- a/src/view/dataElements/xdmObject/components/nodeEdit.styl
+++ b/src/view/dataElements/xdmObject/components/nodeEdit.styl
@@ -1,4 +1,3 @@
-
 .NodeEdit-breadcrumbs {
-  margin-left: -4px;
+  margin-left: calc(-1 * var(--spectrum-global-dimension-static-size-100));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The left side of the breadcrumb text wasn't lining up horizontally with the rest of the form. We were trying to align it, but we were only using a `-4px` margin when we needed `-8px`. I ended up leveraging the same CSS variable that React-Spectrum is using for internal padding on the breadcrumb link.

Here's what it looks like now:

![image](https://user-images.githubusercontent.com/210820/129241012-e26145e5-05bb-4784-b2fa-3dc5257fd31f.png)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
