### PR TITLE
Fix test timing to wait for view to be rendered before running expectations

### DIFF
--- a/src/view/components/errorBoundary.jsx
+++ b/src/view/components/errorBoundary.jsx
@@ -26,6 +26,13 @@ export default class ErrorBoundary extends Component {
     return { error };
   }
 
+  componentDidUpdate(_, { error: prevError }) {
+    const { error } = this.state;
+    if (error && prevError !== error) {
+      window.dispatchEvent(new Event("extension-reactor-alloy:rendered"));
+    }
+  }
+
   render() {
     const { error } = this.state;
     const { children } = this.props;

--- a/test/functional/helpers/endpointMocks/dataElementMocks.mjs
+++ b/test/functional/helpers/endpointMocks/dataElementMocks.mjs
@@ -15,6 +15,7 @@ import responseHeaders from "./responseHeaders.mjs";
 
 const DATA_ELEMENT_1_REGEX = /data_elements\/DE1/;
 const DATA_ELEMENT_2_REGEX = /data_elements\/DE2/;
+const DATA_ELEMENT_3_REGEX = /data_elements\/DE3/;
 const DATA_SOLUTIONS_ELEMENT_1_REGEX = /data_elements\/SDE1/;
 
 const testDataVariable1 = {
@@ -49,6 +50,23 @@ const testDataVariable2 = {
     }),
   },
 };
+
+const testDataVariable3 = {
+  id: "DE3",
+  attributes: {
+    name: "Test data variable 3",
+    delegate_descriptor_id: "adobe-alloy::dataElements::variable",
+    settings: JSON.stringify({
+      sandbox: {
+        name: "prod",
+      },
+      schema: {
+        id: "sch123",
+        version: "1.0",
+      },
+    }),
+  },
+};
 const testSolutionsVariable1 = {
   id: "SDE1",
   attributes: {
@@ -67,6 +85,10 @@ export const element1 = RequestMock()
 export const element2 = RequestMock()
   .onRequestTo({ url: DATA_ELEMENT_2_REGEX, method: "GET" })
   .respond({ data: testDataVariable2 }, 200, responseHeaders);
+
+export const element3 = RequestMock()
+  .onRequestTo({ url: DATA_ELEMENT_3_REGEX, method: "GET" })
+  .respond({ data: testDataVariable3 }, 200, responseHeaders);
 
 export const solutionsElement1 = RequestMock()
   .onRequestTo({ url: DATA_SOLUTIONS_ELEMENT_1_REGEX, method: "GET" })

--- a/test/functional/helpers/extensionViewController.mjs
+++ b/test/functional/helpers/extensionViewController.mjs
@@ -72,6 +72,8 @@ export default {
           initInfo,
           sharedViewMethodMocks,
         });
+        // This promise will resolve when the extension view is rendered.
+        return window.initializeExtensionViewPromise;
       },
       {
         dependencies: {

--- a/test/functional/specs/view/actions/updateVariable.spec.mjs
+++ b/test/functional/specs/view/actions/updateVariable.spec.mjs
@@ -196,18 +196,18 @@ test.requestHooks(dataElementMocks.element1, dataElementsMocks.multiple)(
   },
 );
 
-test.requestHooks(dataElementMocks.element1, dataElementsMocks.multiple)(
+test.requestHooks(dataElementMocks.element3, dataElementsMocks.multiple, schemaMocks.basic)(
   "doesn't show warning when the schema version is the same",
-  async () => {
+  async (t) => {
     await extensionViewController.init({
       propertySettings: {
         id: "PRabcd",
       },
       settings: {
-        dataElementId: "DE1",
+        dataElementId: "DE3",
         schema: {
-          id: "https://ns.adobe.com/unifiedjsqeonly/schemas/8f9fc4c28403e4428bbe7b97436322c44a71680349dfd489",
-          version: "1.2",
+          id: "sch123",
+          version: "1.0",
         },
         data: {},
       },


### PR DESCRIPTION


<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

The configuration spec "initializes form fields with full settings", was consistently failing on my machine. I found that the problem was that the test runner was not waiting long enough after initializing the extension view controller before running expectations. I changed it so that it now waits for the rendered event before continuing. This caused a problem because when an error is thrown, the rendered event isn't triggered. I added a trigger for this in the error boundary. This uncovered a problem with one of the update variable tests. It was trying to verify that an error was not shown, but because it was checking too early it was succeeding even though the error would show if it waited until the view was rendered. I fixed this by updating a test to pull down mocked versions of the schema.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
