### PR TITLE
Add runtime test for integration with Experience Cloud ID Service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/alloy": "^2.13.1-beta.0",
+        "@adobe/alloy": "^2.13.1-beta.1",
         "@adobe/react-spectrum": "~3.16.0",
         "@react-spectrum/combobox": "^3.0.0-rc.0",
         "@react-stately/data": "^3.4.0",
@@ -69,6 +69,7 @@
         "karma-spec-reporter": "0.0.32",
         "lint-staged": "^10.5.4",
         "minimist": "^1.2.6",
+        "mockvisitor": "file:test/functional/runtime/mockVisitor",
         "npm-run-all": "^4.1.5",
         "parcel": "^2.4.1",
         "prettier": "^1.17.0",
@@ -86,9 +87,9 @@
       }
     },
     "node_modules/@adobe/alloy": {
-      "version": "2.13.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.1-beta.0.tgz",
-      "integrity": "sha512-QiwcMYSmL0nMYD52dML5worJQPMrWFAs8CWnT4s2hTmHgzpEgcaIFA4Ti6kmdhwZMzgX7tloJ424dsYN96ojGg==",
+      "version": "2.13.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.1-beta.1.tgz",
+      "integrity": "sha512-TvMhIlXG8mvW9a22ep7aZMccvAYk5cyWdImhyVqidjUu5R54Lz1597dwMOFrWoaT96httrWqgLfXedNoEPWfpQ==",
       "dependencies": {
         "@adobe/reactor-cookie": "^1.0.0",
         "@adobe/reactor-load-script": "^1.1.1",
@@ -18956,6 +18957,10 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mockvisitor": {
+      "resolved": "test/functional/runtime/mockVisitor",
+      "link": true
+    },
     "node_modules/moment": {
       "version": "2.29.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
@@ -25861,13 +25866,18 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "test/functional/runtime/mockVisitor": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "Apache-2.0"
     }
   },
   "dependencies": {
     "@adobe/alloy": {
-      "version": "2.13.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.1-beta.0.tgz",
-      "integrity": "sha512-QiwcMYSmL0nMYD52dML5worJQPMrWFAs8CWnT4s2hTmHgzpEgcaIFA4Ti6kmdhwZMzgX7tloJ424dsYN96ojGg==",
+      "version": "2.13.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.1-beta.1.tgz",
+      "integrity": "sha512-TvMhIlXG8mvW9a22ep7aZMccvAYk5cyWdImhyVqidjUu5R54Lz1597dwMOFrWoaT96httrWqgLfXedNoEPWfpQ==",
       "requires": {
         "@adobe/reactor-cookie": "^1.0.0",
         "@adobe/reactor-load-script": "^1.1.1",
@@ -40892,6 +40902,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
+    },
+    "mockvisitor": {
+      "version": "file:test/functional/runtime/mockVisitor"
     },
     "moment": {
       "version": "2.29.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/alloy": "^2.13.0-beta.0",
+        "@adobe/alloy": "^2.13.1-beta.0",
         "@adobe/react-spectrum": "~3.16.0",
         "@react-spectrum/combobox": "^3.0.0-rc.0",
         "@react-stately/data": "^3.4.0",
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@adobe/alloy": {
-      "version": "2.13.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.0-beta.0.tgz",
-      "integrity": "sha512-QPnfmq1HZJltYnXVZRnvt/n9L4s7ps19WvzuWtxi9Z8hDbhjeaupIGlfvdC110uPEO4rFUtM79NsQGIaGRXlJQ==",
+      "version": "2.13.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.1-beta.0.tgz",
+      "integrity": "sha512-QiwcMYSmL0nMYD52dML5worJQPMrWFAs8CWnT4s2hTmHgzpEgcaIFA4Ti6kmdhwZMzgX7tloJ424dsYN96ojGg==",
       "dependencies": {
         "@adobe/reactor-cookie": "^1.0.0",
         "@adobe/reactor-load-script": "^1.1.1",
@@ -25900,9 +25900,9 @@
   },
   "dependencies": {
     "@adobe/alloy": {
-      "version": "2.13.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.0-beta.0.tgz",
-      "integrity": "sha512-QPnfmq1HZJltYnXVZRnvt/n9L4s7ps19WvzuWtxi9Z8hDbhjeaupIGlfvdC110uPEO4rFUtM79NsQGIaGRXlJQ==",
+      "version": "2.13.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@adobe/alloy/-/alloy-2.13.1-beta.0.tgz",
+      "integrity": "sha512-QiwcMYSmL0nMYD52dML5worJQPMrWFAs8CWnT4s2hTmHgzpEgcaIFA4Ti6kmdhwZMzgX7tloJ424dsYN96ojGg==",
       "requires": {
         "@adobe/reactor-cookie": "^1.0.0",
         "@adobe/reactor-load-script": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "karma-spec-reporter": "0.0.32",
         "lint-staged": "^10.5.4",
         "minimist": "^1.2.6",
+        "mockvisitor": "file:test/functional/runtime/mockVisitor",
         "npm-run-all": "^4.1.5",
         "parcel": "^2.4.1",
         "prettier": "^1.17.0",
@@ -19010,6 +19011,10 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mockvisitor": {
+      "resolved": "test/functional/runtime/mockVisitor",
+      "link": true
+    },
     "node_modules/moment": {
       "version": "2.29.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
@@ -25885,6 +25890,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "test/functional/runtime/mockVisitor": {
+      "name": "mockvisitor",
+      "version": "0.0.1",
+      "dev": true,
+      "license": "Apache-2.0"
     }
   },
   "dependencies": {
@@ -40949,6 +40960,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
+    },
+    "mockvisitor": {
+      "version": "file:test/functional/runtime/mockVisitor"
     },
     "moment": {
       "version": "2.29.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "@adobe/alloy": "^2.13.0-beta.0",
+    "@adobe/alloy": "^2.13.1-beta.0",
     "@adobe/react-spectrum": "~3.16.0",
     "@react-spectrum/combobox": "^3.0.0-rc.0",
     "@react-stately/data": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "karma-spec-reporter": "0.0.32",
     "lint-staged": "^10.5.4",
     "minimist": "^1.2.6",
+    "mockvisitor": "file:test/functional/runtime/mockVisitor",
     "npm-run-all": "^4.1.5",
     "parcel": "^2.4.1",
     "prettier": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "@adobe/alloy": "^2.13.1-beta.0",
+    "@adobe/alloy": "^2.13.1-beta.1",
     "@adobe/react-spectrum": "~3.16.0",
     "@react-spectrum/combobox": "^3.0.0-rc.0",
     "@react-stately/data": "^3.4.0",
@@ -111,6 +111,7 @@
     "karma-spec-reporter": "0.0.32",
     "lint-staged": "^10.5.4",
     "minimist": "^1.2.6",
+    "mockvisitor": "file:test/functional/runtime/mockVisitor",
     "npm-run-all": "^4.1.5",
     "parcel": "^2.4.1",
     "prettier": "^1.17.0",

--- a/test/functional/runtime/mockVisitor/extension.json
+++ b/test/functional/runtime/mockVisitor/extension.json
@@ -21,5 +21,6 @@
       "type": "object",
       "properties": {}
     }
-  }
+  },
+  "main": "src/lib/sharedModules/mcidInstance.js"
 }

--- a/test/functional/runtime/mockVisitor/extension.json
+++ b/test/functional/runtime/mockVisitor/extension.json
@@ -1,0 +1,25 @@
+{
+  "displayName": "Mock Visitor",
+  "name": "adobe-mcid",
+  "platform": "web",
+  "version": "0.0.1",
+  "description": "Mock Experience Cloud ID Service for use with testing",
+  "author": {
+    "name": "adobe"
+  },
+  "viewBasePath": "src/view/",
+  "sharedModules": [
+    {
+      "name": "mcid-instance",
+      "libPath": "src/lib/sharedModules/mcidInstance.js"
+    }
+  ],
+  "configuration": {
+    "viewPath": "configuration/configuration.html",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/test/functional/runtime/mockVisitor/package.json
+++ b/test/functional/runtime/mockVisitor/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "mockvisitor",
+  "version": "0.0.1",
+  "description": "Mock Experience Cloud ID Service for use with testing",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/test/functional/runtime/mockVisitor/src/lib/sharedModules/mcidInstance.js
+++ b/test/functional/runtime/mockVisitor/src/lib/sharedModules/mcidInstance.js
@@ -1,21 +1,12 @@
-const ecid = "123456789abcdef0";
-const initialize = () => {
-  const instance = {
+const ecid = "00781847927133700121980094732316198575";
+
+window.Visitor = () => undefined;
+window.Visitor.getInstance = () => {
+  return {
     getMarketingCloudVisitorID(callback) {
       callback(ecid);
     }
   };
-  window.Visitor = () => undefined;
-  window.Visitor.getInstance = () => {
-    return instance;
-  };
 };
 
-module.exports = new Promise(resolve => {
-  // console.log("Initializing visitor");
-  setTimeout(() => {
-    initialize();
-    resolve();
-    // console.log("Done initializing visitor");
-  }, 1000);
-});
+module.exports = window.Visitor;

--- a/test/functional/runtime/mockVisitor/src/lib/sharedModules/mcidInstance.js
+++ b/test/functional/runtime/mockVisitor/src/lib/sharedModules/mcidInstance.js
@@ -1,0 +1,21 @@
+const ecid = "123456789abcdef0";
+const initialize = () => {
+  const instance = {
+    getMarketingCloudVisitorID(callback) {
+      callback(ecid);
+    }
+  };
+  window.Visitor = () => undefined;
+  window.Visitor.getInstance = () => {
+    return instance;
+  };
+};
+
+module.exports = new Promise(resolve => {
+  // console.log("Initializing visitor");
+  setTimeout(() => {
+    initialize();
+    resolve();
+    // console.log("Done initializing visitor");
+  }, 1000);
+});

--- a/test/functional/runtime/mockVisitor/src/view/configuration/configuration.html
+++ b/test/functional/runtime/mockVisitor/src/view/configuration/configuration.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Extension Configuration</title>
+  </head>
+  <body>
+    Mock Experience Cloud ID Service
+
+    <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
+    <script>
+      window.extensionBridge.register({
+        init: function(info) {},
+        getSettings: function() {
+          return {};
+        },
+        validate: function() {
+          return true;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/test/functional/runtime/visitorMigration.spec.js
+++ b/test/functional/runtime/visitorMigration.spec.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import { t } from "testcafe";
 import createNetworkLogger from "./helpers/createNetworkLogger";
 import appendLaunchLibrary from "./helpers/appendLaunchLibrary";
+import getReturnedEcid from "./helpers/getReturnedEcid";
 import { TEST_PAGE } from "./helpers/constants/url";
 
 const networkLogger = createNetworkLogger();
@@ -84,12 +85,11 @@ fixture("Visitor migration")
 
 test("waits for Visitor to be initialized before running", async () => {
   await appendLaunchLibrary(container);
-  /* await t.eval(() => {
-    window._satellite.setDebug(true);
-  }); */
   // The requestLogger.count method uses TestCafe's smart query
   // assertion mechanism, so it will wait for the request to be
   // made or a timeout is reached.
   await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
-  // await t.debug();
+  const ecid = getReturnedEcid(networkLogger.edgeEndpointLogs.requests[0]);
+  // This is the ID returned from the mock visitor extension.
+  await t.expect(ecid).eql("00781847927133700121980094732316198575");
 });

--- a/test/functional/runtime/visitorMigration.spec.js
+++ b/test/functional/runtime/visitorMigration.spec.js
@@ -89,6 +89,7 @@ test("waits for Visitor to be initialized before running", async () => {
   // assertion mechanism, so it will wait for the request to be
   // made or a timeout is reached.
   await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
+  await t.debug();
   const ecid = getReturnedEcid(networkLogger.edgeEndpointLogs.requests[0]);
   // This is the ID returned from the mock visitor extension.
   await t.expect(ecid).eql("00781847927133700121980094732316198575");

--- a/test/functional/runtime/visitorMigration.spec.js
+++ b/test/functional/runtime/visitorMigration.spec.js
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { t } from "testcafe";
+import createNetworkLogger from "./helpers/createNetworkLogger";
+import appendLaunchLibrary from "./helpers/appendLaunchLibrary";
+import { TEST_PAGE } from "./helpers/constants/url";
+
+const networkLogger = createNetworkLogger();
+
+const container = {
+  extensions: {
+    "adobe-alloy": {
+      displayName: "Adobe Experience Platform Web SDK",
+      settings: {
+        instances: [
+          {
+            name: "alloy",
+            edgeConfigId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83:AditiTest"
+          }
+        ]
+      }
+    },
+    "adobe-mcid": {
+      displayName: "Mock Visitor",
+      settings: {}
+    }
+  },
+  rules: [
+    {
+      id: "RL1651248059877",
+      name: "Page Top",
+      events: [
+        {
+          modulePath: "sandbox/pageTop.js",
+          settings: {}
+        }
+      ],
+      actions: [
+        {
+          modulePath: "adobe-alloy/dist/lib/actions/sendEvent/index.js",
+          settings: {
+            instanceName: "alloy"
+          }
+        }
+      ]
+    }
+  ],
+  property: {
+    name: "Sandbox property",
+    settings: {
+      id: "PR12345",
+      domains: ["adobe.com", "example.com"],
+      undefinedVarsReturnEmpty: false
+    }
+  },
+  company: {
+    orgId: "5BFE274A5F6980A50A495C08@AdobeOrg"
+  },
+  environment: {
+    id: "EN00000000000000000000000000000000",
+    stage: "development"
+  },
+  buildInfo: {
+    turbineVersion: "27.2.1",
+    turbineBuildDate: "2022-04-29T16:01:37.616Z",
+    buildDate: "2022-04-29T16:01:37.616Z",
+    environment: "development"
+  }
+};
+
+fixture("Visitor migration")
+  .page(TEST_PAGE)
+  .requestHooks([networkLogger.edgeEndpointLogs]);
+
+test("waits for Visitor to be initialized before running", async () => {
+  await appendLaunchLibrary(container);
+  /* await t.eval(() => {
+    window._satellite.setDebug(true);
+  }); */
+  // The requestLogger.count method uses TestCafe's smart query
+  // assertion mechanism, so it will wait for the request to be
+  // made or a timeout is reached.
+  await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
+  // await t.debug();
+});

--- a/test/functional/runtime/visitorMigration.spec.js
+++ b/test/functional/runtime/visitorMigration.spec.js
@@ -89,7 +89,6 @@ test("waits for Visitor to be initialized before running", async () => {
   // assertion mechanism, so it will wait for the request to be
   // made or a timeout is reached.
   await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
-  await t.debug();
   const ecid = getReturnedEcid(networkLogger.edgeEndpointLogs.requests[0]);
   // This is the ID returned from the mock visitor extension.
   await t.expect(ecid).eql("00781847927133700121980094732316198575");


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This PR adds a runtime test for the Web SDK integration with the Experience Cloud ID Service inside of Tags. To actually fix the bug, a change to Alloy is required. The runtime test uses a mock extension that sets window.Visitor, and then makes sure that is used by Web SDK.

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-9421

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
