### PR TITLE
subscribeContentCards event

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -963,6 +963,36 @@ const createExtensionManifest = ({ version }) => {
             ]
           }
         }
+      },
+      {
+        name: "subscribe-content-cards",
+        displayName: "Subscribe content cards",
+        libPath: "dist/lib/events/subscribeContentCards/index.js",
+        viewPath: "events/subscribeContentCards.html",
+        schema: {
+          $schema: "http://json-schema.org/draft-04/schema#",
+          type: "object",
+          instanceName: {
+            type: "string",
+            minLength: 1
+          },
+          surfaces: {
+            anyOf: [
+              {
+                type: "array",
+                minItems: 1,
+                items: {
+                  type: "string",
+                  minLength: 1
+                }
+              },
+              {
+                type: "string",
+                pattern: "^%[^%]+%$"
+              }
+            ]
+          }
+        }
       }
     ],
     dataElements: [

--- a/src/lib/events/subscribeContentCards/createSubscribeContentCards.js
+++ b/src/lib/events/subscribeContentCards/createSubscribeContentCards.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports =
+  ({ instanceManager }) =>
+  (settings, trigger) => {
+    const { instanceName, ...options } = settings;
+
+    const instance = instanceManager.getInstance(instanceName);
+    if (!instance) {
+      throw new Error(
+        `Failed to subscribe content cards for instance "${instanceName}". No instance was found with this name.`
+      );
+    }
+
+    return instance("subscribeContentCards", {
+      ...options,
+      callback: trigger
+    });
+  };

--- a/src/lib/events/subscribeContentCards/index.js
+++ b/src/lib/events/subscribeContentCards/index.js
@@ -1,0 +1,16 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const createSubscribeContentCards = require("./createSubscribeContentCards");
+const instanceManager = require("../../instanceManager/index");
+
+module.exports = createSubscribeContentCards({ instanceManager });

--- a/src/view/events/subscribeContentCards.html
+++ b/src/view/events/subscribeContentCards.html
@@ -8,6 +8,6 @@
   <body>
     <div id="root"></div>
     <script src="https://assets.adobedtm.com/activation/reactor/extensionbridge/extensionbridge.min.js"></script>
-    <script type="module" src="subscribeRulesetItems.jsx"></script>
+    <script type="module" src="subscribeContentCards.jsx"></script>
   </body>
 </html>

--- a/src/view/events/subscribeContentCards.jsx
+++ b/src/view/events/subscribeContentCards.jsx
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { string } from "yup";
+import renderForm from "../forms/renderForm";
+import form from "../forms/form";
+import instancePicker from "../forms/instancePicker";
+import fieldArray from "../forms/fieldArray";
+import { validateSurface } from "../utils/surfaceUtils";
+import notice from "../forms/notice";
+
+const subscribeContentCardsForm = form({}, [
+  notice({
+    title: "Subscribe content cards",
+    description:
+      "This event will trigger the rule whenever there are content cards that have matched. This is a good place to add an action to render the content cards. You can use the data element `%event.items%` to access the content cards. Or within a custom code action it is available as `event.items`.  Convenience methods `rendered`, 'clicked' and 'dismissed' are also available.",
+    beta: true
+  }),
+  instancePicker({ name: "instanceName" }),
+  fieldArray({
+    name: "surfaces",
+    label: "Surfaces",
+    singularLabel: "Surface",
+    description: "Create an array of surfaces to filter the content cards.",
+    dataElementDescription:
+      "This data element should resolve to an array of surfaces.",
+    validationSchema: string().test(
+      "is-surface",
+      () => "Please provide a valid surface",
+      (value, testContext) => {
+        const message = validateSurface(value);
+        if (message) {
+          return testContext.createError({ message });
+        }
+        return true;
+      }
+    )
+  })
+]);
+
+renderForm(subscribeContentCardsForm);


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This PR adds a new event type to support the `subscribeContentCards` command.  See related alloy PR: https://github.com/adobe/alloy/pull/1125

This is my first time contributing to this repo, so please take a close look and let me know your feedback! 😄 

## Screenshots (if appropriate):

![screenshot-2024-05-24 at 16 50 22@2x](https://github.com/adobe/reactor-extension-alloy/assets/427213/1043f758-fb8b-4818-9da7-26f8538c5ba8)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

