### PR TITLE
Fixed an issue where XDM object data element did not work when there was only one schema

### DIFF
--- a/src/view/dataElements/xdmObject.jsx
+++ b/src/view/dataElements/xdmObject.jsx
@@ -122,6 +122,15 @@ const initializeSchemas = async ({
   if (schemasFirstPage.length === 1 && !schemasFirstPageCursor) {
     const { $id, title, version } = schemasFirstPage[0];
     initialValues.schema2 = { $id, title, version };
+
+    const schema = await fetchSchema({
+      orgId,
+      imsAccess,
+      schemaId: $id,
+      schemaVersion: version,
+      sandboxName
+    });
+    context.schema = schema;
   }
 
   context.schemasFirstPage = schemasFirstPage;

--- a/test/functional/dataElements/xdmObject/xdmObjectSchemaSelection.spec.js
+++ b/test/functional/dataElements/xdmObject/xdmObjectSchemaSelection.spec.js
@@ -15,6 +15,7 @@ import * as sandboxMocks from "../../helpers/endpointMocks/sandboxesMocks";
 import * as schemasMocks from "../../helpers/endpointMocks/schemasMocks";
 import * as schemaMocks from "../../helpers/endpointMocks/schemaMocks";
 import initializeExtensionView from "./helpers/initializeExtensionView";
+import xdmTree from "./helpers/xdmTree";
 import spectrum from "../../helpers/spectrum";
 import editor from "./helpers/editor";
 import createExtensionViewFixture from "../../helpers/createExtensionViewFixture";
@@ -244,6 +245,7 @@ test.requestHooks(
 )("auto-selects schema if the sandbox contains a single schema", async () => {
   await initializeExtensionView();
   await schemaField.expectText("Test Schema 1");
+  await xdmTree.node("testField").expectExists();
 });
 
 test.requestHooks(sandboxMocks.singleWithoutDefault, schemasMocks.multiple)(


### PR DESCRIPTION

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This was caused by some refactoring I did last release.
<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-10078

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
