### PR TITLE
Fixed an issue where saving Config Overrides without all 3 environments set would crash the extension.

### DIFF
--- a/src/view/components/overrides/overrides.jsx
+++ b/src/view/components/overrides/overrides.jsx
@@ -73,6 +73,7 @@ const Overrides = ({
     : "edgeConfigOverrides";
   const hideFieldsSet = new Set(hideFields);
 
+  /** @type {{value: import("./overridesBridge").EnvironmentConfigOverrideFormikState}[] } */
   const [{ value: edgeConfigOverrides }] = useField(prefix);
   const formikContext = useFormikContext();
   /**
@@ -117,9 +118,9 @@ const Overrides = ({
       configOrgId,
       imsAccess: initInfo.tokens.imsAccess,
       edgeConfigId:
-        edgeConfigOverrides.development.datastreamId ||
+        edgeConfigOverrides.development?.datastreamId ||
         edgeConfigIds.developmentEnvironment.datastreamId,
-      sandbox: edgeConfigOverrides.development.datastreamId
+      sandbox: edgeConfigOverrides.development?.datastreamId
         ? edgeConfigOverrides.development.sandbox
         : edgeConfigIds.developmentEnvironment.sandbox,
       requestCache
@@ -129,11 +130,11 @@ const Overrides = ({
       configOrgId,
       imsAccess: initInfo.tokens.imsAccess,
       edgeConfigId:
-        edgeConfigOverrides.staging.datastreamId ||
-        edgeConfigIds.stagingEnvironment.datastreamId,
-      sandbox: edgeConfigOverrides.staging.datastreamId
-        ? edgeConfigOverrides.staging.sandbox
-        : edgeConfigIds.stagingEnvironment.sandbox,
+        edgeConfigOverrides.staging?.datastreamId ||
+        edgeConfigIds.stagingEnvironment?.datastreamId,
+      sandbox: edgeConfigOverrides.staging?.datastreamId
+        ? edgeConfigOverrides.staging?.sandbox
+        : edgeConfigIds.stagingEnvironment?.sandbox,
       requestCache
     }),
     [PRODUCTION]: useFetchConfig({
@@ -141,9 +142,9 @@ const Overrides = ({
       configOrgId,
       imsAccess: initInfo.tokens.imsAccess,
       edgeConfigId:
-        edgeConfigOverrides.production.datastreamId ||
+        edgeConfigOverrides.production?.datastreamId ||
         edgeConfigIds.productionEnvironment.datastreamId,
-      sandbox: edgeConfigOverrides.production.datastreamId
+      sandbox: edgeConfigOverrides.production?.datastreamId
         ? edgeConfigOverrides.production.sandbox
         : edgeConfigIds.productionEnvironment.sandbox,
       requestCache

--- a/src/view/components/overrides/overridesBridge.js
+++ b/src/view/components/overrides/overridesBridge.js
@@ -16,8 +16,57 @@ import copyPropertiesWithDefaultFallback from "../../configuration/utils/copyPro
 import trimValue from "../../utils/trimValues";
 import { dataElementRegex } from "./utils";
 
+/**
+ * @typedef {Object} EnvironmentConfigOverrideFormikState
+ * @property {string} [sandbox]
+ * @property {string} [datastreamId]
+ * @property {string} [datastreamIdInputMethod]
+ * @property {Object} [com_adobe_experience_platform]
+ * @property {Object} [com_adobe_experience_platform.datasets]
+ * @property {Object} [com_adobe_experience_platform.datasets.event]
+ * @property {string} [com_adobe_experience_platform.datasets.event.datasetId]
+ * @property {Object} [com_adobe_experience_platform.datasets.profile]
+ * @property {string} [com_adobe_experience_platform.datasets.profile.datasetId]
+ * @property {Object} [com_adobe_analytics]
+ * @property {string[]} [com_adobe_analytics.reportSuites]
+ * @property {Object} [com_adobe_identity]
+ * @property {string} [com_adobe_identity.idSyncContainerId]
+ * @property {Object} [com_adobe_target]
+ * @property {string} [com_adobe_target.propertyToken]
+ *
+ * @typedef {Object} ConfigOverridesFormikState
+ * @property {EnvironmentConfigOverrideFormikState} [development]
+ * @property {EnvironmentConfigOverrideFormikState} [staging]
+ * @property {EnvironmentConfigOverrideFormikState} [production]
+ *
+ * @typedef {Object} EnvironmentConfigOverrideLaunchSettings
+ * @property {string} [sandbox]
+ * @property {string} [datastreamId]
+ * @property {string} [datastreamIdInputMethod]
+ * @property {Object} [com_adobe_experience_platform]
+ * @property {Object} [com_adobe_experience_platform.datasets]
+ * @property {Object} [com_adobe_experience_platform.datasets.event]
+ * @property {string} [com_adobe_experience_platform.datasets.event.datasetId]
+ * @property {Object} [com_adobe_experience_platform.datasets.profile]
+ * @property {string} [com_adobe_experience_platform.datasets.profile.datasetId]
+ * @property {Object} [com_adobe_analytics]
+ * @property {string[]} [com_adobe_analytics.reportSuites]
+ * @property {Object} [com_adobe_identity]
+ * @property {number} [com_adobe_identity.idSyncContainerId]
+ * @property {Object} [com_adobe_target]
+ * @property {string} [com_adobe_target.propertyToken]
+ *
+ * @typedef {Object} ConfigOverridesLaunchSettings
+ * @property {EnvironmentConfigOverrideLaunchSettings} [development]
+ * @property {EnvironmentConfigOverrideLaunchSettings} [staging]
+ * @property {EnvironmentConfigOverrideLaunchSettings} [production]
+ */
+
 export const bridge = {
-  // return formik state
+  /**
+   * Get the default formik state for the overrides form.
+   * @returns {ConfigOverridesFormikState}
+   */
   getInstanceDefaults: () => ({
     edgeConfigOverrides: OVERRIDE_ENVIRONMENTS.reduce(
       (acc, env) => ({
@@ -47,8 +96,11 @@ export const bridge = {
       {}
     )
   }),
-
-  // convert launch settings to formik state
+  /**
+   * Converts the saved Launch instance settings to the formik state.
+   * @param {{ edgeConfigOverrides: ConfigOverridesLaunchSettings }} params
+   * @returns {ConfigOverridesFormikState}
+   */
   getInitialInstanceValues: ({ instanceSettings }) => {
     const instanceValues = {};
 
@@ -98,8 +150,13 @@ export const bridge = {
 
     return instanceValues;
   },
-  // convert formik state to launch settings
+  /**
+   * Converts the formik state to the Launch instance settings.
+   * @param {{ instanceValues: { edgeConfigOverrides: ConfigOverridesFormikState }}} params
+   * @returns {{ edgeConfigOverrides: ConfigOverridesLaunchSettings }}
+   */
   getInstanceSettings: ({ instanceValues }) => {
+    /** @type {{ edgeConfigOverrides?: ConfigOverridesLaunchSettings }} */
     const instanceSettings = {};
     const propertyKeysToCopy = ["edgeConfigOverrides"];
 
@@ -111,6 +168,7 @@ export const bridge = {
     });
 
     OVERRIDE_ENVIRONMENTS.forEach(env => {
+      /** @type {EnvironmentConfigOverrideLaunchSettings} */
       const overrides = instanceSettings.edgeConfigOverrides?.[env];
       if (!overrides || Object.keys(overrides).length === 0) {
         return;
@@ -135,6 +193,7 @@ export const bridge = {
       }
     });
 
+    /** @type {{ edgeConfigOverrides: ConfigOverridesLaunchSettings }} */
     const trimmedInstanceSettings = trimValue(instanceSettings);
     if (
       trimmedInstanceSettings?.edgeConfigOverrides?.development?.sandbox ===

--- a/test/functional/specs/configuration/configuration.spec.js
+++ b/test/functional/specs/configuration/configuration.spec.js
@@ -1756,3 +1756,35 @@ test.requestHooks(
     await instances[1].overrides.textFields.reportSuiteOverrides[0].expectIsTextField();
   }
 );
+
+test("allows the setting of overrides in only a single environment", async () => {
+  await extensionViewController.init();
+  await instances[0].edgeConfig.inputMethodFreeformRadio.click();
+  await instances[0].edgeConfig.inputMethodFreeform.productionEnvironmentField.typeText(
+    "PR123"
+  );
+  await instances[0].overrides.envTabs.development.click();
+  await instances[0].overrides.textFields.eventDatasetOverride.typeText(
+    "6336ff95ba16ca1c07b4c0db"
+  );
+  await extensionViewController.expectIsValid();
+  await extensionViewController.expectSettings({
+    instances: [
+      {
+        edgeConfigId: "PR123",
+        name: "alloy",
+        edgeConfigOverrides: {
+          development: {
+            com_adobe_experience_platform: {
+              datasets: {
+                event: {
+                  datasetId: "6336ff95ba16ca1c07b4c0db"
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  });
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

The `<Overrides/>` React component was looking for the `datastreamId` for every config overrides environment, even if that environment had no settings. If an environment had no settings, then it would be looking for a `datastreamId` on `undefined`, which crashes the extension.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-11375: Setting Third Party Sync ID and saving break the extension](https://jira.corp.adobe.com/browse/PDCL-11375)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
