### PR TITLE
When one item, fieldArray delete button clears

### DIFF
--- a/src/view/forms/fieldArray.jsx
+++ b/src/view/forms/fieldArray.jsx
@@ -253,11 +253,16 @@ export default function fieldArray({
                             <ActionButton
                               data-test-id={`${namePrefix}${name}${index}RemoveButton`}
                               isQuiet
-                              isDisabled={items.length === 1}
                               variant="secondary"
                               onPress={() => {
                                 // using arrayHelpers.remove mangles the error message
-                                setItems(items.filter((_, i) => i !== index));
+                                const newItems = items.filter(
+                                  (_, i) => i !== index
+                                );
+                                if (newItems.length === 0) {
+                                  newItems.push("");
+                                }
+                                setItems(newItems);
                               }}
                               aria-label={`Remove ${label} ${index + 1}`}
                               marginTop={0}


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

Previously, when there was only one item in an array, the delete button was disabled. Now the delete button is active, but when you click it, it just clears the text from the item, leaving the text box there.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
