### PR TITLE
Add restrictions to the scope and surfaces array within the extension schema

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -195,7 +195,12 @@
               "decisionScopes": {
                 "anyOf": [
                   {
-                    "type": "array"
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
                   },
                   {
                     "type": "string",
@@ -206,7 +211,12 @@
               "surfaces": {
                 "anyOf": [
                   {
-                    "type": "array"
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
                   },
                   {
                     "type": "string",


### PR DESCRIPTION

## Description

After review, Brent suggested that we add restrictions to the array option for decisionScopes and surfaces. Since we are moving the location of decisionScopes this is a good time to do it. I added the restriction that it is a non-empty array of non-empty strings.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
