### PR TITLE
Fix redirect with identity when elements are inside anchor tag, and set logger properly

### DIFF
--- a/src/lib/actions/redirectWithIdentity/createRedirectWithIdentity.js
+++ b/src/lib/actions/redirectWithIdentity/createRedirectWithIdentity.js
@@ -24,14 +24,14 @@ module.exports = ({ instanceManager, document, logger }) => (
     return Promise.resolve();
   }
 
-  if (!event || !event.nativeEvent) {
+  if (!event || !event.element) {
     logger.warn(
-      `Native event not found when running "Redirect with identity." This action is meant to be used with a Core click event.`
+      `Clicked element not found when running "Redirect with identity." This action is meant to be used with a Core click event.`
     );
     return Promise.resolve();
   }
 
-  if (!event.nativeEvent.target || !event.nativeEvent.target.href) {
+  if (!event.element.href) {
     logger.warn(
       `Invalid event target when running "Redirect with identity." This action is meant to be used with a Core click event using an "a[href]" selector.`
     );
@@ -42,7 +42,7 @@ module.exports = ({ instanceManager, document, logger }) => (
     event.nativeEvent.preventDefault();
   }
 
-  const url = event.nativeEvent.target.href;
+  const url = event.element.href;
   return instance("appendIdentityToUrl", { url }).then(
     ({ url: newLocation }) => {
       document.location = newLocation;

--- a/src/lib/actions/redirectWithIdentity/index.js
+++ b/src/lib/actions/redirectWithIdentity/index.js
@@ -15,4 +15,8 @@ const instanceManager = require("../../instanceManager/index");
 
 const document = window.document;
 
-module.exports = createRedirectWithIdentity({ instanceManager, document });
+module.exports = createRedirectWithIdentity({
+  instanceManager,
+  document,
+  logger: turbine.logger
+});

--- a/test/functional/runtime/redirectWithIdentity.spec.js
+++ b/test/functional/runtime/redirectWithIdentity.spec.js
@@ -106,7 +106,7 @@ test("Redirects with an identity", async () => {
   await appendLaunchLibrary(container);
 
   await addHtmlToBody(
-    `<a id="mylink" href="${SECONDARY_TEST_PAGE}">My link</a>`
+    `<a href="${SECONDARY_TEST_PAGE}"><div id="mylink">My link</div></a>`
   );
   // The requestLogger.count method uses TestCafe's smart query
   // assertion mechanism, so it will wait for the request to be

--- a/test/unit/lib/actions/redirectWithIdentity/createRedirectWithIdentity.spec.js
+++ b/test/unit/lib/actions/redirectWithIdentity/createRedirectWithIdentity.spec.js
@@ -28,10 +28,10 @@ describe("createRedirectWithIdentity", () => {
     document = { location: "originalLocation" };
     event = {
       nativeEvent: {
-        preventDefault: jasmine.createSpy("preventDefault"),
-        target: {
-          href: "originalHref"
-        }
+        preventDefault: jasmine.createSpy("preventDefault")
+      },
+      element: {
+        href: "originalHref"
       }
     };
     logger = jasmine.createSpyObj("logger", ["warn"]);
@@ -79,10 +79,9 @@ describe("createRedirectWithIdentity", () => {
       redirectWithIdentity(
         { instanceName: "myinstance" },
         {
-          nativeEvent: {
-            target: {
-              href: "originalHref"
-            }
+          nativeEvent: {},
+          element: {
+            href: "originalHref"
           }
         }
       )


### PR DESCRIPTION

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

When you click on elements like "img" inside an anchor tag, the redirect with identity action does not work to add the identity. This is because the event.nativeElement.target ends up being the img tag and not the anchor tag. Tags also exposes event.element which is always the anchor tag. Using this should fix this bug. Additionally, the logger was not hooked up properly so the attempt to log a warning was throwing an error.
<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-9930
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
