### PR TITLE
Fixed an issue where datastream config overrides were disabled when upgrading to latest version

### DIFF
--- a/src/view/components/overrides/overridesBridge.js
+++ b/src/view/components/overrides/overridesBridge.js
@@ -227,6 +227,29 @@ export const bridge = {
           ENABLED_MATCH_FIELD_VALUES.enabled,
         );
       });
+    // do the same for datastream ID overrides
+    OVERRIDE_ENVIRONMENTS.filter((env) =>
+      deepGet(
+        cleanedInstanceSettings,
+        `edgeConfigOverrides.${env}.datastreamId`,
+      ),
+    )
+      .filter(
+        (env) =>
+          !isDataElement(
+            deepGet(
+              cleanedInstanceSettings,
+              `edgeConfigOverrides.${env}.enabled`,
+            ),
+          ),
+      )
+      .forEach((env) => {
+        deepSet(
+          cleanedInstanceSettings,
+          `edgeConfigOverrides.${env}.enabled`,
+          ENABLED_MATCH_FIELD_VALUES.enabled,
+        );
+      });
 
     copyPropertiesWithDefaultFallback({
       toObj: instanceValues,

--- a/test/unit/view/components/overrides/overridesBridge.spec.js
+++ b/test/unit/view/components/overrides/overridesBridge.spec.js
@@ -504,6 +504,152 @@ describe("overridesBridge", () => {
       });
     });
 
+    it("should enable edgeConfigOverrides if there is no 'enabled' field but is a datastream override", () => {
+      const instanceSettings = {
+        edgeConfigOverrides: {
+          development: {
+            datastreamId: "aca8c786-4940-442f-ace5-7c4aba02118e",
+          },
+        },
+      };
+      const result = bridge.getInitialInstanceValues({
+        instanceSettings,
+      });
+      expect(result).toEqual({
+        edgeConfigOverrides: {
+          development: {
+            sandbox: "",
+            datastreamId: "aca8c786-4940-442f-ace5-7c4aba02118e",
+            datastreamIdInputMethod: "freeform",
+            enabled: MATCH_FIELD.enabled,
+            com_adobe_experience_platform: {
+              enabled: FIELD.enabled,
+              datasets: {
+                event: {
+                  datasetId: "",
+                },
+              },
+              com_adobe_edge_ode: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_segmentation: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_destinations: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_ajo: {
+                enabled: FIELD.enabled,
+              },
+            },
+            com_adobe_analytics: {
+              enabled: FIELD.enabled,
+              reportSuites: [""],
+            },
+            com_adobe_identity: {
+              idSyncContainerId: undefined,
+            },
+            com_adobe_target: {
+              enabled: FIELD.enabled,
+              propertyToken: "",
+            },
+            com_adobe_audience_manager: {
+              enabled: FIELD.enabled,
+            },
+            com_adobe_launch_ssf: {
+              enabled: FIELD.enabled,
+            },
+          },
+          staging: {
+            sandbox: "",
+            datastreamId: "",
+            datastreamIdInputMethod: "freeform",
+            enabled: MATCH_FIELD.disabled,
+            com_adobe_experience_platform: {
+              enabled: FIELD.enabled,
+              datasets: {
+                event: {
+                  datasetId: "",
+                },
+              },
+              com_adobe_edge_ode: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_segmentation: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_destinations: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_ajo: {
+                enabled: FIELD.enabled,
+              },
+            },
+            com_adobe_analytics: {
+              enabled: FIELD.enabled,
+              reportSuites: [""],
+            },
+            com_adobe_identity: {
+              idSyncContainerId: undefined,
+            },
+            com_adobe_target: {
+              enabled: FIELD.enabled,
+              propertyToken: "",
+            },
+            com_adobe_audience_manager: {
+              enabled: FIELD.enabled,
+            },
+            com_adobe_launch_ssf: {
+              enabled: FIELD.enabled,
+            },
+          },
+          production: {
+            sandbox: "",
+            datastreamId: "",
+            datastreamIdInputMethod: "freeform",
+            enabled: MATCH_FIELD.disabled,
+            com_adobe_experience_platform: {
+              enabled: FIELD.enabled,
+              datasets: {
+                event: {
+                  datasetId: "",
+                },
+              },
+              com_adobe_edge_ode: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_segmentation: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_destinations: {
+                enabled: FIELD.enabled,
+              },
+              com_adobe_edge_ajo: {
+                enabled: FIELD.enabled,
+              },
+            },
+            com_adobe_analytics: {
+              enabled: FIELD.enabled,
+              reportSuites: [""],
+            },
+            com_adobe_identity: {
+              idSyncContainerId: undefined,
+            },
+            com_adobe_target: {
+              enabled: FIELD.enabled,
+              propertyToken: "",
+            },
+            com_adobe_audience_manager: {
+              enabled: FIELD.enabled,
+            },
+            com_adobe_launch_ssf: {
+              enabled: FIELD.enabled,
+            },
+          },
+        },
+      });
+    });
+
     it("should convert from booleans to 'Enabled' and 'Disabled' ", () => {
       const enabledEdgeConfigOverrides = envs.reduce(
         (acc, env) => ({


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When upgrading from 2.26.0 to 2.27.0, the Overrides settings bridge will look at each child key to see if there are any overrides. If there are, it will set the top-level `.enabled` key. 

For example, the old setting

```json
{
  "edgeConfigOverrides": {
    "development": {
      "com_adobe_target": {
        "propertyToken": "01dbc634-07c1-d8f9-ca69-b489a5ac5e94"
      }
    }
  }
}
```
is upgraded to 
```json
{
  "edgeConfigOverrides": {
    "development": {
      "enabled": true,
      "com_adobe_target": {
        "enabled": true,
        "propertyToken": "01dbc634-07c1-d8f9-ca69-b489a5ac5e94"
      }
    }
  }
}
```

However, the top level keys like `datastreamID` were not considered. So, if there was only a `datastreamId`

```json
{
  "edgeConfigOverrides": {
    "development": {
      "datastreamId": "f1b9b3e0-7b3b-4b3b-8b3b-9b3b3b3b3b3b"
    }
  }
}
```

it would get incorrectly upgraded to

```json
{
  "edgeConfigOverrides": {
    "development": {
      "enabled": false
    }
  }
}
```

which is wrong.

With these changes, it is transformed to 

```json
{
  "edgeConfigOverrides": {
    "development": {
      "enabled": true,
      "datastreamId": "f1b9b3e0-7b3b-4b3b-8b3b-9b3b3b3b3b3b"
    }
  }
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-12782](https://jira.corp.adobe.com/browse/PDCL-12782)
[Slack conversation](https://adobedx.slack.com/archives/CQ1KQ9WBC/p1731598545647839)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
