### PR TITLE
Rename mboxEdit to adobe_authoring_enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "reactor-extension-alloy",
       "version": "2.9.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/src/view/configuration/constants/prehidingSnippet.js
+++ b/src/view/configuration/constants/prehidingSnippet.js
@@ -3,5 +3,5 @@ export default `<script>
   if (a) return;
   var o=e.createElement("style");
   o.id="alloy-prehiding",o.innerText=n,i.appendChild(o),setTimeout(function(){o.parentNode&&o.parentNode.removeChild(o)},t)}}
-  (document, document.location.href.indexOf("mboxEdit") !== -1, ".personalization-container { opacity: 0 !important }", 3000);
+  (document, document.location.href.indexOf("adobe_authoring_enabled") !== -1, ".personalization-container { opacity: 0 !important }", 3000);
 </script>`;


### PR DESCRIPTION
`mboxEdit` has been changed in the VEC and the Web SDK to `adobe_authoring_enabled`.

I have a PR to fix the public doc as well: https://git.corp.adobe.com/AdobeDocs/experience-platform.en/pull/2467


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I've updated the schema in extension.json or no changes are necessary.
