### PR TITLE
Fixed an issue where ID Sync Container overrides could not be set without enabling Audience Manager

### DIFF
--- a/src/view/components/overrides/hooks.js
+++ b/src/view/components/overrides/hooks.js
@@ -117,7 +117,12 @@ const getServiceStatus = (apiResult) =>
             "com_adobe_experience_platform_edge_segmentation.enabled",
           ),
     },
-
+    // This value is not configurable via datastream config overrides.
+    com_adobe_identity: {
+      value: !apiResult
+        ? true
+        : deepGet(apiResult, "com_adobe_identity.idSyncEnabled"),
+    },
     com_adobe_experience_platform_edge_destinations: {
       fieldName:
         "com_adobe_experience_platform.com_adobe_edge_destinations.enabled",

--- a/src/view/components/overrides/overrides.jsx
+++ b/src/view/components/overrides/overrides.jsx
@@ -432,12 +432,9 @@ const Overrides = ({
                               )}
                           </ProductSubsection>
                         )}
-                        {(visibleFields.has(
-                          FIELD_NAMES.idSyncContainerOverride,
-                        ) ||
-                          visibleFields.has(
-                            FIELD_NAMES.audienceManagerEnabled,
-                          )) && (
+                        {visibleFields.has(
+                          FIELD_NAMES.audienceManagerEnabled,
+                        ) && (
                           <ProductSubsection name="Adobe Audience Manager">
                             {visibleFields.has(
                               FIELD_NAMES.audienceManagerEnabled,
@@ -463,45 +460,34 @@ const Overrides = ({
                                 {...EnabledDisabledOptions}
                               </OverrideInput>
                             )}
-                            {visibleFields.has(
-                              FIELD_NAMES.idSyncContainerOverride,
-                            ) &&
-                              !isDisabled(
-                                "com_adobe_audience_manager.enabled",
-                                serviceStatus.com_adobe_audience_manager.value,
-                              ) && (
-                                <OverrideInput
-                                  data-test-id={
-                                    FIELD_NAMES.idSyncContainerOverride
-                                  }
-                                  label="Third-party ID sync container"
-                                  useManualEntry={
-                                    useManualEntry ||
-                                    idSyncContainers.length === 0
-                                  }
-                                  allowsCustomValue
-                                  overrideType="third-party ID sync container"
-                                  primaryItem={primaryIdSyncContainer}
-                                  defaultItems={idSyncContainers}
-                                  isDisabled={
-                                    !serviceStatus.com_adobe_audience_manager
-                                      .value
-                                  }
-                                  validate={validateIdSyncContainerOption}
-                                  name={`${prefix}.${env}.com_adobe_identity.idSyncContainerId`}
-                                  inputMode="numeric"
-                                  width="size-5000"
-                                  pattern={/\d+/}
-                                  description={idSyncContainerDescription}
-                                >
-                                  {({ value, label }) => (
-                                    <Item key={value}>{label}</Item>
-                                  )}
-                                </OverrideInput>
-                              )}
                           </ProductSubsection>
                         )}
-
+                        {visibleFields.has(
+                          FIELD_NAMES.idSyncContainerOverride,
+                        ) && (
+                          <OverrideInput
+                            data-test-id={FIELD_NAMES.idSyncContainerOverride}
+                            label="Third-party ID sync container"
+                            useManualEntry={
+                              useManualEntry || idSyncContainers.length === 0
+                            }
+                            allowsCustomValue
+                            overrideType="third-party ID sync container"
+                            primaryItem={primaryIdSyncContainer}
+                            defaultItems={idSyncContainers}
+                            isDisabled={!serviceStatus.com_adobe_identity.value}
+                            validate={validateIdSyncContainerOption}
+                            name={`${prefix}.${env}.com_adobe_identity.idSyncContainerId`}
+                            inputMode="numeric"
+                            width="size-5000"
+                            pattern={/\d+/}
+                            description={idSyncContainerDescription}
+                          >
+                            {({ value, label }) => (
+                              <Item key={value}>{label}</Item>
+                            )}
+                          </OverrideInput>
+                        )}
                         {[
                           FIELD_NAMES.eventDatasetOverride,
                           FIELD_NAMES.experiencePlatformEnabled,

--- a/test/functional/specs/view/configuration/configuration.spec.mjs
+++ b/test/functional/specs/view/configuration/configuration.spec.mjs
@@ -2207,7 +2207,8 @@ test("hides disabled overrides when service is disabled", async () => {
   await instances[0].overrides.comboBoxes.audienceManagerEnabled.enterSearch(
     "Disabled",
   );
-  await instances[0].overrides.textFields.idSyncContainerOverride.expectNotExists();
+  // Audience Manager and ID Sync Container ID are separate.
+  await instances[0].overrides.textFields.idSyncContainerOverride.expectExists();
 
   await instances[0].overrides.comboBoxes.edgeDestinationsEnabled.expectExists();
   await instances[0].overrides.comboBoxes.edgeSegmentationEnabled.expectExists();
@@ -2256,7 +2257,6 @@ test("hides disabled overrides when service is disabled", async () => {
     ],
   });
 });
-
 
 test("enables all datastream override fields if there is no Blackbird config", async () => {
   await extensionViewController.init();


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Currently, in order to edit the ID Sync Container ID override, Audience Manager needs to be enabled.

When developing #443, I assumed that the ID Sync Container ID was only used in an Audience Manager context. This was an incorrect assumption and they should not be linked.

This PR separates them.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[Slack conversation](https://adobedx.slack.com/archives/CQ1KQ9WBC/p1731969734894859)
[PDCL-12794](https://jira.corp.adobe.com/browse/PDCL-12794)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.
