### PR TITLE
If the deploy fails, wait 5 minutes

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,11 +22,13 @@ npm run package
 echo "$REACTOR_IO_INTEGRATION_PRIVATE_KEY_CONTENTS" > private.key
 
 # reactor-uploader 5.0.5 has a bug where an error occurs during upload
+# If this fails we sleep for 5 minutes, then run the next command. Sometimes the upload
+# just needs a little time to complete.
 npx @adobe/reactor-uploader@5.0.4 package-adobe-alloy-${VERSION}.zip \
   --org-id=97D1F3F459CE0AD80A495CBE@AdobeOrg \
   --tech-account-id=CC7A4BD95E695DBA0A495EB7@techacct.adobe.com \
   --api-key=f401a5fe22184c91a85fd441a8aa2976 \
-  --private-key="./private.key"
+  --private-key="./private.key" || sleep 300
 
 echo "Y" | npx @adobe/reactor-releaser \
   --org-id=97D1F3F459CE0AD80A495CBE@AdobeOrg \


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

We've had some issues with the deploy to Tags taking longer than expected. This change makes it so that if that happens we just wait 5 minutes and then run the releaser. The best fix will be to update the uploader so that the timeout is configurable, but in the mean time we can use this change.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
