### PR TITLE
PDCL-6649 Fixed error sometimes being thrown when clicking Save in Launch.

### DIFF
--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -89,6 +89,12 @@ const XdmObject = ({ initInfo, formikProps, registerImperativeFormApi }) => {
   useEffect(() => {
     registerImperativeFormApi({
       getSettings({ values }) {
+        if (!isEditorRenderable) {
+          // We're in an invalid state where we can't
+          // build a proper settings object.
+          return {};
+        }
+
         const schema = {
           id: selectedSchema.$id,
           version: selectedSchema.version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Copied from the JIRA issue since it explains it well:

Start to create a data element using the XDM Object data element type. Don't select any schema (you'll need to have more than one sandbox or more than one schema in order to not select a schema). Hit Save to Library (or one of the other Save buttons Launch provides). Notice it results in an error. You'll see "An error occurred" in the extension view.

When Save was clicked, the extension view was in an invalid state. Launch called the extension's validate function, which returned false, but then Launch also called getSettings. Our getSettings assumes that it will only be called if validate returns true. Because of this, the code ends up inadvertently throwing an error.

Now, in this scenario, Launch doesn't really need to be calling getSettings if validate returns false. I've logged that issue in https://jira.corp.adobe.com/browse/PDCL-6647. However, there's another scenario when getSettings may be called when the view is in an invalid state. When a user navigates away from the extension view without hitting the Save button, Launch requests settings from the extension and compares them to the persisted settings. If they are different, Launch assumes the extension view is dirty and asks the user if they would like to save or discard their changes before navigating. Launch doesn't call validate in this case.

For this reason, we need to place more guards inside the getSettings function so that it won't throw errors when it's called and the extension view is in an invalid state.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-6649
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Unexpected errors don't provide a good user experience.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
