### PR TITLE
Fix inefficient data element regex for overrides

### DIFF
--- a/src/view/components/overrides/utils.js
+++ b/src/view/components/overrides/utils.js
@@ -83,7 +83,7 @@ export const createIsItemInArray = (
   };
 };
 
-export const dataElementRegex = /^([^%\n]*(%[^%\n]+%)+[^%\n]*)+$/i;
+export const dataElementRegex = /^([^%\n]*%[^%\n]+%)+[^%\n]*$/i;
 
 /**
  * Returns whether or not the value is a data element expression

--- a/test/unit/view/components/overrides/utils.spec.js
+++ b/test/unit/view/components/overrides/utils.spec.js
@@ -39,7 +39,7 @@ describe("overrides/utils.js", () => {
       ],
       [
         "should validate multiple data elements in the same string",
-        "%my data element% %my other data element%"
+        "%my data element% %my other data element%%my third data element%%my fourth data element%"
       ]
     ].forEach(([testName, testValue]) => {
       it(testName, () => {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

From Jon Snyder

> The regex you have is: `/^(a*(%a+%)+a*)+$/` where `a = [^%\n]`
> So the inefficiency is that if you had a bunch of data elements all in a row, e.g. `%foo%%bar%`, the regex could iterate on the inner loop or the outer loop, and to make sure nothing worked it would try all combinations.
> a better way would be to do it like this: `/^(a*%a+%)+a*$/ e.g. /^([^%\n]*%[^%\n]+%)+[^%\n]*$/`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
