### PR TITLE
Fixing filterClickDetails bug

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -387,6 +387,11 @@ const createExtensionManifest = ({ version }) => {
           parameters: ["content"],
         },
         {
+          type: "function",
+          propertyPath: "instances[].clickCollection.filterClickDetails",
+          parameters: ["content"],
+        },
+        {
           type: "remove",
           propertyPath: "instances[].edgeConfigInputMethod",
         },


### PR DESCRIPTION

## Description

Filter click details callback was not defined to be transformed to a function.

## Related Issue

## Motivation and Context

Make filter click details callback working.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
