### PR TITLE
BuildInfo is deprecated in favor of environment.stage

### DIFF
--- a/src/lib/instanceManager/createInstanceManager.js
+++ b/src/lib/instanceManager/createInstanceManager.js
@@ -35,9 +35,9 @@ module.exports = ({
       instanceByName[name] = instance;
 
       const computedEdgeConfigId =
-        (turbine.buildInfo.environment === "development" &&
+        (turbine.environment.stage === "development" &&
           developmentEdgeConfigId) ||
-        (turbine.buildInfo.environment === "staging" && stagingEdgeConfigId) ||
+        (turbine.environment.stage === "staging" && stagingEdgeConfigId) ||
         edgeConfigId;
 
       instance("configure", {

--- a/test/unit/lib/instanceManager/createInstanceManager.spec.js
+++ b/test/unit/lib/instanceManager/createInstanceManager.spec.js
@@ -51,7 +51,7 @@ describe("Instance Manager", () => {
         ]
       },
       onDebugChanged: undefined,
-      buildInfo: { environment: "production" }
+      environment: { stage: "production" }
     });
     turbine.debugEnabled = false;
     mockWindow = {};
@@ -136,14 +136,14 @@ describe("Instance Manager", () => {
   });
 
   it("handles a staging environment", () => {
-    turbine.buildInfo.environment = "staging";
+    turbine.environment.stage = "staging";
     build();
     expect(alloy1.calls.argsFor(0)[1].edgeConfigId).toEqual("PR123:stage");
     expect(alloy2.calls.argsFor(0)[1].edgeConfigId).toEqual("PR456");
   });
 
   it("handles a development environment", () => {
-    turbine.buildInfo.environment = "development";
+    turbine.environment.stage = "development";
     build();
     expect(alloy1.calls.argsFor(0)[1].edgeConfigId).toEqual("PR123:dev");
     expect(alloy2.calls.argsFor(0)[1].edgeConfigId).toEqual("PR456");


### PR DESCRIPTION
Launch made a change which deprecated buildInfo. We need to know the environment to determine which data stream to use. The new property is in `turbine.environment.stage`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I've updated the schema in extension.json or no changes are necessary.
