### PR TITLE
Added graceful handling of missing data elements in update variable actions

### DIFF
--- a/src/view/actions/updateVariable.jsx
+++ b/src/view/actions/updateVariable.jsx
@@ -61,9 +61,13 @@ const getInitialFormStateFromDataElement = async ({
   existingFormStateNode,
   signal,
 }) => {
-  const value = {};
-  deepAssign(value, context.originalData);
-  deepAssign(value, data);
+  let value;
+  if (context.originalData) {
+    value = structuredClone(context.originalData);
+    deepAssign(value, data);
+  } else {
+    value = data;
+  }
 
   if (
     dataElement.settings &&

--- a/src/view/actions/updateVariable.jsx
+++ b/src/view/actions/updateVariable.jsx
@@ -177,6 +177,9 @@ const getInitialValues =
         });
       } catch {
         // Ignore the error and let the user select the data element.
+        // We null out the schema because in the sandbox init can be called multiple times.
+        context.schema = null;
+        context.dataElementId = null;
       }
     }
     if (

--- a/src/view/utils/deepAssign.js
+++ b/src/view/utils/deepAssign.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const isNil = (value) => value == null;
+const isObject = (value) =>
+  !isNil(value) && !Array.isArray(value) && typeof value === "object";
+
+const deepAssignObject = (target, source) => {
+  Object.keys(source).forEach((key) => {
+    if (isObject(target[key]) && isObject(source[key])) {
+      deepAssignObject(target[key], source[key]);
+      return;
+    }
+
+    target[key] = source[key];
+  });
+};
+
+/**
+ * Recursively copy the values of all enumerable own properties from a source item to a target item if the both items are objects
+ * @param {Object} target - a target object
+ * @param {...Object} source - an array of source objects
+ * @example
+ * deepAssign({ a: 'a', b: 'b' }, { b: 'B', c: 'c' });
+ * // { a: 'a', b: 'B', c: 'c' }
+ */
+export default (target, ...sources) => {
+  if (isNil(target)) {
+    throw new TypeError('deepAssign "target" cannot be null or undefined');
+  }
+
+  const result = Object(target);
+
+  sources.forEach((source) => deepAssignObject(result, Object(source)));
+
+  return result;
+};

--- a/test/functional/specs/view/actions/updateVariable.spec.mjs
+++ b/test/functional/specs/view/actions/updateVariable.spec.mjs
@@ -235,10 +235,55 @@ test.requestHooks(
     await xdmTree.node("otherField").click();
     await stringEdit.enterValue("myvalue2");
     await dataElementField.openMenu();
+
     await dataElementField.selectMenuOption("Test data variable 3");
     await xdmTree.node("testField").click();
     await stringEdit.expectValue("myvalue1");
     await xdmTree.node("otherField").expectNotExists();
+    await dataElementField.openMenu();
+    await dataElementField.selectMenuOption("Test data variable 4");
+    await xdmTree.node("testField").click();
+    await stringEdit.expectValue("myvalue1");
+    await xdmTree.node("otherField").click();
+    await stringEdit.expectValue("myvalue2");
+
+    extensionViewController.expectSettings({
+      data: {
+        testField: "myvalue1",
+        otherField: "myvalue2",
+      },
+      dataElementId: "DE4",
+      schema: {
+        id: "sch456",
+        version: "1.0",
+      },
+    });
+  },
+);
+
+test.requestHooks(
+  schemaMocks.basic,
+  schemaMocks.other,
+  dataElementsMocks.multiple,
+)(
+  "keeps data around when data element is no longer found.",
+  async (t) => {
+    await extensionViewController.init({
+      propertySettings: {
+        id: "PRabcd",
+      },
+      settings: {
+        dataElementId: "not_found",
+        schema: {
+          id: "sch456",
+          version: "1.0",
+        },
+        data: {
+          testField: "myvalue1",
+          otherField: "myvalue2",
+        },
+      },
+    });
     await dataElementField.openMenu();
     await dataElementField.selectMenuOption("Test data variable 4");
     await xdmTree.node("testField").click();


### PR DESCRIPTION

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

Previously, if you deleted a data element, all your update variable actions with that data element would just show an error and not let you edit. Also if you copy a property all the update variable actions in the new property would still reference the data elements in the copied property and would just show the error too. This change catches the data element not found error and allows you to select a new data element, filling in all the values from before.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
