### PR TITLE
For FETCH type guided events require renderDecisions set to true

### DIFF
--- a/src/view/actions/sendEvent.jsx
+++ b/src/view/actions/sendEvent.jsx
@@ -67,23 +67,21 @@ const xdmFieldDescription = (
 const wrapGetInitialValues =
   (getInitialValues) =>
   ({ initInfo }) => {
-    const {
-      personalization = {},
-      guidedEventsEnabled,
-      guidedEvent,
-      renderDecisions,
-    } = initInfo.settings || {};
-    const newSettings = { ...initInfo.settings };
+    const { personalization = {}, ...otherSettings } = initInfo.settings || {};
 
+    // Flatten personalization settings and use strings for data element booleans
     if (personalization.defaultPersonalizationEnabled === true) {
-      newSettings.personalization.defaultPersonalizationEnabled = "true";
+      personalization.defaultPersonalizationEnabled = "true";
     } else if (personalization.defaultPersonalizationEnabled === false) {
-      newSettings.personalization.defaultPersonalizationEnabled = "false";
+      personalization.defaultPersonalizationEnabled = "false";
     }
+    const newSettings = { ...personalization, ...otherSettings };
 
     // Handle backward compatability for making renderDecisions set to true
     // for FETCH guided events. Previously you could modify renderDecisions on
     // a FETCH guieded event.
+    const { guidedEventsEnabled, guidedEvent, renderDecisions } = newSettings;
+
     if (
       !renderDecisions &&
       guidedEventsEnabled &&


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

On the consultant office hours call, one of the consultants brought up the fact that "renderDecisions" is not pre-checked when using guided events. This has caused some confusion when using guided events. This change makes it so that renderDecisions is checked and cannot be changed when using the guided fetch event. For existing settings, when loading the new UI, we check to see if the user was using the fetch guided event AND had renderDecisions false. When this happens, we push the UI to the non-guided event UI with all the same settings they had previously. This way their settings will not get modified when editing something else in their send event action.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
