### PR TITLE
Fix more issues with config overrides and datastream overrides

### DIFF
--- a/src/view/components/overrides/overrides.jsx
+++ b/src/view/components/overrides/overrides.jsx
@@ -325,7 +325,7 @@ const Overrides = ({
                             envEdgeConfigIds.datastreamId
                               ? ` (${envEdgeConfigIds.datastreamId})`
                               : ""
-                          }. This does not support cross-organization datastream overrides.`}
+                          }.`}
                           orgId={configOrgId}
                           imsAccess={initInfo.tokens.imsAccess}
                           name={`${prefix}.${env}.datastreamId`}

--- a/src/view/components/overrides/overrides.jsx
+++ b/src/view/components/overrides/overrides.jsx
@@ -155,9 +155,9 @@ const Overrides = ({
       edgeConfigId:
         edgeConfigOverrides.development.datastreamId ||
         edgeConfigIds.developmentEnvironment.datastreamId,
-      sandbox:
-        edgeConfigOverrides.development.sandbox ||
-        edgeConfigIds.developmentEnvironment.sandbox,
+      sandbox: edgeConfigOverrides.development.datastreamId
+        ? edgeConfigOverrides.development.sandbox
+        : edgeConfigIds.developmentEnvironment.sandbox,
       requestCache
     }),
     [STAGING]: useFetchConfig({
@@ -167,9 +167,9 @@ const Overrides = ({
       edgeConfigId:
         edgeConfigOverrides.staging.datastreamId ||
         edgeConfigIds.stagingEnvironment.datastreamId,
-      sandbox:
-        edgeConfigOverrides.staging.sandbox ||
-        edgeConfigIds.stagingEnvironment.sandbox,
+      sandbox: edgeConfigOverrides.staging.datastreamId
+        ? edgeConfigOverrides.staging.sandbox
+        : edgeConfigIds.stagingEnvironment.sandbox,
       requestCache
     }),
     [PRODUCTION]: useFetchConfig({
@@ -179,9 +179,9 @@ const Overrides = ({
       edgeConfigId:
         edgeConfigOverrides.production.datastreamId ||
         edgeConfigIds.productionEnvironment.datastreamId,
-      sandbox:
-        edgeConfigOverrides.production.sandbox ||
-        edgeConfigIds.productionEnvironment.sandbox,
+      sandbox: edgeConfigOverrides.production.datastreamId
+        ? edgeConfigOverrides.production.sandbox
+        : edgeConfigIds.productionEnvironment.sandbox,
       requestCache
     })
   };

--- a/src/view/components/overrides/overridesBridge.js
+++ b/src/view/components/overrides/overridesBridge.js
@@ -15,6 +15,8 @@ import copyPropertiesIfValueDifferentThanDefault from "../../configuration/utils
 import copyPropertiesWithDefaultFallback from "../../configuration/utils/copyPropertiesWithDefaultFallback";
 import trimValue from "../../utils/trimValues";
 
+const dataElementRegex = /^([^%\n]*(%[^%\n]+%)+[^%\n]*)$/gi;
+
 export const bridge = {
   // return formik state
   getInstanceDefaults: () => ({
@@ -118,7 +120,7 @@ export const bridge = {
       // number, unless it is a data element (/^%.+%$/gi)
       if (
         overrides.com_adobe_identity?.idSyncContainerId &&
-        !/^%.+%$/gi.test(overrides.com_adobe_identity.idSyncContainerId)
+        !dataElementRegex.test(overrides.com_adobe_identity.idSyncContainerId)
       ) {
         overrides.com_adobe_identity.idSyncContainerId = parseInt(
           overrides.com_adobe_identity.idSyncContainerId,
@@ -161,7 +163,7 @@ export const bridge = {
             com_adobe_identity: object({
               idSyncContainerId: lazy(value =>
                 typeof value === "string" && value.includes("%")
-                  ? string().matches(/^([^%\n]*(%[^%\n]+%)+[^%\n]*)$/gi)
+                  ? string().matches(dataElementRegex)
                   : number()
                       .positive()
                       .integer()


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
- [x] When a datastream is not selected, but you select a different sandbox, the options reload and revert to a text entry.
- [x] Remove the "this does not support cross-organization datastream overrides" text
- [x] Cannot save-load a partial data element in the ID sync container ID field (e.g. "%My data element%1234")

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
