### PR TITLE
Added documentation text to redirect with identity. Disable instance picker when only one option

### DIFF
--- a/src/view/actions/redirectWithIdentity.jsx
+++ b/src/view/actions/redirectWithIdentity.jsx
@@ -11,10 +11,12 @@ governing permissions and limitations under the License.
 */
 
 import React from "react";
+import { Link } from "@adobe/react-spectrum";
 import render from "../render";
 import ExtensionView from "../components/extensionView";
 import FormElementContainer from "../components/formElementContainer";
 import InstanceNamePicker from "../components/instanceNamePicker";
+import Alert from "../components/alert";
 
 const getInitialValues = ({ initInfo }) => {
   const { instanceName = initInfo.extensionSettings.instances[0].name } =
@@ -38,13 +40,38 @@ const RedirectWithIdentity = () => {
       getInitialValues={getInitialValues}
       getSettings={getSettings}
       render={({ initInfo }) => (
-        <FormElementContainer>
-          <InstanceNamePicker
-            data-test-id="instanceNamePicker"
-            name="instanceName"
-            initInfo={initInfo}
-          />
-        </FormElementContainer>
+        <>
+          <Alert
+            variant="informative"
+            title="Redirect with identity"
+            width="size-5000"
+            marginTop="size-100"
+            marginBottom="size-200"
+          >
+            Use this action to share identities from the current page to other
+            domains. This action is designed to be used with a click event type
+            and a value comparison condition. See{" "}
+            <Link>
+              <a
+                href="https://experienceleague.adobe.com/docs/experience-platform/edge/identity/id-sharing.html#tags-extension"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                cross-domain ID sharing
+              </a>
+            </Link>{" "}
+            for more information.
+          </Alert>
+          <FormElementContainer>
+            <InstanceNamePicker
+              data-test-id="instanceNamePicker"
+              name="instanceName"
+              initInfo={initInfo}
+              description="Choose the instance with the identity you would like to use on the linked page."
+              disabledDescription="Only one instance was configured for this extension so no configuration is required for this action."
+            />
+          </FormElementContainer>
+        </>
       )}
     />
   );

--- a/src/view/components/instanceNamePicker.jsx
+++ b/src/view/components/instanceNamePicker.jsx
@@ -16,14 +16,26 @@ import { Item } from "@adobe/react-spectrum";
 import getInstanceOptions from "../utils/getInstanceOptions";
 import FormikPicker from "./formikReactSpectrum3/formikPicker";
 
-const InstanceNamePicker = ({ "data-test-id": dataTestId, name, initInfo }) => {
+const InstanceNamePicker = ({
+  "data-test-id": dataTestId,
+  name,
+  initInfo,
+  description,
+  disabledDescription
+}) => {
+  const items = getInstanceOptions(initInfo);
+  const isDisabled = items.length <= 1;
   return (
     <FormikPicker
       data-test-id={dataTestId}
       name={name}
       label="Instance"
-      items={getInstanceOptions(initInfo)}
+      items={items}
       width="size-5000"
+      isDisabled={isDisabled}
+      description={
+        isDisabled && disabledDescription ? disabledDescription : description
+      }
     >
       {item => <Item key={item.value}>{item.label}</Item>}
     </FormikPicker>
@@ -33,7 +45,9 @@ const InstanceNamePicker = ({ "data-test-id": dataTestId, name, initInfo }) => {
 InstanceNamePicker.propTypes = {
   "data-test-id": PropTypes.string,
   name: PropTypes.string.isRequired,
-  initInfo: PropTypes.object.isRequired
+  initInfo: PropTypes.object.isRequired,
+  description: PropTypes.string,
+  disabledDescription: PropTypes.string
 };
 
 export default InstanceNamePicker;


### PR DESCRIPTION

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

Add documentation text to the redirect with identity UI linking to the future documentation. See https://git.corp.adobe.com/AdobeDocs/experience-platform.en/blob/PLAT-119966-Document-mobile-to-web-and-cross-domain-id-sharing-feature/help/edge/identity/id-sharing.md

Add a description field to the instance picker for when it is disabled and when it is active. Disable the instance selector when there is only one option. This changes sendEvent and setConsent UIs too.

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-8099

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

<img width="486" alt="Screen Shot 2022-06-06 at 4 12 43 PM" src="https://user-images.githubusercontent.com/952132/172258401-419b625c-dbcd-4ed4-a95c-2d29fe3d3844.png">

<img width="449" alt="Screen Shot 2022-06-06 at 4 13 15 PM" src="https://user-images.githubusercontent.com/952132/172258409-16734c9c-8bc7-43ac-8a27-430f399a31e2.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.
