### PR TITLE
Fix for populating the schema drop down with non default sandbox.

### DIFF
--- a/src/view/utils/createPagedLoader.js
+++ b/src/view/utils/createPagedLoader.js
@@ -26,6 +26,7 @@ export default ({
   let state = IDLE;
   let filterText = "";
   let abortController;
+  let currentLoadItems = loadItems;
 
   const load = async loadingState => {
     state = loadingState;
@@ -39,7 +40,7 @@ export default ({
     let newItems;
     let newCursor;
     try {
-      ({ items: newItems, cursor: newCursor } = await loadItems({
+      ({ items: newItems, cursor: newCursor } = await currentLoadItems({
         filterText,
         cursor,
         signal: currentAbortController.signal
@@ -84,6 +85,9 @@ export default ({
       cursor = null;
       filterText = text;
       load(FILTERING);
+    },
+    setLoadItems(newLoadItems) {
+      currentLoadItems = newLoadItems;
     }
   };
 };

--- a/src/view/utils/fetchSandboxes.js
+++ b/src/view/utils/fetchSandboxes.js
@@ -38,6 +38,21 @@ export default async ({ orgId, imsAccess, signal }) => {
   }
 
   return {
-    results: parsedResponse.parsedBody.sandboxes
+    results: [
+      ...parsedResponse.parsedBody.sandboxes,
+      {
+        name: "my-second-sandbox",
+        title: "My Second Sandbox",
+        state: "active",
+        type: "production",
+        region: "VA7",
+        isDefault: true,
+        eTag: -270737284,
+        createdDate: "2020-09-22 04:46:03",
+        lastModifiedDate: "2020-09-22 04:46:03",
+        createdBy: "system",
+        lastModifiedBy: "system"
+      }
+    ]
   };
 };

--- a/src/view/utils/fetchSandboxes.js
+++ b/src/view/utils/fetchSandboxes.js
@@ -38,21 +38,6 @@ export default async ({ orgId, imsAccess, signal }) => {
   }
 
   return {
-    results: [
-      ...parsedResponse.parsedBody.sandboxes,
-      {
-        name: "my-second-sandbox",
-        title: "My Second Sandbox",
-        state: "active",
-        type: "production",
-        region: "VA7",
-        isDefault: true,
-        eTag: -270737284,
-        createdDate: "2020-09-22 04:46:03",
-        lastModifiedDate: "2020-09-22 04:46:03",
-        createdBy: "system",
-        lastModifiedBy: "system"
-      }
-    ]
+    results: parsedResponse.parsedBody.sandboxes
   };
 };

--- a/src/view/utils/usePagedComboBox.js
+++ b/src/view/utils/usePagedComboBox.js
@@ -60,6 +60,10 @@ const usePagedComboBox = ({
     if (!firstPage) {
       unfilteredLoaderRef.current.reload();
     }
+  } else {
+    // We need to update the loadItems function because there may be
+    // changed dependencies.
+    unfilteredLoaderRef.current.setLoadItems(loadItems);
   }
   const filteredLoaderRef = useRef(null);
   if (filteredLoaderRef.current === null) {
@@ -74,6 +78,10 @@ const usePagedComboBox = ({
       loadItems,
       setData: filteredSetData
     });
+  } else {
+    // We need to update the loadItems function because there may be
+    // changed dependencies.
+    filteredLoaderRef.current.setLoadItems(loadItems);
   }
 
   const getItem = key => {

--- a/test/functional/dataElements/variable.spec.js
+++ b/test/functional/dataElements/variable.spec.js
@@ -396,3 +396,34 @@ test.requestHooks(sandboxMocks.singleWithoutDefault, schemasMocks.paging)(
     );
   }
 );
+
+test
+  .requestHooks(
+    sandboxMocks.multipleWithDefault,
+    schemasMocks.sandbox2,
+    schemasMocks.sandbox3,
+    schemaMocks.schema3b
+  )
+  .only(
+    "Allows you to select a schema from the non-default sandbox",
+    async () => {
+      await extensionViewController.init({});
+      await sandboxField.expectText("PRODUCTION Test Sandbox 2 (VA7)");
+      await sandboxField.selectOption("PRODUCTION Test Sandbox 3 (VA7)");
+
+      await schemaField.openMenu();
+      await schemaField.selectMenuOption("Test Schema 3B");
+      await extensionViewController.expectIsValid();
+      const settings = await extensionViewController.getSettings();
+      delete settings.cacheId;
+      await t.expect(settings).eql({
+        sandbox: {
+          name: "testsandbox3"
+        },
+        schema: {
+          id: "https://ns.adobe.com/unifiedjsqeonly/schemas/schema3b",
+          version: "1.0"
+        }
+      });
+    }
+  );

--- a/test/functional/dataElements/xdmObject/xdmObjectSchemaSelection.spec.js
+++ b/test/functional/dataElements/xdmObject/xdmObjectSchemaSelection.spec.js
@@ -369,3 +369,27 @@ test
       schemasMocks.pagingTitles.slice(-3)
     );
   });
+
+test.requestHooks(
+  sandboxMocks.multipleWithDefault,
+  schemasMocks.sandbox2,
+  schemasMocks.sandbox3,
+  schemaMocks.schema3b
+)("Allows you to select a schema from the non-default sandbox", async () => {
+  const extensionViewController = await initializeExtensionView({});
+  await sandboxField.expectText("PRODUCTION Test Sandbox 2 (VA7)");
+  await sandboxField.selectOption("PRODUCTION Test Sandbox 3 (VA7)");
+
+  await schemaField.openMenu();
+  await schemaField.selectMenuOption("Test Schema 3B");
+  await extensionViewController.expectSettings({
+    data: {},
+    sandbox: {
+      name: "testsandbox3"
+    },
+    schema: {
+      id: "https://ns.adobe.com/unifiedjsqeonly/schemas/schema3b",
+      version: "1.0"
+    }
+  });
+});

--- a/test/functional/helpers/endpointMocks/schemaMocks.js
+++ b/test/functional/helpers/endpointMocks/schemaMocks.js
@@ -133,3 +133,28 @@ export const otherArray = RequestMock()
     200,
     responseHeaders
   );
+
+export const schema3b = RequestMock()
+  .onRequestTo({
+    url: /\/schemaregistry\/tenant\/schemas\/.*schema3b$/,
+    headers: {
+      "x-sandbox-name": "testsandbox3"
+    },
+    method: "GET"
+  })
+  .respond(
+    {
+      $id: "sch123",
+      title: "Test Schema 1",
+      version: "1.0",
+      type: "object",
+      properties: {
+        testField: {
+          title: "Test Field",
+          type: "string"
+        }
+      }
+    },
+    200,
+    responseHeaders
+  );

--- a/test/functional/helpers/endpointMocks/schemasMocks.js
+++ b/test/functional/helpers/endpointMocks/schemasMocks.js
@@ -64,6 +64,65 @@ export const multiple = RequestMock()
     responseHeaders
   );
 
+export const sandbox2 = RequestMock()
+  .onRequestTo(async request => {
+    return (
+      request.url.match(SCHEMAS_ENDPOINT_REGEX) &&
+      request.headers["x-sandbox-name"] === "testsandbox2" &&
+      request.method === "get"
+    );
+  })
+  .respond(
+    {
+      results: [
+        {
+          $id: "https://ns.adobe.com/unifiedjsqeonly/schemas/schema2a",
+          version: "1.0",
+          title: "Test Schema 2A"
+        },
+        {
+          $id: "https://ns.adobe.com/unifiedjsqeonly/schemas/schema2b",
+          version: "1.0",
+          title: "Test Schema 2B"
+        }
+      ],
+      _page: {
+        next: null
+      }
+    },
+    200,
+    responseHeaders
+  );
+
+export const sandbox3 = RequestMock()
+  .onRequestTo(async request => {
+    return (
+      request.url.match(SCHEMAS_ENDPOINT_REGEX) &&
+      request.headers["x-sandbox-name"] === "testsandbox3" &&
+      request.method === "get"
+    );
+  })
+  .respond(
+    {
+      results: [
+        {
+          $id: "https://ns.adobe.com/unifiedjsqeonly/schemas/schema3a",
+          version: "1.0",
+          title: "Test Schema 3A"
+        },
+        {
+          $id: "https://ns.adobe.com/unifiedjsqeonly/schemas/schema3b",
+          version: "1.0",
+          title: "Test Schema 3B"
+        }
+      ],
+      _page: {
+        next: null
+      }
+    },
+    200,
+    responseHeaders
+  );
 export const search = RequestMock()
   .onRequestTo({
     url: /\/schemaregistry\/tenant\/schemas\?.*property=title/,


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

In 2.16.0 I updated the way the sandbox and schema selectors work together. The original function for fetching schemas was not updated as the sandbox changed. This caused the function to still have the closure for the old sandbox so it always fetched the schemas for the default sandbox. This updates that function fixing problems in both the XDM Object data element and Variable data element.

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-10189
https://jira.corp.adobe.com/browse/PDCL-10258
https://jira.corp.adobe.com/browse/PLATIR-28372
https://jira.corp.adobe.com/browse/PDCL-10307

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
