### PR TITLE
Make extension.json formatting more similar to the prior formatting

### DIFF
--- a/scripts/helpers/buildExtensionManifest.js
+++ b/scripts/helpers/buildExtensionManifest.js
@@ -72,7 +72,10 @@ const stringify = (obj, prettyPrint = true) => {
     return result;
   }
   const prettierConfig = prettier.resolveConfig();
-  return prettier.format(result, { ...prettierConfig, parser: "json" });
+  return prettier.format(result, {
+    ...prettierConfig,
+    parser: "json-stringify"
+  });
 };
 
 /**


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
Format `extension.json` using the same formatting as `JSON.stringify()` instead of formatting it like prettier's default Javascript formatting.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Brent says that the script changed the formatting of the `extension.json` too much and it makes finding changes difficult and asked that I change it to something more similar to what it was in the past (see the screenshot: 2.19.0 is the left, 2.20.1 is the right). 

![image](https://github.com/adobe/reactor-extension-alloy/assets/18412686/b280f2d9-2add-4aa7-876e-5efcfa0d3099)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
