### PR TITLE
Record Alloy instances to window

### DIFF
--- a/src/lib/.eslintrc.js
+++ b/src/lib/.eslintrc.js
@@ -14,7 +14,11 @@ module.exports = {
     "no-var": "off",
     "func-names": "off",
     "import/no-default-export": 2,
-    "import/no-named-export": 2
+    "import/no-named-export": 2,
+    "no-underscore-dangle": [
+      "error",
+      { allow: ["__alloyNS", "__alloyMonitors"] }
+    ]
   },
   globals: {
     turbine: "readonly"

--- a/src/lib/instanceManager/createInstanceManager.js
+++ b/src/lib/instanceManager/createInstanceManager.js
@@ -32,6 +32,10 @@ module.exports = ({
     }) => {
       const instance = createInstance({ name });
       window[name] = instance;
+      if (!window.__alloyNS) {
+        window.__alloyNS = [];
+      }
+      window.__alloyNS.push(name);
       instanceByName[name] = instance;
       const environment = turbine.environment && turbine.environment.stage;
 

--- a/test/unit/lib/instanceManager/createInstanceManager.spec.js
+++ b/test/unit/lib/instanceManager/createInstanceManager.spec.js
@@ -79,7 +79,11 @@ describe("Instance Manager", () => {
 
   it("creates SDK instances", () => {
     build();
-    expect(mockWindow).toEqual({ alloy1, alloy2 });
+    expect(mockWindow).toEqual({
+      alloy1,
+      alloy2,
+      __alloyNS: ["alloy1", "alloy2"]
+    });
   });
 
   it("configures an SDK instance for each configured instance", () => {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

In [the Alloy base code](https://experienceleague.adobe.com/docs/experience-platform/edge/fundamentals/installing-the-sdk.html?lang=en#adding-the-code), it stores the name of all created Alloy instances on the `window.__alloyNS` array. But when created through Launch, the names of Alloy instances are not reported anywhere. 

With this PR, the names of instances are put into `window.__alloyNS`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-11125](https://jira.corp.adobe.com/browse/PDCL-11125)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

With this change, external tools (like the AEP debugger) can be knowledgable of Alloy instances created by Launch.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
