### PR TITLE
New settings to manage improved click collection

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -282,6 +282,30 @@ const createExtensionManifest = ({ version }) => {
                 clickCollectionEnabled: {
                   type: "boolean",
                 },
+                clickCollection: {
+                  type: "object",
+                  properties: {
+                    internalLinkEnabled: {
+                      type: "boolean",
+                    },
+                    externalLinkEnabled: {
+                      type: "boolean",
+                    },
+                    downloadLinkEnabled: {
+                      type: "boolean",
+                    },
+                    useSessionStorage: {
+                      type: "boolean",
+                    },
+                    eventGroupingEnabled: {
+                      type: "boolean",
+                    },
+                    filterClickProperties: {
+                      type: "string",
+                      minLength: 1,
+                    },
+                  },
+                },
                 downloadLinkQualifier: {
                   type: "string",
                   minLength: 1,

--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -300,7 +300,7 @@ const createExtensionManifest = ({ version }) => {
                     eventGroupingEnabled: {
                       type: "boolean",
                     },
-                    filterClickProperties: {
+                    filterClickDetails: {
                       type: "string",
                       minLength: 1,
                     },

--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -294,7 +294,7 @@ const createExtensionManifest = ({ version }) => {
                     downloadLinkEnabled: {
                       type: "boolean",
                     },
-                    useSessionStorage: {
+                    sessionStorageEnabled: {
                       type: "boolean",
                     },
                     eventGroupingEnabled: {

--- a/src/view/components/codeField.jsx
+++ b/src/view/components/codeField.jsx
@@ -30,6 +30,7 @@ const CodeField = ({
   description,
   language,
   placeholder,
+  beta,
 }) => {
   const [{ value }, { touched, error }, { setValue, setTouched }] =
     useField(name);
@@ -68,6 +69,7 @@ const CodeField = ({
       description={description}
       error={touched && error ? error : undefined}
       onPress={onPress}
+      beta={beta}
     />
   );
 };
@@ -79,6 +81,7 @@ CodeField.propTypes = {
   buttonLabelSuffix: PropTypes.string,
   name: PropTypes.string.isRequired,
   description: PropTypes.node,
+  beta: PropTypes.bool,
   language: PropTypes.string,
   placeholder: PropTypes.string,
 };

--- a/src/view/components/codePreview.jsx
+++ b/src/view/components/codePreview.jsx
@@ -22,6 +22,7 @@ import {
 import CodeIcon from "@spectrum-icons/workflow/Code";
 import FieldDescriptionAndError from "./fieldDescriptionAndError";
 import "./codePreview.styl";
+import BetaBadge from "./betaBadge";
 
 const CodePreview = ({
   "data-test-id": dataTestId,
@@ -32,6 +33,7 @@ const CodePreview = ({
   description,
   error,
   onPress,
+  beta,
 }) => {
   return (
     // To get this element to shrink to its contents, we had to use
@@ -42,6 +44,7 @@ const CodePreview = ({
     // textarea sizing when there is a label on it.
     <View position="relative" alignSelf="flex-start">
       <LabeledValue label={label} aria-label={ariaLabel} />
+      {beta && <BetaBadge />}
       <FieldDescriptionAndError description={description} error={error}>
         <TextArea
           width="size-5000"
@@ -73,6 +76,7 @@ CodePreview.propTypes = {
   description: PropTypes.node,
   error: PropTypes.string,
   onPress: PropTypes.func.isRequired,
+  beta: PropTypes.bool,
 };
 
 export default CodePreview;

--- a/src/view/configuration/dataCollectionSection.jsx
+++ b/src/view/configuration/dataCollectionSection.jsx
@@ -28,6 +28,7 @@ import copyPropertiesWithDefaultFallback from "./utils/copyPropertiesWithDefault
 import FormElementContainer from "../components/formElementContainer";
 import FieldDescriptionAndError from "../components/fieldDescriptionAndError";
 import BetaBadge from "../components/betaBadge";
+import Alert from "../components/alert";
 
 const CONTEXT_GRANULARITY = {
   ALL: "all",
@@ -81,6 +82,7 @@ export const bridge = {
         downloadLinkEnabled: true,
         sessionStorageEnabled: false,
         eventGroupingEnabled: false,
+        filterClickProperties: "",
       },
       downloadLinkQualifier:
         "\\.(exe|zip|wav|mp3|mov|mpg|avi|wmv|pdf|doc|docx|xls|xlsx|ppt|pptx)$",
@@ -134,13 +136,6 @@ export const bridge = {
     if (instanceValues.contextGranularity === CONTEXT_GRANULARITY.SPECIFIC) {
       instanceSettings.context = instanceValues.context;
     }
-    // if (
-    //   instanceValues.onBeforeLinkClickSend &&
-    //   instanceValues.clickCollection.filterClickProperties
-    // ) {
-    //   console.warn("Both onBeforeLinkClickSend and filterClickProperties are defined. onBeforeLinkClickSend is deprecated and will be ignored.");
-    // }
-
     return instanceSettings;
   },
   instanceValidationSchema: object().shape({
@@ -287,7 +282,6 @@ const DataCollectionSection = ({ instanceFieldName }) => {
                   beta
                 />
               </Flex>
-
               <Flex gap="size-100">
                 <CodeField
                   data-test-id="onBeforeLinkClickSendEditButton"
@@ -301,6 +295,15 @@ const DataCollectionSection = ({ instanceFieldName }) => {
                   }
                 />
               </Flex>
+              {instanceValues.onBeforeLinkClickSend &&
+                instanceValues.clickCollection.filterClickProperties && (
+                  <Alert variant="notice" title="Warning">
+                    Both filter-click-properties and on-before-link-click-send
+                    callbacks have been defined. On-before-link-click-send has
+                    been deprecated and will not be used if
+                    filter-click-properties is available.
+                  </Alert>
+                )}
             </FieldSubset>
           )}
         </div>

--- a/src/view/configuration/dataCollectionSection.jsx
+++ b/src/view/configuration/dataCollectionSection.jsx
@@ -82,7 +82,7 @@ export const bridge = {
         downloadLinkEnabled: true,
         sessionStorageEnabled: false,
         eventGroupingEnabled: false,
-        filterClickProperties: "",
+        filterClickDetails: "",
       },
       downloadLinkQualifier:
         "\\.(exe|zip|wav|mp3|mov|mpg|avi|wmv|pdf|doc|docx|xls|xlsx|ppt|pptx)$",
@@ -270,10 +270,10 @@ const DataCollectionSection = ({ instanceFieldName }) => {
 
               <Flex gap="size-100">
                 <CodeField
-                  data-test-id="filterClickPropertiesEditButton"
+                  data-test-id="filterClickDetailsEditButton"
                   label="Filter click properties"
                   buttonLabelSuffix="filter click properties callback code"
-                  name={`${instanceFieldName}.clickCollection.filterClickProperties`}
+                  name={`${instanceFieldName}.clickCollection.filterClickDetails`}
                   description="Callback function to evaluate and modify click-related properties before collection."
                   language="javascript"
                   placeholder={
@@ -296,7 +296,7 @@ const DataCollectionSection = ({ instanceFieldName }) => {
                 />
               </Flex>
               {instanceValues.onBeforeLinkClickSend &&
-                instanceValues.clickCollection.filterClickProperties && (
+                instanceValues.clickCollection.filterClickDetails && (
                   <Alert variant="notice" title="Warning">
                     Both filter-click-properties and on-before-link-click-send
                     callbacks have been defined. On-before-link-click-send has

--- a/src/view/configuration/dataCollectionSection.jsx
+++ b/src/view/configuration/dataCollectionSection.jsx
@@ -131,10 +131,6 @@ export const bridge = {
       defaultsObj: bridge.getInstanceDefaults(),
       keys: propertyKeysToCopy,
     });
-    // Copy clickCollection settings if clickCollection is enabled
-    if (instanceValues.clickCollectionEnabled) {
-      instanceSettings.clickCollection = instanceValues.clickCollection;
-    }
     if (instanceValues.contextGranularity === CONTEXT_GRANULARITY.SPECIFIC) {
       instanceSettings.context = instanceValues.context;
     }

--- a/test/functional/helpers/adobeIOClientCredentials.js
+++ b/test/functional/helpers/adobeIOClientCredentials.js
@@ -41,7 +41,7 @@ if (clientSecret && (privateKeyPath || privateKeyContents)) {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(
-      `Failed to read private key at ${privateKeyPath}. Please ensure the value provided in the ${PRIVATE_KEY_FILE_ENV_VAR_NAME} environment variable is correct.`,
+      `${e}\nFailed to read private key at ${privateKeyPath}. Please ensure the value provided in the ${PRIVATE_KEY_FILE_ENV_VAR_NAME} environment variable is correct.`,
     );
   }
 

--- a/test/functional/helpers/viewSelectors.js
+++ b/test/functional/helpers/viewSelectors.js
@@ -114,6 +114,11 @@ for (let i = 0; i < 3; i += 1) {
     clickCollectionEnabledField: spectrum.checkbox(
       "clickCollectionEnabledField",
     ),
+    internalLinkEnabledField: spectrum.checkbox("internalLinkEnabledField"),
+    eventGroupingEnabledField: spectrum.checkbox("eventGroupingEnabledField"),
+    sessionStorageEnabledField: spectrum.checkbox("sessionStorageEnabledField"),
+    externalLinkEnabledField: spectrum.checkbox("externalLinkEnabledField"),
+    downloadLinkEnabledField: spectrum.checkbox("downloadLinkEnabledField"),
     downloadLinkQualifierField: spectrum.textField(
       "downloadLinkQualifierField",
     ),
@@ -124,6 +129,9 @@ for (let i = 0; i < 3; i += 1) {
       "downloadLinkQualifierTestButton",
     ),
     onBeforeEventSendEditButton: spectrum.button("onBeforeEventSendEditButton"),
+    filterClickPropertiesEditButton: spectrum.button(
+      "filterClickPropertiesEditButton",
+    ),
     onBeforeLinkClickSendEditButton: spectrum.button(
       "onBeforeLinkClickSendEditButton",
     ),

--- a/test/functional/helpers/viewSelectors.js
+++ b/test/functional/helpers/viewSelectors.js
@@ -111,12 +111,12 @@ for (let i = 0; i < 3; i += 1) {
     prehidingStyleEditButton: spectrum.button("prehidingStyleEditButton"),
     targetMigrationEnabled: spectrum.checkbox("targetMigrationEnabledField"),
 
-    clickCollectionEnabledField: spectrum.checkbox(
-      "clickCollectionEnabledField",
-    ),
     internalLinkEnabledField: spectrum.checkbox("internalLinkEnabledField"),
-    eventGroupingEnabledField: spectrum.checkbox("eventGroupingEnabledField"),
-    sessionStorageEnabledField: spectrum.checkbox("sessionStorageEnabledField"),
+    eventGrouping: {
+      noneField: spectrum.radio("eventGroupingNoneField"),
+      sessionStorageField: spectrum.radio("eventGroupingSessionStorageField"),
+      memoryField: spectrum.radio("eventGroupingMemoryField"),
+    },
     externalLinkEnabledField: spectrum.checkbox("externalLinkEnabledField"),
     downloadLinkEnabledField: spectrum.checkbox("downloadLinkEnabledField"),
     downloadLinkQualifierField: spectrum.textField(

--- a/test/functional/helpers/viewSelectors.js
+++ b/test/functional/helpers/viewSelectors.js
@@ -129,8 +129,8 @@ for (let i = 0; i < 3; i += 1) {
       "downloadLinkQualifierTestButton",
     ),
     onBeforeEventSendEditButton: spectrum.button("onBeforeEventSendEditButton"),
-    filterClickPropertiesEditButton: spectrum.button(
-      "filterClickPropertiesEditButton",
+    filterClickDetailsEditButton: spectrum.button(
+      "filterClickDetailsEditButton",
     ),
     onBeforeLinkClickSendEditButton: spectrum.button(
       "onBeforeLinkClickSendEditButton",

--- a/test/functional/specs/configuration/configuration.spec.js
+++ b/test/functional/specs/configuration/configuration.spec.js
@@ -233,6 +233,11 @@ test("initializes form fields with full settings", async () => {
   await instances[1].idMigrationEnabled.expectUnchecked();
   await instances[1].thirdPartyCookiesEnabled.expectUnchecked();
   await instances[1].clickCollectionEnabledField.expectChecked();
+  await instances[1].internalLinkEnabledField.expectChecked();
+  await instances[1].eventGroupingEnabledField.expectUnchecked();
+  await instances[1].sessionStorageEnabledField.expectUnchecked();
+  await instances[1].externalLinkEnabledField.expectChecked();
+  await instances[1].downloadLinkEnabledField.expectChecked();
   await instances[1].downloadLinkQualifierField.expectValue(
     defaultDownloadLinkQualifier,
   );
@@ -242,7 +247,7 @@ test("initializes form fields with full settings", async () => {
   await instances[1].specificContext.environmentField.expectUnchecked();
   await instances[1].specificContext.placeContextField.expectUnchecked();
   await instances[1].specificContext.highEntropyUserAgentHintsContextField.expectUnchecked();
-  await instances[0].targetMigrationEnabled.expectUnchecked();
+  await instances[1].targetMigrationEnabled.expectUnchecked();
 
   await instancesTabs.selectTab("alloy3");
 
@@ -251,7 +256,7 @@ test("initializes form fields with full settings", async () => {
   await instances[2].defaultConsent.pendingRadio.expectUnchecked();
   await instances[2].defaultConsent.dataElementRadio.expectUnchecked();
   await instances[2].defaultConsent.dataElementField.expectNotExists();
-  await instances[0].targetMigrationEnabled.expectUnchecked();
+  await instances[2].targetMigrationEnabled.expectUnchecked();
 });
 
 test("initializes form fields with minimal settings", async () => {
@@ -291,6 +296,11 @@ test("initializes form fields with minimal settings", async () => {
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
   await instances[0].clickCollectionEnabledField.expectChecked();
+  await instances[0].internalLinkEnabledField.expectChecked();
+  await instances[0].eventGroupingEnabledField.expectUnchecked();
+  await instances[0].sessionStorageEnabledField.expectUnchecked();
+  await instances[0].externalLinkEnabledField.expectChecked();
+  await instances[0].downloadLinkEnabledField.expectChecked();
   await instances[0].downloadLinkQualifierField.expectValue(
     defaultDownloadLinkQualifier,
   );
@@ -331,6 +341,11 @@ test.requestHooks(sandboxesMocks.singleDefault, datastreamsMocks.multiple)(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
     await instances[0].clickCollectionEnabledField.expectChecked();
+    await instances[0].internalLinkEnabledField.expectChecked();
+    await instances[0].eventGroupingEnabledField.expectUnchecked();
+    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectChecked();
+    await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
       defaultDownloadLinkQualifier,
     );
@@ -430,6 +445,7 @@ test("returns full valid settings", async () => {
   await instances[1].idMigrationEnabled.click();
   await instances[1].thirdPartyCookiesEnabled.click();
   await instances[1].onBeforeEventSendEditButton.click();
+  await instances[1].filterClickPropertiesEditButton.click();
   await instances[1].onBeforeLinkClickSendEditButton.click();
   // Click on the field before clearing to get rid of the "..."
   await instances[1].downloadLinkQualifierField.click();
@@ -495,11 +511,16 @@ test("returns full valid settings", async () => {
           "language=javascript;code=// Modify content.xdm or content.data as necessary. There is no need to wrap the\n" +
           "// code in a function or return a value. For example:\n" +
           '// content.xdm.web.webPageDetails.name = "Checkout";',
+        clickCollection: {
+          filterClickProperties:
+            "language=javascript;code=// Use this custom code block to adjust or filter click data. You can use the following variables:\n// content.clickedElement: The DOM element that was clicked\n// content.pageName: The page name when the click happened\n// content.linkName: The name of the clicked link\n// content.linkRegion: The region of the clicked link\n// content.linkType: The type of link (typically exit, download, or other)\n// content.linkUrl: The destination URL of the clicked link\n// Return false to omit link data.",
+        },
         onBeforeLinkClickSend:
-          'language=javascript;code=// Filter by "content.clickedElement".\n' +
-          "// Modify content.xdm or content.data as necessary. There is no need to wrap the\n" +
-          "// code in a function or return a value. For example:\n" +
-          '// content.xdm.web.webPageDetails.name = "Checkout";',
+          "language=javascript;code=// Use this custom code block to adjust or filter the payload sent to Adobe. You can use the following variables:\n// content.clickedElement: The DOM element that was clicked\n// content.xdm: The XDM payload for the event\n// content.data: The data object payload for the event\n// Return false to abort sending data.",
+        // 'language=javascript;code=// Filter by "content.clickedElement".\n' +
+        // "// Modify content.xdm or content.data as necessary. There is no need to wrap the\n" +
+        // "// code in a function or return a value. For example:\n" +
+        // '// content.xdm.web.webPageDetails.name = "Checkout";',
         context: ["web", "device", "environment", "placeContext"],
         downloadLinkQualifier: "[]",
       },
@@ -926,6 +947,11 @@ test.requestHooks(
     await instances[0].targetMigrationEnabled.expectUnchecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
     await instances[0].clickCollectionEnabledField.expectChecked();
+    await instances[0].internalLinkEnabledField.expectChecked();
+    await instances[0].eventGroupingEnabledField.expectUnchecked();
+    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectChecked();
+    await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
       defaultDownloadLinkQualifier,
     );
@@ -970,6 +996,11 @@ test.requestHooks(
     await instances[0].targetMigrationEnabled.expectUnchecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
     await instances[0].clickCollectionEnabledField.expectChecked();
+    await instances[0].internalLinkEnabledField.expectChecked();
+    await instances[0].eventGroupingEnabledField.expectUnchecked();
+    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectChecked();
+    await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
       defaultDownloadLinkQualifier,
     );
@@ -1271,6 +1302,11 @@ test.requestHooks(sandboxesMocks.userRegionMissing, datastreamMocks.notExist)(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
     await instances[0].clickCollectionEnabledField.expectChecked();
+    await instances[0].internalLinkEnabledField.expectChecked();
+    await instances[0].eventGroupingEnabledField.expectUnchecked();
+    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectChecked();
+    await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
       defaultDownloadLinkQualifier,
     );

--- a/test/functional/specs/configuration/configuration.spec.js
+++ b/test/functional/specs/configuration/configuration.spec.js
@@ -153,7 +153,9 @@ test("initializes form fields with full settings", async () => {
   await instances[0].defaultConsent.dataElementField.expectNotExists();
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
-  await instances[0].clickCollectionEnabledField.expectUnchecked();
+  await instances[0].internalLinkEnabledField.expectUnchecked();
+  await instances[0].externalLinkEnabledField.expectUnchecked();
+  await instances[0].downloadLinkEnabledField.expectUnchecked();
   await instances[0].contextGranularity.specificField.expectChecked();
   await instances[0].specificContext.webField.expectUnchecked();
   await instances[0].specificContext.deviceField.expectChecked();
@@ -232,10 +234,8 @@ test("initializes form fields with full settings", async () => {
   );
   await instances[1].idMigrationEnabled.expectUnchecked();
   await instances[1].thirdPartyCookiesEnabled.expectUnchecked();
-  await instances[1].clickCollectionEnabledField.expectChecked();
   await instances[1].internalLinkEnabledField.expectChecked();
-  await instances[1].eventGroupingEnabledField.expectUnchecked();
-  await instances[1].sessionStorageEnabledField.expectUnchecked();
+  await instances[1].eventGrouping.noneField.expectChecked();
   await instances[1].externalLinkEnabledField.expectChecked();
   await instances[1].downloadLinkEnabledField.expectChecked();
   await instances[1].downloadLinkQualifierField.expectValue(
@@ -295,10 +295,8 @@ test("initializes form fields with minimal settings", async () => {
   await instances[0].defaultConsent.dataElementField.expectNotExists();
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
-  await instances[0].clickCollectionEnabledField.expectChecked();
   await instances[0].internalLinkEnabledField.expectChecked();
-  await instances[0].eventGroupingEnabledField.expectUnchecked();
-  await instances[0].sessionStorageEnabledField.expectUnchecked();
+  await instances[0].eventGrouping.noneField.expectChecked();
   await instances[0].externalLinkEnabledField.expectChecked();
   await instances[0].downloadLinkEnabledField.expectChecked();
   await instances[0].downloadLinkQualifierField.expectValue(
@@ -340,10 +338,8 @@ test.requestHooks(sandboxesMocks.singleDefault, datastreamsMocks.multiple)(
     await instances[0].defaultConsent.dataElementField.expectNotExists();
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectChecked();
     await instances[0].internalLinkEnabledField.expectChecked();
-    await instances[0].eventGroupingEnabledField.expectUnchecked();
-    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].eventGrouping.noneField.expectChecked();
     await instances[0].externalLinkEnabledField.expectChecked();
     await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
@@ -444,9 +440,11 @@ test("returns full valid settings", async () => {
   );
   await instances[1].idMigrationEnabled.click();
   await instances[1].thirdPartyCookiesEnabled.click();
+  await instances[1].eventGrouping.sessionStorageField.click();
   await instances[1].onBeforeEventSendEditButton.click();
   await instances[1].filterClickDetailsEditButton.click();
-  await instances[1].onBeforeLinkClickSendEditButton.click();
+  // onBeforeLinkClickSendEditButton no longer available in the UI if it has not been set
+  // await instances[1].onBeforeLinkClickSendEditButton.click();
   // Click on the field before clearing to get rid of the "..."
   await instances[1].downloadLinkQualifierField.click();
   await instances[1].downloadLinkQualifierField.clear();
@@ -514,13 +512,9 @@ test("returns full valid settings", async () => {
         clickCollection: {
           filterClickDetails:
             "language=javascript;code=// Use this custom code block to adjust or filter click data. You can use the following variables:\n// content.clickedElement: The DOM element that was clicked\n// content.pageName: The page name when the click happened\n// content.linkName: The name of the clicked link\n// content.linkRegion: The region of the clicked link\n// content.linkType: The type of link (typically exit, download, or other)\n// content.linkUrl: The destination URL of the clicked link\n// Return false to omit link data.",
+          sessionStorageEnabled: true,
+          eventGroupingEnabled: true,
         },
-        onBeforeLinkClickSend:
-          "language=javascript;code=// Use this custom code block to adjust or filter the payload sent to Adobe. You can use the following variables:\n// content.clickedElement: The DOM element that was clicked\n// content.xdm: The XDM payload for the event\n// content.data: The data object payload for the event\n// Return false to abort sending data.",
-        // 'language=javascript;code=// Filter by "content.clickedElement".\n' +
-        // "// Modify content.xdm or content.data as necessary. There is no need to wrap the\n" +
-        // "// code in a function or return a value. For example:\n" +
-        // '// content.xdm.web.webPageDetails.name = "Checkout";',
         context: ["web", "device", "environment", "placeContext"],
         downloadLinkQualifier: "[]",
       },
@@ -880,7 +874,7 @@ test("does not save prehidingStyle code if it matches placeholder", async () => 
   });
 });
 
-test("does not save onBeforeEventSend and onBeforeLinkClickSend code if it matches placeholder", async () => {
+test("does not save onBeforeEventSend and filterClickDetails code if it matches placeholder", async () => {
   await extensionViewController.init(
     {},
     {
@@ -895,7 +889,7 @@ test("does not save onBeforeEventSend and onBeforeLinkClickSend code if it match
     "PR123",
   );
   await instances[0].onBeforeEventSendEditButton.click();
-  await instances[0].onBeforeLinkClickSendEditButton.click();
+  await instances[0].filterClickDetailsEditButton.click();
   await extensionViewController.expectIsValid();
   await extensionViewController.expectSettings({
     instances: [
@@ -946,10 +940,8 @@ test.requestHooks(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].targetMigrationEnabled.expectUnchecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectChecked();
     await instances[0].internalLinkEnabledField.expectChecked();
-    await instances[0].eventGroupingEnabledField.expectUnchecked();
-    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].eventGrouping.noneField.expectChecked();
     await instances[0].externalLinkEnabledField.expectChecked();
     await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
@@ -995,10 +987,8 @@ test.requestHooks(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].targetMigrationEnabled.expectUnchecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectChecked();
     await instances[0].internalLinkEnabledField.expectChecked();
-    await instances[0].eventGroupingEnabledField.expectUnchecked();
-    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].eventGrouping.noneField.expectChecked();
     await instances[0].externalLinkEnabledField.expectChecked();
     await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(
@@ -1073,8 +1063,9 @@ test.requestHooks(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].targetMigrationEnabled.expectUnchecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectUnchecked();
-    await instances[0].contextGranularity.specificField.expectChecked();
+    await instances[0].internalLinkEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectUnchecked();
+    await instances[0].downloadLinkEnabledField.expectUnchecked();
     await instances[0].specificContext.webField.expectUnchecked();
     await instances[0].specificContext.deviceField.expectChecked();
     await instances[0].specificContext.environmentField.expectUnchecked();
@@ -1142,7 +1133,9 @@ test.requestHooks(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].targetMigrationEnabled.expectChecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectUnchecked();
+    await instances[0].internalLinkEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectUnchecked();
+    await instances[0].downloadLinkEnabledField.expectUnchecked();
     await instances[0].contextGranularity.specificField.expectChecked();
     await instances[0].specificContext.webField.expectUnchecked();
     await instances[0].specificContext.deviceField.expectChecked();
@@ -1208,7 +1201,9 @@ test.requestHooks(
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].targetMigrationEnabled.expectUnchecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectUnchecked();
+    await instances[0].internalLinkEnabledField.expectUnchecked();
+    await instances[0].externalLinkEnabledField.expectUnchecked();
+    await instances[0].downloadLinkEnabledField.expectUnchecked();
     await instances[0].contextGranularity.specificField.expectChecked();
     await instances[0].specificContext.webField.expectUnchecked();
     await instances[0].specificContext.deviceField.expectChecked();
@@ -1261,7 +1256,9 @@ test.requestHooks(
   await instances[0].defaultConsent.dataElementField.expectNotExists();
   await instances[0].idMigrationEnabled.expectChecked();
   await instances[0].thirdPartyCookiesEnabled.expectChecked();
-  await instances[0].clickCollectionEnabledField.expectUnchecked();
+  await instances[0].internalLinkEnabledField.expectUnchecked();
+  await instances[0].externalLinkEnabledField.expectUnchecked();
+  await instances[0].downloadLinkEnabledField.expectUnchecked();
   await instances[0].contextGranularity.specificField.expectChecked();
   await instances[0].specificContext.webField.expectUnchecked();
   await instances[0].specificContext.deviceField.expectChecked();
@@ -1301,10 +1298,10 @@ test.requestHooks(sandboxesMocks.userRegionMissing, datastreamMocks.notExist)(
     await instances[0].defaultConsent.dataElementField.expectNotExists();
     await instances[0].idMigrationEnabled.expectChecked();
     await instances[0].thirdPartyCookiesEnabled.expectChecked();
-    await instances[0].clickCollectionEnabledField.expectChecked();
     await instances[0].internalLinkEnabledField.expectChecked();
-    await instances[0].eventGroupingEnabledField.expectUnchecked();
-    await instances[0].sessionStorageEnabledField.expectUnchecked();
+    await instances[0].eventGrouping.noneField.expectChecked();
+    await instances[0].externalLinkEnabledField.expectChecked();
+    await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].externalLinkEnabledField.expectChecked();
     await instances[0].downloadLinkEnabledField.expectChecked();
     await instances[0].downloadLinkQualifierField.expectValue(

--- a/test/functional/specs/configuration/configuration.spec.js
+++ b/test/functional/specs/configuration/configuration.spec.js
@@ -445,7 +445,7 @@ test("returns full valid settings", async () => {
   await instances[1].idMigrationEnabled.click();
   await instances[1].thirdPartyCookiesEnabled.click();
   await instances[1].onBeforeEventSendEditButton.click();
-  await instances[1].filterClickPropertiesEditButton.click();
+  await instances[1].filterClickDetailsEditButton.click();
   await instances[1].onBeforeLinkClickSendEditButton.click();
   // Click on the field before clearing to get rid of the "..."
   await instances[1].downloadLinkQualifierField.click();
@@ -512,7 +512,7 @@ test("returns full valid settings", async () => {
           "// code in a function or return a value. For example:\n" +
           '// content.xdm.web.webPageDetails.name = "Checkout";',
         clickCollection: {
-          filterClickProperties:
+          filterClickDetails:
             "language=javascript;code=// Use this custom code block to adjust or filter click data. You can use the following variables:\n// content.clickedElement: The DOM element that was clicked\n// content.pageName: The page name when the click happened\n// content.linkName: The name of the clicked link\n// content.linkRegion: The region of the clicked link\n// content.linkType: The type of link (typically exit, download, or other)\n// content.linkUrl: The destination URL of the clicked link\n// Return false to omit link data.",
         },
         onBeforeLinkClickSend:


### PR DESCRIPTION
## Description

The Web SDK Tags Extension now includes more granular settings on how to manage click collection:

+ Internal links
  + Enable event grouping
  + Enable session storage
+ External links
+ Download links

## Related Issue

[AN-329919](https://jira.corp.adobe.com/browse/AN-329919)

## Motivation and Context

These granular settings provides more flexibility to users on what type of clicks they want to collect and also how that data is collected.

## Screenshots (if appropriate):

![image](https://github.com/adobe/reactor-extension-alloy/assets/2584844/5b349d43-925d-4db7-a5ef-ea65dba8aafe)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.
