### PR TITLE
Fix config overrides

### DIFF
--- a/src/view/components/overrides/index.js
+++ b/src/view/components/overrides/index.js
@@ -1,0 +1,5 @@
+import Overrides from "./overrides";
+
+export { bridge } from "./overridesBridge";
+
+export default Overrides;

--- a/src/view/components/overrides/overrides.jsx
+++ b/src/view/components/overrides/overrides.jsx
@@ -3,101 +3,11 @@ import Delete from "@spectrum-icons/workflow/Delete";
 import { FieldArray, useField } from "formik";
 import PropTypes from "prop-types";
 import React from "react";
-import { array, number, object, string } from "yup";
-import copyPropertiesIfValueDifferentThanDefault from "../configuration/utils/copyPropertiesIfValueDifferentThanDefault";
-import copyPropertiesWithDefaultFallback from "../configuration/utils/copyPropertiesWithDefaultFallback";
-import FormElementContainer from "./formElementContainer";
-import FormikTextField from "./formikReactSpectrum3/formikTextField";
-import SectionHeader from "./sectionHeader";
-import DataElementSelector from "./dataElementSelector";
 
-export const bridge = {
-  // return formik state
-  getInstanceDefaults: () => ({
-    edgeConfigOverrides: {
-      com_adobe_experience_platform: {
-        datasets: {
-          event: {
-            datasetId: ""
-          }
-        }
-      },
-      com_adobe_analytics: {
-        reportSuites: [""]
-      },
-      com_adobe_identity: {
-        idSyncContainerId: ""
-      },
-      com_adobe_target: {
-        propertyToken: ""
-      }
-    }
-  }),
-  // convert launch settings to formik state
-  getInitialInstanceValues: ({ instanceSettings }) => {
-    const instanceValues = {};
-
-    copyPropertiesWithDefaultFallback({
-      toObj: instanceValues,
-      fromObj: instanceSettings,
-      defaultsObj: bridge.getInstanceDefaults(),
-      keys: ["edgeConfigOverrides"]
-    });
-
-    return instanceValues;
-  },
-  // convert formik state to launch settings
-  getInstanceSettings: ({ instanceValues }) => {
-    const instanceSettings = {};
-    const propertyKeysToCopy = ["edgeConfigOverrides"];
-
-    copyPropertiesIfValueDifferentThanDefault({
-      toObj: instanceSettings,
-      fromObj: instanceValues,
-      defaultsObj: bridge.getInstanceDefaults(),
-      keys: propertyKeysToCopy
-    });
-
-    if (
-      instanceSettings.edgeConfigOverrides?.com_adobe_identity
-        ?.idSyncContainerId
-    ) {
-      // Alloy, Konductor, and Blackbird expect this to be a number
-      instanceSettings.edgeConfigOverrides.com_adobe_identity.idSyncContainerId = parseInt(
-        instanceSettings.edgeConfigOverrides.com_adobe_identity
-          .idSyncContainerId,
-        10
-      );
-    }
-
-    return instanceSettings;
-  },
-  formikStateValidationSchema: object({
-    edgeConfigOverrides: object({
-      com_adobe_experience_platform: object({
-        datasets: object({
-          event: object({
-            datasetId: string()
-          }),
-          profile: object({
-            datasetId: string()
-          })
-        })
-      }),
-      com_adobe_analytics: object({
-        reportSuites: array(string())
-      }),
-      com_adobe_identity: object({
-        idSyncContainerId: number()
-          .positive()
-          .integer()
-      }),
-      com_adobe_target: object({
-        propertyToken: string()
-      })
-    })
-  })
-};
+import FormElementContainer from "../formElementContainer";
+import FormikTextField from "../formikReactSpectrum3/formikTextField";
+import SectionHeader from "../sectionHeader";
+import DataElementSelector from "../dataElementSelector";
 
 /**
  * The names of the different fields that can appear in the form. Used to pass

--- a/src/view/components/overrides/overridesBridge.js
+++ b/src/view/components/overrides/overridesBridge.js
@@ -1,0 +1,91 @@
+import { array, number, object, string } from "yup";
+import copyPropertiesIfValueDifferentThanDefault from "../../configuration/utils/copyPropertiesIfValueDifferentThanDefault";
+import copyPropertiesWithDefaultFallback from "../../configuration/utils/copyPropertiesWithDefaultFallback";
+
+export const bridge = {
+  // return formik state
+  getInstanceDefaults: () => ({
+    edgeConfigOverrides: {
+      com_adobe_experience_platform: {
+        datasets: {
+          event: {
+            datasetId: ""
+          }
+        }
+      },
+      com_adobe_analytics: {
+        reportSuites: [""]
+      },
+      com_adobe_identity: {
+        idSyncContainerId: ""
+      },
+      com_adobe_target: {
+        propertyToken: ""
+      }
+    }
+  }),
+  // convert launch settings to formik state
+  getInitialInstanceValues: ({ instanceSettings }) => {
+    const instanceValues = {};
+
+    copyPropertiesWithDefaultFallback({
+      toObj: instanceValues,
+      fromObj: instanceSettings,
+      defaultsObj: bridge.getInstanceDefaults(),
+      keys: ["edgeConfigOverrides"]
+    });
+
+    return instanceValues;
+  },
+  // convert formik state to launch settings
+  getInstanceSettings: ({ instanceValues }) => {
+    const instanceSettings = {};
+    const propertyKeysToCopy = ["edgeConfigOverrides"];
+
+    copyPropertiesIfValueDifferentThanDefault({
+      toObj: instanceSettings,
+      fromObj: instanceValues,
+      defaultsObj: bridge.getInstanceDefaults(),
+      keys: propertyKeysToCopy
+    });
+
+    if (
+      instanceSettings.edgeConfigOverrides?.com_adobe_identity
+        ?.idSyncContainerId
+    ) {
+      // Alloy, Konductor, and Blackbird expect this to be a number
+      instanceSettings.edgeConfigOverrides.com_adobe_identity.idSyncContainerId = parseInt(
+        instanceSettings.edgeConfigOverrides.com_adobe_identity
+          .idSyncContainerId,
+        10
+      );
+    }
+
+    return instanceSettings;
+  },
+  formikStateValidationSchema: object({
+    edgeConfigOverrides: object({
+      com_adobe_experience_platform: object({
+        datasets: object({
+          event: object({
+            datasetId: string()
+          }),
+          profile: object({
+            datasetId: string()
+          })
+        })
+      }),
+      com_adobe_analytics: object({
+        reportSuites: array(string())
+      }),
+      com_adobe_identity: object({
+        idSyncContainerId: number()
+          .positive()
+          .integer()
+      }),
+      com_adobe_target: object({
+        propertyToken: string()
+      })
+    })
+  })
+};

--- a/src/view/configuration/utils/copyPropertiesWithDefaultFallback.js
+++ b/src/view/configuration/utils/copyPropertiesWithDefaultFallback.js
@@ -16,10 +16,29 @@ governing permissions and limitations under the License.
  * @param {Object} options.toObj Object to which properties should be copied.
  * @param {Object} options.fromObj Object from which properties should be copied.
  * @param {Object} options.defaultsObj Default values for each property.
- * @param {Array} options.keys The keys of the properties that should be copied.
+ * @param {string[]} options.keys The top level keys of the properties that should be copied.
  */
-export default ({ toObj, fromObj, defaultsObj, keys }) => {
+export default function copyPropertiesWithDefaultFallback({
+  toObj,
+  fromObj,
+  defaultsObj,
+  keys
+}) {
   keys.forEach(key => {
+    if (
+      typeof fromObj[key] === "object" &&
+      fromObj[key] !== null &&
+      !Array.isArray(fromObj[key])
+    ) {
+      toObj[key] = toObj[key] ?? {};
+      copyPropertiesWithDefaultFallback({
+        toObj: toObj[key],
+        fromObj: fromObj[key],
+        defaultsObj: defaultsObj[key],
+        keys: Object.keys(defaultsObj[key])
+      });
+      return;
+    }
     toObj[key] = fromObj[key] ?? defaultsObj[key];
   });
-};
+}

--- a/test/unit/view/components/overridesBridge.spec.js
+++ b/test/unit/view/components/overridesBridge.spec.js
@@ -135,5 +135,33 @@ describe("overridesBridge", () => {
         });
       }).not.toThrow();
     });
+
+    it("should coerce the id sync container is a string", () => {
+      expect(() => {
+        const value = bridge.formikStateValidationSchema.validateSync({
+          edgeConfigOverrides: {
+            com_adobe_experience_platform: {
+              datasets: {
+                event: {
+                  datasetId: "6335faf30f5a161c0b4b1444"
+                }
+              }
+            },
+            com_adobe_analytics: {
+              reportSuites: ["unifiedjsqeonly2"]
+            },
+            com_adobe_identity: {
+              idSyncContainerId: "30793"
+            },
+            com_adobe_target: {
+              propertyToken: "a15d008c-5ec0-cabd-7fc7-ab54d56f01e8"
+            }
+          }
+        });
+        expect(
+          value.edgeConfigOverrides.com_adobe_identity.idSyncContainerId
+        ).toBe(30793);
+      }).not.toThrow();
+    });
   });
 });

--- a/test/unit/view/components/overridesBridge.spec.js
+++ b/test/unit/view/components/overridesBridge.spec.js
@@ -28,7 +28,7 @@ describe("overridesBridge", () => {
   });
 
   describe("getInitialInstanceValues", () => {
-    it("it should copy over changed values with default fallbacks", () => {
+    it("should copy over changed values with default fallbacks", () => {
       const instanceSettings = {
         name: "alloy",
         context: [
@@ -82,7 +82,58 @@ describe("overridesBridge", () => {
     });
   });
 
-  describe("getInstanceSettings", () => {});
+  describe("getInstanceSettings", () => {
+    it("should copy over changed values", () => {
+      const instanceValues = {
+        edgeConfigOverrides: {
+          com_adobe_target: {
+            propertyToken: "01dbc634-07c1-d8f9-ca69-b489a5ac5e94"
+          }
+        }
+      };
 
-  describe("formikStateValidationSchema", () => {});
+      const instanceSettings = bridge.getInstanceSettings({
+        instanceValues
+      });
+      expect(instanceSettings).toEqual({
+        edgeConfigOverrides: {
+          com_adobe_target: {
+            propertyToken: "01dbc634-07c1-d8f9-ca69-b489a5ac5e94"
+          }
+        }
+      });
+    });
+  });
+
+  describe("formikStateValidationSchema", () => {
+    it("should return a yup schema", () => {
+      const schema = bridge.formikStateValidationSchema;
+      expect(schema).toBeDefined();
+    });
+
+    it("should validate the edge config overrides", () => {
+      expect(() => {
+        bridge.formikStateValidationSchema.validateSync({
+          edgeConfigOverrides: {
+            com_adobe_experience_platform: {
+              datasets: {
+                event: {
+                  datasetId: "6335faf30f5a161c0b4b1444"
+                }
+              }
+            },
+            com_adobe_analytics: {
+              reportSuites: ["unifiedjsqeonly2"]
+            },
+            com_adobe_identity: {
+              idSyncContainerId: 30793
+            },
+            com_adobe_target: {
+              propertyToken: "a15d008c-5ec0-cabd-7fc7-ab54d56f01e8"
+            }
+          }
+        });
+      }).not.toThrow();
+    });
+  });
 });

--- a/test/unit/view/components/overridesBridge.spec.js
+++ b/test/unit/view/components/overridesBridge.spec.js
@@ -1,0 +1,88 @@
+// eslint-disable-next-line import/extensions
+import { bridge } from "../../../../src/view/components/overrides/overridesBridge.js";
+
+describe("overridesBridge", () => {
+  describe("getInstanceDefaults", () => {
+    it("should return default values", () => {
+      expect(bridge.getInstanceDefaults()).toEqual({
+        edgeConfigOverrides: {
+          com_adobe_experience_platform: {
+            datasets: {
+              event: {
+                datasetId: ""
+              }
+            }
+          },
+          com_adobe_analytics: {
+            reportSuites: [""]
+          },
+          com_adobe_identity: {
+            idSyncContainerId: ""
+          },
+          com_adobe_target: {
+            propertyToken: ""
+          }
+        }
+      });
+    });
+  });
+
+  describe("getInitialInstanceValues", () => {
+    it("it should copy over changed values with default fallbacks", () => {
+      const instanceSettings = {
+        name: "alloy",
+        context: [
+          "web",
+          "device",
+          "environment",
+          "placeContext",
+          "highEntropyUserAgentHints"
+        ],
+        sandbox: "prod",
+        edgeDomain: "firstparty.alloyio.com",
+        edgeConfigId: "140a1d7d-90ac-44d4-921e-6bb819da36b7",
+        stagingSandbox: "prod",
+        onBeforeEventSend:
+          '// Pass the ECID from the adobe_mc param if it exists.\n\nconsole.log("IN ON BEFORE EVENT SEND");\n\nvar adobeMcEcid = _satellite.getVar("adobeMcEcid");\n\nif (adobeMcEcid) {\n  // TODO: Expire existing kndctr_ORG ID_AdobeOrg_identity\n  \n  if (!content.xdm.identityMap) {\n    content.xdm.identityMap = {\n      ECID: []\n    }\n  }\n  \n  content.xdm.identityMap.ECID = [{\n    "id": adobeMcEcid,\n    "authenticatedState": "ambiguous"\n  }];\n  \n  console.log("ECID WAS ADDED TO EVENT -> XDM -> IDENTITYMAP");\n}',
+        developmentSandbox: "prod",
+        edgeConfigOverrides: {
+          com_adobe_target: {
+            propertyToken: "01dbc634-07c1-d8f9-ca69-b489a5ac5e94"
+          }
+        },
+        stagingEdgeConfigId: "140a1d7d-90ac-44d4-921e-6bb819da36b7:stage",
+        targetMigrationEnabled: true,
+        developmentEdgeConfigId: "140a1d7d-90ac-44d4-921e-6bb819da36b7:dev",
+        thirdPartyCookiesEnabled: false
+      };
+
+      const instanceValues = bridge.getInitialInstanceValues({
+        instanceSettings
+      });
+      expect(instanceValues).toEqual({
+        edgeConfigOverrides: {
+          com_adobe_target: {
+            propertyToken: "01dbc634-07c1-d8f9-ca69-b489a5ac5e94"
+          },
+          com_adobe_analytics: {
+            reportSuites: [""]
+          },
+          com_adobe_identity: {
+            idSyncContainerId: ""
+          },
+          com_adobe_experience_platform: {
+            datasets: {
+              event: {
+                datasetId: ""
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+
+  describe("getInstanceSettings", () => {});
+
+  describe("formikStateValidationSchema", () => {});
+});

--- a/test/unit/view/configuration/utils/copyPropertiesWithDefaultFallback.spec.js
+++ b/test/unit/view/configuration/utils/copyPropertiesWithDefaultFallback.spec.js
@@ -1,0 +1,47 @@
+import copyPropertiesWithDefaultFallback from "../../../../../src/view/configuration/utils/copyPropertiesWithDefaultFallback";
+
+describe("copyPropertiesWithDefaultFallback", () => {
+  it("should copy only the keys specified", () => {
+    const toObj = {};
+    const fromObj = {
+      a: "foo",
+      b: "bar",
+      c: ""
+    };
+    const defaultsObj = {
+      a: "",
+      b: "",
+      c: ""
+    };
+    const keys = ["a", "b"];
+    copyPropertiesWithDefaultFallback({
+      toObj,
+      fromObj,
+      defaultsObj,
+      keys
+    });
+    expect(Object.keys(toObj)).toEqual(keys);
+  });
+
+  it("should copy the default values when the key has not changed", () => {
+    const toObj = {};
+    const fromObj = {
+      a: "",
+      b: "bar",
+      c: ""
+    };
+    const defaultsObj = {
+      a: "",
+      b: "",
+      c: ""
+    };
+    const keys = ["a", "b"];
+    copyPropertiesWithDefaultFallback({
+      toObj,
+      fromObj,
+      defaultsObj,
+      keys
+    });
+    expect(toObj).toEqual({ a: "", b: "bar" });
+  });
+});

--- a/test/unit/view/configuration/utils/copyPropertiesWithDefaultFallback.spec.js
+++ b/test/unit/view/configuration/utils/copyPropertiesWithDefaultFallback.spec.js
@@ -44,4 +44,45 @@ describe("copyPropertiesWithDefaultFallback", () => {
     });
     expect(toObj).toEqual({ a: "", b: "bar" });
   });
+
+  it("should support copying nested objects", () => {
+    const toObj = {};
+    const fromObj = {
+      a: "foo",
+      c: {
+        d: {
+          e: "baz"
+        }
+      }
+    };
+    const defaultsObj = {
+      a: "",
+      b: "",
+      c: {
+        d: {
+          e: "",
+          f: ""
+        },
+        g: ""
+      }
+    };
+    const keys = ["a", "b", "c"];
+    copyPropertiesWithDefaultFallback({
+      toObj,
+      fromObj,
+      defaultsObj,
+      keys
+    });
+    expect(toObj).toEqual({
+      a: "foo",
+      b: "",
+      c: {
+        d: {
+          e: "baz",
+          f: ""
+        },
+        g: ""
+      }
+    });
+  });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

In testing for the release, we found an issue where the the extension would throw an error after saving a configuration with overrides. This is because the default report suites overrides array was not getting copied over to the new formik state, and the component to render each of the input for each report suite was hitting a null value.

This branch changes `copyPropertiesWithDefaultFallback()` to support nested objects. It also adds unit tests for it and for the overrides bridges.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
