### PR TITLE
Add defaultPersonalizationEnabled option to sendEvent

### DIFF
--- a/scripts/helpers/createExtensionManifest.js
+++ b/scripts/helpers/createExtensionManifest.js
@@ -436,6 +436,9 @@ const createExtensionManifest = ({ version }) => {
                 },
                 includeRenderedPropositions: {
                   type: "boolean"
+                },
+                defaultPersonalizationEnabled: {
+                  type: "boolean"
                 }
               },
               additionalProperties: false

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -79,13 +79,15 @@ const wrapGetSettings = getSettings => ({ values }) => {
     surfaces,
     sendDisplayEvent,
     includeRenderedPropositions,
+    defaultPersonalizationEnabled,
     ...settings
   } = getSettings({ values });
   if (
     decisionScopes ||
     surfaces ||
     sendDisplayEvent === false ||
-    includeRenderedPropositions
+    includeRenderedPropositions ||
+    defaultPersonalizationEnabled
   ) {
     settings.personalization = {};
   }
@@ -100,6 +102,10 @@ const wrapGetSettings = getSettings => ({ values }) => {
   }
   if (includeRenderedPropositions) {
     settings.personalization.includeRenderedPropositions = includeRenderedPropositions;
+  }
+  if (defaultPersonalizationEnabled) {
+    settings.personalization.defaultPersonalizationEnabled =
+      defaultPersonalizationEnabled === "true";
   }
   return settings;
 };
@@ -233,6 +239,31 @@ const sendDisplayEventUnchecked = disabledCheckbox({
   beta: true
 });
 
+const defaultPersonalizationEnabledField = radioGroup({
+  name: "defaultPersonalizationEnabled",
+  label: "Request default personalization",
+  dataElementSupported: false,
+  defaultValue: "auto",
+  items: [
+    {
+      value: "auto",
+      label:
+        "Automatic - request default personalization when it has not yet been requested."
+    },
+    {
+      value: "true",
+      label:
+        "Enabled - explicitly request the page scope and default surface. This will also refresh the view cache."
+    },
+    {
+      value: "false",
+      label:
+        "Disabled - explicitly suppress the request for the page scope and default surface."
+    }
+  ],
+  beta: true
+});
+
 const configOverrideFields = configOverrides();
 const datasetIdField = textField({
   name: "datasetId",
@@ -274,7 +305,8 @@ const sendEventForm = form(
           decisionScopesField,
           surfacesField,
           renderDecisionsField,
-          sendDisplayEventField
+          sendDisplayEventField,
+          defaultPersonalizationEnabledField
         ]),
         configOverrideFields,
         datasetIdField
@@ -320,7 +352,8 @@ const sendEventForm = form(
               decisionScopesField,
               surfacesField,
               renderDecisionsField,
-              sendDisplayEventUnchecked
+              sendDisplayEventUnchecked,
+              defaultPersonalizationEnabledField
             ]),
             configOverrideFields
           ]

--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -253,7 +253,7 @@ const defaultPersonalizationEnabledField = radioGroup({
     {
       value: "true",
       label:
-        "Enabled - explicitly request the page scope and default surface. This will also refresh the view cache."
+        "Enabled - explicitly request the page scope and default surface. This will update the SPA view cache."
     },
     {
       value: "false",


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

<img width="402" alt="Screenshot 2023-10-26 at 11 33 23 PM" src="https://github.com/adobe/reactor-extension-alloy/assets/952132/2e2eda2a-4f86-4f0d-9c86-80726d0a1270">
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
