### PR TITLE
Added deprecation notice to sendEvent datasetId option

### DIFF
--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -226,8 +226,8 @@ const SendEvent = () => {
             <FormikTextField
               data-test-id="datasetIdField"
               name="datasetId"
-              description="Send data to a different dataset than what's been provided in the datastream."
-              label="Dataset ID"
+              description='Send data to a different dataset than what&apos;s been provided in the datastream. Note: this option is deprecated. Use "Event dataset" in the "Datastream Configuration Overrides" options instead.'
+              label="Dataset ID (deprecated)"
               width="size-5000"
             />
           </DataElementSelector>


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Following [this comment in #307](https://github.com/adobe/reactor-extension-alloy/pull/307#issuecomment-1522135488),
Add a deprecation notice to the `datasetId` input field on the `sendEvent` action.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

<img width="446" alt="image" src="https://user-images.githubusercontent.com/18412686/234354599-4ec9410f-e9a9-45fd-834e-d5c58abbd565.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.
