### PR TITLE
Deprecate the datasetId option

### DIFF
--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -28,6 +28,7 @@ import Overrides, { bridge as overridesBridge } from "../components/overrides";
 import { DATA_ELEMENT_REQUIRED } from "../constants/validationErrorMessages";
 import FormElementContainer from "../components/formElementContainer";
 import InstanceNamePicker from "../components/instanceNamePicker";
+import { deepAssign } from "../utils/deepAssign";
 
 const getInitialValues = ({ initInfo }) => {
   const {
@@ -42,6 +43,16 @@ const getInitialValues = ({ initInfo }) => {
     edgeConfigOverrides = overridesBridge.getInstanceDefaults()
       .edgeConfigOverrides
   } = initInfo.settings || {};
+  const initialOverrides = overridesBridge.getInitialInstanceValues({
+    instanceSettings: { edgeConfigOverrides }
+  });
+  if (datasetId) {
+    deepAssign(
+      initialOverrides,
+      "edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId",
+      datasetId
+    );
+  }
 
   return {
     instanceName,
@@ -50,13 +61,10 @@ const getInitialValues = ({ initInfo }) => {
     data,
     type,
     mergeId,
-    datasetId,
     documentUnloading,
     ...decisionScopesBridge.getInitialValues({ initInfo }),
     ...surfacesBridge.getInitialValues({ initInfo }),
-    ...overridesBridge.getInitialInstanceValues({
-      instanceSettings: { edgeConfigOverrides }
-    })
+    ...initialOverrides
   };
 };
 
@@ -94,8 +102,14 @@ const getSettings = ({ values }) => {
   if (values.mergeId) {
     settings.mergeId = values.mergeId;
   }
+  // datasetId is deprecated in favor of edgeConfigOverrides
   if (values.datasetId) {
-    settings.datasetId = values.datasetId;
+    // deep assign to settings.edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId
+    deepAssign(
+      settings,
+      "edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId",
+      values.datasetId
+    );
   }
   // Only add if the value is different than the default (false).
   if (values.documentUnloading) {

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -239,9 +239,9 @@ const SendEvent = () => {
           <DataElementSelector>
             <FormikTextField
               data-test-id="datasetIdField"
-              name="datasetId"
-              description="Send data to a different dataset than what's been provided in the datastream."
-              label="Dataset ID"
+              name="edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId"
+              description={`Send data to a different dataset than what's been provided in the datastream. Note: this option is deprecated. Use "Event dataset" in the "Datastream Configuration Overrides" options instead.`}
+              label="Dataset ID (deprecated)"
               width="size-5000"
             />
           </DataElementSelector>

--- a/src/view/utils/deepAssign.js
+++ b/src/view/utils/deepAssign.js
@@ -1,0 +1,24 @@
+/**
+ * Assign a value to a property path on an object without modifying nearby
+ * properties. Modifies the target object.
+ *
+ * @param {{ [key: string]: * }} target The destination object for the value
+ * @param {string} path The property path to set. A string of period-separated keys
+ * @param {*} value
+ * @returns {void}
+ * @example
+ * const obj = {};
+ * deepAssign(obj, "a.b.c", 1);
+ * console.log(obj); // { a: { b: { c: 1 } } }
+ */
+export function deepAssign(target, path, value) {
+  const [key, ...rest] = path.split(".");
+  if (rest.length === 0) {
+    target[key] = value;
+  } else {
+    if (!target[key]) {
+      target[key] = {};
+    }
+    deepAssign(target[key], rest.join("."), value);
+  }
+}

--- a/test/unit/view/utils/deepAssign.spec.js
+++ b/test/unit/view/utils/deepAssign.spec.js
@@ -1,0 +1,21 @@
+import { deepAssign } from "../../../../src/view/utils/deepAssign";
+
+describe("deepAssign", () => {
+  it("should assign a value to a property path on an object without modifying nearby properties", () => {
+    const obj = { a: { b: { e: 2 }, d: 1 } };
+    deepAssign(obj, "a.b.c", 1);
+    expect(obj).toEqual({ a: { b: { c: 1, e: 2 }, d: 1 } });
+  });
+
+  it("should overwrite existing values", () => {
+    const obj = { a: { b: { e: 2 }, d: 1 } };
+    deepAssign(obj, "a.b.e", 3);
+    expect(obj).toEqual({ a: { b: { e: 3 }, d: 1 } });
+  });
+
+  it("should throw an error when a non-object is encountered in the path", () => {
+    expect(() => {
+      deepAssign(1, "a.b.c", 1);
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

The following changes are on the `sendEvent` action configuration page

- Add a deprecation notice to the label and field description for the `datasetId` option
- When loading existing settings, take the old `datasetId` value and put it into `edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId`
- When saving new settings, take anything saved in `datasetId` and put it in `edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId` instead. This codepath will never be run, but it's a safety measure.
- Keep the `datasetId` input field, but have it mirror exactly the `edgeConfigOverrides.com_adobe_experience_platform.datasets.event.datasetId` input field. They map to the same value and changes in one reflect the other.
- Create `deepAssign()` (with unit tests), a small utility function that assigns to a string path of an nested object

For example,

```js
const obj = {};
deepAssign(obj, "a.b.c", 1);
console.log(obj); // { a: { b: { c: 1 } } }
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-10349: Deprecate `datasetId` option in Web SDK Tags Extension UI](https://jira.corp.adobe.com/browse/PDCL-10349)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

With the advent of datastream configuration overrides, [we have deprecated the `datasetId` option for the `sendEvent` command. Alloy shows a console warning to use the new option when `datasetId` is used](https://github.com/adobe/alloy/blob/08c77750e9f9db23fbff84d744f3e300888ab181/src/components/DataCollector/index.js#L71). 

## Screenshots (if appropriate):

<img width="453" alt="image" src="https://user-images.githubusercontent.com/18412686/234044743-ae86545d-c9bc-4c46-80d0-fd21cf4fea7c.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
