### PR TITLE
Fixed issue where data elements could not be saved in ID sync container ID field

### DIFF
--- a/scripts/helpers/createExtensionManifest.js
+++ b/scripts/helpers/createExtensionManifest.js
@@ -77,7 +77,15 @@ const createEdgeConfigOverridesSchema = isAction => {
       type: "object",
       properties: {
         idSyncContainerId: {
-          type: "integer"
+          anyOf: [
+            {
+              type: "integer"
+            },
+            {
+              type: "string",
+              pattern: "^([^%\n]*%[^%\n]+%)+[^%\n]*$"
+            }
+          ]
         }
       },
       required: ["idSyncContainerId"]

--- a/scripts/helpers/createExtensionManifest.js
+++ b/scripts/helpers/createExtensionManifest.js
@@ -82,8 +82,7 @@ const createEdgeConfigOverridesSchema = isAction => {
               type: "integer"
             },
             {
-              type: "string",
-              pattern: "^([^%\n]*%[^%\n]+%)+[^%\n]*$"
+              type: "string"
             }
           ]
         }

--- a/src/lib/utils/createGetConfigOverrides.js
+++ b/src/lib/utils/createGetConfigOverrides.js
@@ -51,6 +51,18 @@ const createGetConfigOverrides = environmentName => settings => {
       .filter(Boolean);
   }
 
+  if (
+    computedConfigOverrides.com_adobe_identity?.idSyncContainerId !==
+      undefined &&
+    computedConfigOverrides.com_adobe_identity?.idSyncContainerId !== null &&
+    typeof computedConfigOverrides.com_adobe_identity?.idSyncContainerId ===
+      "string"
+  ) {
+    computedConfigOverrides.com_adobe_identity.idSyncContainerId = parseInt(
+      computedConfigOverrides.com_adobe_identity.idSyncContainerId.trim(),
+      10
+    );
+  }
   return computedConfigOverrides;
 };
 

--- a/src/lib/utils/createGetConfigOverrides.js
+++ b/src/lib/utils/createGetConfigOverrides.js
@@ -58,10 +58,18 @@ const createGetConfigOverrides = environmentName => settings => {
     typeof computedConfigOverrides.com_adobe_identity?.idSyncContainerId ===
       "string"
   ) {
-    computedConfigOverrides.com_adobe_identity.idSyncContainerId = parseInt(
+    const parsedValue = parseInt(
       computedConfigOverrides.com_adobe_identity.idSyncContainerId.trim(),
       10
     );
+    if (Number.isNaN(parsedValue)) {
+      throw new Error(
+        `The ID sync container ID "${
+          computedConfigOverrides.com_adobe_identity.idSyncContainerId
+        }" is not a valid integer.`
+      );
+    }
+    computedConfigOverrides.com_adobe_identity.idSyncContainerId = parsedValue;
   }
   return computedConfigOverrides;
 };

--- a/test/unit/lib/utils/createGetConfigOverrides.spec.js
+++ b/test/unit/lib/utils/createGetConfigOverrides.spec.js
@@ -127,6 +127,25 @@ describe("createGetConfigOverrides", () => {
           }
         });
       });
+
+      it("should throw an exception with a friendly error when the ID sync container ID cannot be parsed to an int", () => {
+        expect(() => {
+          createConfigOverrides(
+            {
+              edgeConfigOverrides: {
+                [stage]: {
+                  com_adobe_identity: {
+                    idSyncContainerId: "not a number"
+                  }
+                }
+              }
+            },
+            stage
+          );
+        }).toThrowError(
+          `The ID sync container ID "not a number" is not a valid integer.`
+        );
+      });
     });
   });
 

--- a/test/unit/lib/utils/createGetConfigOverrides.spec.js
+++ b/test/unit/lib/utils/createGetConfigOverrides.spec.js
@@ -89,6 +89,44 @@ describe("createGetConfigOverrides", () => {
           }
         });
       });
+
+      it("should convert string values to numbers when appropriate", () => {
+        const result = createConfigOverrides(
+          {
+            edgeConfigOverrides: {
+              [stage]: {
+                com_adobe_identity: {
+                  idSyncContainerId: "30793"
+                }
+              }
+            }
+          },
+          stage
+        );
+        expect(result).toEqual({
+          com_adobe_identity: {
+            idSyncContainerId: 30793
+          }
+        });
+
+        const result2 = createConfigOverrides(
+          {
+            edgeConfigOverrides: {
+              [stage]: {
+                com_adobe_identity: {
+                  idSyncContainerId: 30793
+                }
+              }
+            }
+          },
+          stage
+        );
+        expect(result2).toEqual({
+          com_adobe_identity: {
+            idSyncContainerId: 30793
+          }
+        });
+      });
     });
   });
 


### PR DESCRIPTION


<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
Where the `extension.json` previously only allowed `number` in the ID sync container ID field, with this change, it allows either a `number` or a `string` that matches the regex `^([^%\n]*%[^%\n]+%)+[^%\n]*$` for data elements.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PLATIR-30215](https://jira.corp.adobe.com/browse/PLATIR-30215?focusedCommentId=37547998&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-37547998)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Our automated tests do not test the `extension.json`, so it slipped through the cracks.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
