### PR TITLE
Fixed the sort order of numerical properties in the XDM data element such as eVars.

### DIFF
--- a/src/view/dataElements/xdmObject/helpers/object/populateTreeNode.js
+++ b/src/view/dataElements/xdmObject/helpers/object/populateTreeNode.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import numberAwareCompareFunction from "../../../../utils/numberAwareCompareFunction";
 import { WHOLE } from "../../constants/populationStrategy";
 import computePopulationAmount from "../computePopulationAmount";
 import computePopulationNote from "../computePopulationNote";
@@ -29,27 +30,29 @@ export default ({
   if (properties) {
     const propertyNames = Object.keys(properties);
     if (propertyNames.length) {
-      treeNode.children = propertyNames.sort().map(propertyName => {
-        const propertyFormStateNode = properties[propertyName];
-        const childNode = getTreeNode({
-          formStateNode: propertyFormStateNode,
-          treeNodeComponent,
-          displayName: propertyName,
-          isAncestorUsingWholePopulationStrategy:
-            isAncestorUsingWholePopulationStrategy ||
-            populationStrategy === WHOLE,
-          notifyParentOfTouched: confirmTouchedAtCurrentOrDescendantNode,
-          errors:
-            errors && errors.properties
-              ? errors.properties[propertyName]
-              : undefined,
-          touched:
-            touched && touched.properties
-              ? touched.properties[propertyName]
-              : undefined
+      treeNode.children = propertyNames
+        .sort(numberAwareCompareFunction)
+        .map(propertyName => {
+          const propertyFormStateNode = properties[propertyName];
+          const childNode = getTreeNode({
+            formStateNode: propertyFormStateNode,
+            treeNodeComponent,
+            displayName: propertyName,
+            isAncestorUsingWholePopulationStrategy:
+              isAncestorUsingWholePopulationStrategy ||
+              populationStrategy === WHOLE,
+            notifyParentOfTouched: confirmTouchedAtCurrentOrDescendantNode,
+            errors:
+              errors && errors.properties
+                ? errors.properties[propertyName]
+                : undefined,
+            touched:
+              touched && touched.properties
+                ? touched.properties[propertyName]
+                : undefined
+          });
+          return childNode;
         });
-        return childNode;
-      });
     }
   }
 

--- a/src/view/utils/numberAwareCompareFunction.js
+++ b/src/view/utils/numberAwareCompareFunction.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// This function compares strings that may have numbers in them.
+// It splits the string into numbers and non-numbers, then compares
+// each piece one at a time.
+const regex = new RegExp("([^0-9]*)([0-9\\.]*)", "g");
+const compare = new Intl.Collator().compare;
+
+export default (a, b) => {
+  if (typeof a !== "string" || typeof b !== "string") {
+    return compare(a, b);
+  }
+  const aIter = a.matchAll(regex);
+  const bIter = b.matchAll(regex);
+
+  let aMatch;
+  let bMatch;
+  let aText;
+  let bText;
+  let aNumber;
+  let bNumber;
+  let comparison;
+
+  while (true) {
+    ({ value: aMatch } = aIter.next());
+    ({ value: bMatch } = bIter.next());
+    if (aMatch[0] === "" || bMatch[0] === "") {
+      return compare(aMatch[0], bMatch[0]);
+    }
+    aText = aMatch[1];
+    bText = bMatch[1];
+    comparison = compare(aText, bText);
+    if (comparison !== 0) {
+      return comparison;
+    }
+    aNumber = Number.parseFloat(aMatch[2]);
+    bNumber = Number.parseFloat(bMatch[2]);
+    if (aNumber !== bNumber) {
+      return aNumber - bNumber;
+    }
+  }
+};

--- a/src/view/utils/numberAwareCompareFunction.js
+++ b/src/view/utils/numberAwareCompareFunction.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 // This function compares strings that may have numbers in them.
 // It splits the string into numbers and non-numbers, then compares
 // each piece one at a time.
-const regex = new RegExp("([^0-9]*)([0-9\\.]*)", "g");
+const regex = new RegExp("([^0-9]*)([0-9]*)", "g");
 const compare = new Intl.Collator().compare;
 
 export default (a, b) => {
@@ -31,9 +31,11 @@ export default (a, b) => {
   let bNumber;
   let comparison;
 
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     ({ value: aMatch } = aIter.next());
     ({ value: bMatch } = bIter.next());
+    // the last match from the regex is empty string
     if (aMatch[0] === "" || bMatch[0] === "") {
       return compare(aMatch[0], bMatch[0]);
     }
@@ -43,10 +45,11 @@ export default (a, b) => {
     if (comparison !== 0) {
       return comparison;
     }
-    aNumber = Number.parseFloat(aMatch[2]);
-    bNumber = Number.parseFloat(bMatch[2]);
-    if (aNumber !== bNumber) {
-      return aNumber - bNumber;
+    aNumber = Number.parseInt(aMatch[2], 10);
+    bNumber = Number.parseInt(bMatch[2], 10);
+    comparison = aNumber - bNumber;
+    if (comparison !== 0) {
+      return comparison;
     }
   }
 };

--- a/test/functional/dataElements/xdmObject/helpers/xdmTree.js
+++ b/test/functional/dataElements/xdmObject/helpers/xdmTree.js
@@ -42,6 +42,71 @@ const getIsElementInViewport = selector => {
   )();
 };
 
+const create = node => {
+  const populationIndicator = node.find(
+    createTestIdSelectorString("populationAmountIndicator")
+  );
+  const expansionToggle = node
+    .parent(".ant-tree-treenode")
+    .nth(0)
+    .find(".ant-tree-switcher");
+  return {
+    click: async () => {
+      await t.click(node);
+    },
+    toggleExpansion: async () => {
+      await t.click(expansionToggle);
+    },
+    expectInViewport: async () => {
+      const isElementInViewport = await getIsElementInViewport(node);
+      return t.expect(isElementInViewport).ok();
+    },
+    populationIndicator: {
+      expectFull: async () => {
+        await t.expect(populationIndicator.hasClass("is-full")).ok();
+      },
+      expectPartial: async () => {
+        return t.expect(populationIndicator.hasClass("is-partial")).ok();
+      },
+      expectEmpty: async () => {
+        await t.expect(populationIndicator.hasClass("is-empty")).ok();
+      },
+      expectBlank: async () => {
+        await t.expect(populationIndicator.exists).notOk();
+      }
+    },
+    expectIsValid: async () => {
+      await t.expect(node.hasClass("is-invalid")).notOk();
+    },
+    expectIsNotValid: async () => {
+      await t.expect(node.hasClass("is-invalid")).ok();
+    },
+    expectExists: async () => {
+      await t.expect(node.exists).ok();
+    },
+    expectNotExists: async () => {
+      await t.expect(node.exists).notOk();
+    },
+    expectTitleEquals: async title => {
+      await t
+        .expect(
+          node.find(createTestIdSelectorString("xdmTreeNodeTitleDisplayName"))
+            .innerText
+        )
+        .eql(title);
+    },
+    next: () => {
+      return create(
+        node()
+          .parent(".ant-tree-treenode")
+          .nth(0)
+          .nextSibling()
+          .find(createTestIdSelectorString("xdmTreeNodeTitle"))
+      );
+    }
+  };
+};
+
 export default {
   node: title => {
     const node = xdmTree
@@ -49,50 +114,6 @@ export default {
       .withText(title)
       .parent(createTestIdSelectorString("xdmTreeNodeTitle"))
       .nth(0);
-    const populationIndicator = node.find(
-      createTestIdSelectorString("populationAmountIndicator")
-    );
-    const expansionToggle = node
-      .parent(".ant-tree-treenode")
-      .nth(0)
-      .find(".ant-tree-switcher");
-    return {
-      click: async () => {
-        await t.click(node);
-      },
-      toggleExpansion: async () => {
-        await t.click(expansionToggle);
-      },
-      expectInViewport: async () => {
-        const isElementInViewport = await getIsElementInViewport(node);
-        return t.expect(isElementInViewport).ok();
-      },
-      populationIndicator: {
-        expectFull: async () => {
-          await t.expect(populationIndicator.hasClass("is-full")).ok();
-        },
-        expectPartial: async () => {
-          return t.expect(populationIndicator.hasClass("is-partial")).ok();
-        },
-        expectEmpty: async () => {
-          await t.expect(populationIndicator.hasClass("is-empty")).ok();
-        },
-        expectBlank: async () => {
-          await t.expect(populationIndicator.exists).notOk();
-        }
-      },
-      expectIsValid: async () => {
-        await t.expect(node.hasClass("is-invalid")).notOk();
-      },
-      expectIsNotValid: async () => {
-        await t.expect(node.hasClass("is-invalid")).ok();
-      },
-      expectExists: async () => {
-        await t.expect(node.exists).ok();
-      },
-      expectNotExists: async () => {
-        await t.expect(node.exists).notOk();
-      }
-    };
+    return create(node);
   }
 };

--- a/test/functional/dataElements/xdmObject/xdmObjectEditing.spec.js
+++ b/test/functional/dataElements/xdmObject/xdmObjectEditing.spec.js
@@ -539,3 +539,18 @@ test("clicking a tree node should select and expand the node", async () => {
   await nodeEdit.heading.expectText("_unifiedjsqeonly");
   await xdmTree.node("vendor").expectExists();
 });
+
+test("eVars are ordered numerically", async () => {
+  await initializeExtensionView();
+  await schemaField.openMenu();
+  await schemaField.selectMenuOption("Analytics Migration");
+  await xdmTree.node("_experience").toggleExpansion();
+  await xdmTree.node("analytics").toggleExpansion();
+  await xdmTree.node("customDimensions").toggleExpansion();
+  await xdmTree.node("eVars").toggleExpansion();
+  // before fixing the sorting function, eVar10 followed eVar1
+  await xdmTree
+    .node("eVar1")
+    .next()
+    .expectTitleEquals("eVar2");
+});

--- a/test/unit/lib/utils/numberAwareCompareFunction.spec.js
+++ b/test/unit/lib/utils/numberAwareCompareFunction.spec.js
@@ -1,0 +1,51 @@
+import numberAwareCompareFunction from "../../../../src/view/utils/numberAwareCompareFunction";
+
+describe("numberAwareCompareFunction", () => {
+  it("compares evar2 and evar10", () => {
+    expect(["evar10", "evar2"].sort(numberAwareCompareFunction)).toEqual([
+      "evar2",
+      "evar10"
+    ]);
+  });
+
+  it("compares 2 and 10", () => {
+    expect(["10", "2"].sort(numberAwareCompareFunction)).toEqual(["2", "10"]);
+  });
+
+  it("compares numbers", () => {
+    expect(numberAwareCompareFunction("evar2", "evar10")).toBeLessThan(0);
+    expect(numberAwareCompareFunction("evar10", "evar2")).toBeGreaterThan(0);
+    expect(numberAwareCompareFunction("100", "100")).toEqual(0);
+    expect(numberAwareCompareFunction("", "")).toEqual(0);
+    expect(numberAwareCompareFunction("a", "")).toBeGreaterThan(0);
+    expect(numberAwareCompareFunction("10", "")).toBeGreaterThan(0);
+  });
+
+  it("compares with multiple numbers", () => {
+    expect(
+      ["a10a10", "a10a2", "a2a10", "a2a2"].sort(numberAwareCompareFunction)
+    ).toEqual(["a2a2", "a2a10", "a10a2", "a10a10"]);
+  });
+
+  it("compares decimals", () => {
+    expect(["1.1", "1.02", "1.003"].sort(numberAwareCompareFunction)).toEqual([
+      "1.003",
+      "1.02",
+      "1.1"
+    ]);
+  });
+
+  it("compares with periods", () => {
+    expect(["a.b", "a.a", "b.a"].sort(numberAwareCompareFunction)).toEqual([
+      "a.a",
+      "a.b",
+      "b.a"
+    ]);
+  });
+
+  it("handles non-strings", () => {
+    [undefined, null, 0, 42, { a: "foo" }, "foo"].sort(
+      numberAwareCompareFunction
+    );
+  });
+});

--- a/test/unit/lib/utils/numberAwareCompareFunction.spec.js
+++ b/test/unit/lib/utils/numberAwareCompareFunction.spec.js
@@ -28,11 +28,11 @@ describe("numberAwareCompareFunction", () => {
   });
 
   it("compares decimals", () => {
-    expect(["1.1", "1.02", "1.003"].sort(numberAwareCompareFunction)).toEqual([
-      "1.003",
-      "1.02",
-      "1.1"
-    ]);
+    expect(
+      ["1.1", "1.02", "1.003", "1.1.2", "1.1.1"].sort(
+        numberAwareCompareFunction
+      )
+    ).toEqual(["1.1", "1.1.1", "1.1.2", "1.02", "1.003"]);
   });
 
   it("compares with periods", () => {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
I created a new compare function that sorts properties numerically. Before the order of eVars was [evar1, evar10, evar100, evar101, ...]. The new compare function splits up the string into non-number and number portions, then compares the non-number portions like normal, but compares the number portions numerically. So this would work for properties with numbers first or last, or with strings that have more than one number in them.

I then use this compare function when building the tree nodes in the XDM data element.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-6523

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When editing the XDM data element, setting eVars is difficult because the properties aren't ordered numerically.

## Screenshots (if appropriate):
Before change:
<img width="565" alt="Screen Shot 2022-06-22 at 9 47 46 AM" src="https://user-images.githubusercontent.com/952132/175075641-5d91d67e-dcc5-4b82-a638-714fd9aea9b2.png">
After change:
<img width="491" alt="Screen Shot 2022-06-22 at 9 48 21 AM" src="https://user-images.githubusercontent.com/952132/175075626-27f136ed-9618-4eba-8e74-2ccdbb9162b3.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
