### PR TITLE
Give a default to the overrides view for new rules

### DIFF
--- a/src/view/actions/redirectWithIdentity.jsx
+++ b/src/view/actions/redirectWithIdentity.jsx
@@ -20,13 +20,16 @@ import Alert from "../components/alert";
 import Overrides, { bridge as overridesBridge } from "../components/overrides";
 
 const getInitialValues = ({ initInfo }) => {
-  const { instanceName = initInfo.extensionSettings.instances[0].name } =
-    initInfo.settings || {};
+  const {
+    instanceName = initInfo.extensionSettings.instances[0].name,
+    edgeConfigOverrides = overridesBridge.getInstanceDefaults()
+      .edgeConfigOverrides
+  } = initInfo.settings ?? {};
 
   return {
     instanceName,
     ...overridesBridge.getInitialInstanceValues({
-      instanceSettings: initInfo.settings
+      instanceSettings: { edgeConfigOverrides }
     })
   };
 };

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -38,7 +38,9 @@ const getInitialValues = ({ initInfo }) => {
     type = "",
     mergeId = "",
     datasetId = "",
-    documentUnloading = false
+    documentUnloading = false,
+    edgeConfigOverrides = overridesBridge.getInstanceDefaults()
+      .edgeConfigOverrides
   } = initInfo.settings || {};
 
   return {
@@ -53,7 +55,7 @@ const getInitialValues = ({ initInfo }) => {
     ...decisionScopesBridge.getInitialValues({ initInfo }),
     ...surfacesBridge.getInitialValues({ initInfo }),
     ...overridesBridge.getInitialInstanceValues({
-      instanceSettings: initInfo.settings
+      instanceSettings: { edgeConfigOverrides }
     })
   };
 };

--- a/src/view/actions/setConsent.jsx
+++ b/src/view/actions/setConsent.jsx
@@ -55,14 +55,16 @@ const getInitialValues = ({ initInfo }) => {
   const {
     instanceName = initInfo.extensionSettings.instances[0].name,
     identityMap = "",
-    consent
+    consent,
+    edgeConfigOverrides = overridesBridge.getInstanceDefaults()
+      .edgeConfigOverrides
   } = initInfo.settings || {};
 
   const initialValues = {
     instanceName,
     identityMap,
     ...overridesBridge.getInitialInstanceValues({
-      instanceSettings: initInfo.settings
+      instanceSettings: { edgeConfigOverrides }
     })
   };
 


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When a new rule is created, `initInfo.settings` is `null`. I didn't know that, so I assumed that it would be present. When creating a new rule, we now pass in a sane default.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
