### PR TITLE
Fixed typo in audienceManager: Change `M` to `m`

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -1043,7 +1043,7 @@ const createExtensionManifest = ({ version }) => {
                   type: "array",
                   minItems: 1,
                   items: {
-                    enum: ["analytics", "target", "audienceManager"]
+                    enum: ["analytics", "target", "audiencemanager"]
                   },
                   required: ["name"],
                   additionalProperties: false

--- a/src/lib/actions/updateVariable/createUpdateVariable.js
+++ b/src/lib/actions/updateVariable/createUpdateVariable.js
@@ -14,17 +14,25 @@ const { deletePath } = require("../../utils/pathUtils");
 
 module.exports =
   ({ variableStore, deepAssign }) =>
-  ({ data, dataElementCacheId, transforms, customCode }, event) => {
-    const existingValue = Object.keys(transforms || {}).reduce((memo, path) => {
-      const { clear } = transforms[path];
-      return clear ? deletePath(memo, path) : memo;
-    }, variableStore[dataElementCacheId] || {});
+    ({ data, dataElementCacheId, transforms, customCode }, event) => {
+      const existingValue = Object.keys(transforms || {}).reduce((memo, path) => {
+        const { clear } = transforms[path];
+        return clear ? deletePath(memo, path) : memo;
+      }, variableStore[dataElementCacheId] || {});
 
-    variableStore[dataElementCacheId] = deepAssign({}, existingValue, data);
+      variableStore[dataElementCacheId] = deepAssign({}, existingValue, data);
 
-    if (customCode) {
-      customCode(variableStore[dataElementCacheId], event);
-    }
+      if (customCode) {
+        customCode(variableStore[dataElementCacheId], event);
+      }
 
-    return Promise.resolve();
-  };
+      // This is a temporary fix to support the 'audienceManager' property that should be lowercased.
+      // eslint-disable-next-line no-underscore-dangle
+      const analytics = variableStore[dataElementCacheId]?.__adobe?.analytics || {};
+      if (analytics.audienceManager) {
+        analytics.audiencemanager = analytics.audienceManager;
+        delete analytics.audienceManager;
+      }
+
+      return Promise.resolve();
+    };

--- a/src/lib/actions/updateVariable/createUpdateVariable.js
+++ b/src/lib/actions/updateVariable/createUpdateVariable.js
@@ -14,25 +14,25 @@ const { deletePath } = require("../../utils/pathUtils");
 
 module.exports =
   ({ variableStore, deepAssign }) =>
-    ({ data, dataElementCacheId, transforms, customCode }, event) => {
-      const existingValue = Object.keys(transforms || {}).reduce((memo, path) => {
-        const { clear } = transforms[path];
-        return clear ? deletePath(memo, path) : memo;
-      }, variableStore[dataElementCacheId] || {});
+  ({ data, dataElementCacheId, transforms, customCode }, event) => {
+    const existingValue = Object.keys(transforms || {}).reduce((memo, path) => {
+      const { clear } = transforms[path];
+      return clear ? deletePath(memo, path) : memo;
+    }, variableStore[dataElementCacheId] || {});
 
-      variableStore[dataElementCacheId] = deepAssign({}, existingValue, data);
+    variableStore[dataElementCacheId] = deepAssign({}, existingValue, data);
 
-      if (customCode) {
-        customCode(variableStore[dataElementCacheId], event);
-      }
+    if (customCode) {
+      customCode(variableStore[dataElementCacheId], event);
+    }
 
-      // This is a temporary fix to support the 'audienceManager' property that should be lowercased.
-      // eslint-disable-next-line no-underscore-dangle
-      const analytics = variableStore[dataElementCacheId]?.__adobe?.analytics || {};
-      if (analytics.audienceManager) {
-        analytics.audiencemanager = analytics.audienceManager;
-        delete analytics.audienceManager;
-      }
+    // This is a temporary fix to support the 'audienceManager' property that should be lowercased.
+    // eslint-disable-next-line no-underscore-dangle
+    const adobe = variableStore[dataElementCacheId]?.__adobe || {};
+    if (adobe.audienceManager) {
+      adobe.audiencemanager = adobe.audienceManager;
+      delete adobe.audienceManager;
+    }
 
-      return Promise.resolve();
-    };
+    return Promise.resolve();
+  };

--- a/src/view/actions/updateVariable.jsx
+++ b/src/view/actions/updateVariable.jsx
@@ -110,11 +110,12 @@ const getInitialFormStateFromDataElement = async ({
 
     // Temporary fix to support the audienceManager property that should have been lowercased.
     // eslint-disable-next-line no-underscore-dangle
-    const analytics = data?.__adobe?.analytics || {};
-    if (analytics.audienceManager) {
-      analytics.audiencemanager = analytics.audienceManager;
-      delete analytics.audienceManager;
+    const adobe = data?.data?.__adobe || {};
+    if (adobe.audienceManager) {
+      adobe.audiencemanager = adobe.audienceManager;
+      delete adobe.audienceManager;
     }
+    console.log("getInitialFormState from data element", data);
 
     return getInitialFormState({
       schema,
@@ -130,124 +131,124 @@ const getInitialFormStateFromDataElement = async ({
 
 const getInitialValues =
   context =>
-    async ({ initInfo }) => {
-      const {
-        propertySettings: { id: propertyId } = {},
-        company: { orgId },
-        tokens: { imsAccess }
-      } = initInfo;
-      const {
-        dataElementId,
-        transforms = {},
-        schema: previouslySavedSchemaInfo,
-        customCode = ""
-      } = initInfo.settings || {};
+  async ({ initInfo }) => {
+    const {
+      propertySettings: { id: propertyId } = {},
+      company: { orgId },
+      tokens: { imsAccess }
+    } = initInfo;
+    const {
+      dataElementId,
+      transforms = {},
+      schema: previouslySavedSchemaInfo,
+      customCode = ""
+    } = initInfo.settings || {};
 
-      let { data = {} } = initInfo.settings || {};
+    let { data = {} } = initInfo.settings || {};
 
-      const initialValues = {
-        data,
-        customCode
-      };
-
-      const {
-        results: dataElementsFirstPage,
-        nextPage: dataElementsFirstPageCursor
-      } = await fetchDataElements({
-        orgId,
-        imsAccess,
-        propertyId
-      });
-
-      context.dataElementsFirstPage = dataElementsFirstPage;
-      context.dataElementsFirstPageCursor = dataElementsFirstPageCursor;
-
-      let dataElement;
-      if (dataElementId) {
-        dataElement = await fetchDataElement({
-          orgId,
-          imsAccess,
-          dataElementId
-        });
-        context.previouslySavedSchemaInfo = previouslySavedSchemaInfo;
-      } else if (
-        dataElementsFirstPage.length === 1 &&
-        dataElementsFirstPageCursor === null
-      ) {
-        dataElement = dataElementsFirstPage[0];
-      }
-
-      initialValues.dataElement = dataElement;
-
-      if (dataElement) {
-        const prefix = isDataVariable(dataElement) ? "data" : "xdm";
-        const prefixedTransforms = Object.keys(transforms).reduce((memo, key) => {
-          // The key for a root element transform is "".
-          memo[key === "" ? prefix : `${prefix}.${key}`] = transforms[key];
-          return memo;
-        }, {});
-
-        data = { [prefix]: data };
-
-        const initialFormState = await getInitialFormStateFromDataElement({
-          dataElement,
-          context,
-          orgId,
-          imsAccess,
-          data,
-          transforms: prefixedTransforms
-        });
-
-        return { ...initialValues, ...initialFormState };
-      }
-
-      return initialValues;
+    const initialValues = {
+      data,
+      customCode
     };
 
-const getSettings =
-  context =>
-    ({ values }) => {
-      const { dataElement } = values;
-      const { id: dataElementId, settings } = dataElement || {};
-      const { cacheId: dataElementCacheId } = settings || {};
+    const {
+      results: dataElementsFirstPage,
+      nextPage: dataElementsFirstPageCursor
+    } = await fetchDataElements({
+      orgId,
+      imsAccess,
+      propertyId
+    });
 
-      const transforms = {};
+    context.dataElementsFirstPage = dataElementsFirstPage;
+    context.dataElementsFirstPageCursor = dataElementsFirstPageCursor;
 
-      const { xdm, data } =
-        getValueFromFormState({ formStateNode: values, transforms }) || {};
+    let dataElement;
+    if (dataElementId) {
+      dataElement = await fetchDataElement({
+        orgId,
+        imsAccess,
+        dataElementId
+      });
+      context.previouslySavedSchemaInfo = previouslySavedSchemaInfo;
+    } else if (
+      dataElementsFirstPage.length === 1 &&
+      dataElementsFirstPageCursor === null
+    ) {
+      dataElement = dataElementsFirstPage[0];
+    }
 
-      const dataTransforms = Object.keys(transforms).reduce((memo, key) => {
-        const period = key.indexOf(".");
-        memo[key.substring(period === -1 ? key.length : period + 1)] =
-          transforms[key];
+    initialValues.dataElement = dataElement;
+
+    if (dataElement) {
+      const prefix = isDataVariable(dataElement) ? "data" : "xdm";
+      const prefixedTransforms = Object.keys(transforms).reduce((memo, key) => {
+        // The key for a root element transform is "".
+        memo[key === "" ? prefix : `${prefix}.${key}`] = transforms[key];
         return memo;
       }, {});
 
-      const schema = {
-        id: context.schema?.$id,
-        version: context.schema?.version
-      };
+      data = { [prefix]: data };
 
-      const response = {
-        dataElementId,
-        dataElementCacheId,
-        data: xdm || data || {}
-      };
+      const initialFormState = await getInitialFormStateFromDataElement({
+        dataElement,
+        context,
+        orgId,
+        imsAccess,
+        data,
+        transforms: prefixedTransforms
+      });
 
-      if (schema.id) {
-        response.schema = schema;
-      }
+      return { ...initialValues, ...initialFormState };
+    }
 
-      if (Object.keys(dataTransforms).length > 0) {
-        response.transforms = dataTransforms;
-      }
+    return initialValues;
+  };
 
-      if (values.customCode) {
-        response.customCode = values.customCode;
-      }
+const getSettings =
+  context =>
+  ({ values }) => {
+    const { dataElement } = values;
+    const { id: dataElementId, settings } = dataElement || {};
+    const { cacheId: dataElementCacheId } = settings || {};
 
-      return response;
+    const transforms = {};
+
+    const { xdm, data } =
+      getValueFromFormState({ formStateNode: values, transforms }) || {};
+
+    const dataTransforms = Object.keys(transforms).reduce((memo, key) => {
+      const period = key.indexOf(".");
+      memo[key.substring(period === -1 ? key.length : period + 1)] =
+        transforms[key];
+      return memo;
+    }, {});
+
+    const schema = {
+      id: context.schema?.$id,
+      version: context.schema?.version
     };
+
+    const response = {
+      dataElementId,
+      dataElementCacheId,
+      data: xdm || data || {}
+    };
+
+    if (schema.id) {
+      response.schema = schema;
+    }
+
+    if (Object.keys(dataTransforms).length > 0) {
+      response.transforms = dataTransforms;
+    }
+
+    if (values.customCode) {
+      response.customCode = values.customCode;
+    }
+
+    return response;
+  };
 
 const validationSchema = object().shape({
   dataElement: object().required("Please specify a data element.")
@@ -255,14 +256,14 @@ const validationSchema = object().shape({
 
 const validateFormikState =
   context =>
-    ({ values }) => {
-      const { schema } = context;
-      if (!schema) {
-        return {};
-      }
+  ({ values }) => {
+    const { schema } = context;
+    if (!schema) {
+      return {};
+    }
 
-      return validate(values);
-    };
+    return validate(values);
+  };
 
 const findFirstNodeIdForDepth = (formStateNode, depth) => {
   const {

--- a/src/view/components/objectEditor/helpers/generateSchemaFromSolutions.js
+++ b/src/view/components/objectEditor/helpers/generateSchemaFromSolutions.js
@@ -22,13 +22,15 @@ export default solutions => ({
         __adobe: {
           title: "Adobe",
           type: "object",
-          properties: solutions.reduce((accumulator, currentValue) => {
-            accumulator[currentValue] = {
+          properties: solutions.reduce((accumulator, solutionKey) => {
+            // Temporary support for 'audienceManager' property that should have been lowercased.
+            const solutionKeyLower = solutionKey.toLowerCase();
+            accumulator[solutionKeyLower] = {
               type:
-                currentValue === "analytics" ? OBJECT_ANALYTICS : OBJECT_JSON,
+                solutionKeyLower === "analytics" ? OBJECT_ANALYTICS : OBJECT_JSON,
               expandPaths: false,
               title: solutionsContext.find(
-                ([solution]) => currentValue === solution
+                ([solution]) => solutionKeyLower === solution
               )[1]
             };
             return accumulator;

--- a/src/view/constants/solutions.js
+++ b/src/view/constants/solutions.js
@@ -16,4 +16,4 @@ governing permissions and limitations under the License.
  */
 export const ADOBE_ANALYTICS = "analytics";
 export const ADOBE_TARGET = "target";
-export const ADOBE_AUDIENCE_MANAGER = "audienceManager";
+export const ADOBE_AUDIENCE_MANAGER = "audiencemanager";

--- a/src/view/dataElements/variable/components/dataVariable.jsx
+++ b/src/view/dataElements/variable/components/dataVariable.jsx
@@ -27,7 +27,8 @@ export const bridge = {
     const { solutions = [] } = settings;
 
     const initialValues = {
-      solutions
+      // Temporary support for 'audienceManager' property that should have been lowercased.
+      solutions: solutions.map(s => s.toLowerCase())
     };
 
     return initialValues;

--- a/test/functional/helpers/endpointMocks/dataElementMocks.js
+++ b/test/functional/helpers/endpointMocks/dataElementMocks.js
@@ -58,7 +58,7 @@ const testSolutionsVariable1 = {
     delegate_descriptor_id: "adobe-alloy::dataElements::variable",
     settings: JSON.stringify({
       cacheId: "7b2c068c-6c4c-44bd-b9ad-35a15b7c1959",
-      solutions: ["analytics", "target", "audienceManager"]
+      solutions: ["analytics", "target", "audiencemanager"]
     })
   }
 };

--- a/test/functional/helpers/endpointMocks/dataElementsMocks.js
+++ b/test/functional/helpers/endpointMocks/dataElementsMocks.js
@@ -136,7 +136,7 @@ const testSolutionsVariable1 = {
     delegate_descriptor_id: "adobe-alloy::dataElements::variable",
     settings: JSON.stringify({
       cacheId: "7b2c068c-6c4c-44bd-b9ad-35a15b7c1959",
-      solutions: ["analytics", "target", "audienceManager"]
+      solutions: ["analytics", "target", "audiencemanager"]
     })
   }
 };


### PR DESCRIPTION
## Description

Edge expected the AAM solution in data to be `data.__adobe.audiencemanager`, lower case m.

## Related Issue

https://jira.corp.adobe.com/browse/PLATIR-39445

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
