### PR TITLE
Fix the upgrade path for those with com_adobe_audience_manager override settings

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -152,6 +152,14 @@ const createEdgeConfigOverridesSchema = (isAction) => {
       },
       required: ["enabled"],
     },
+    // deprecated and a typo for com_adobe_audiencemanager, but required for backwards compatibility and upgrades
+    com_adobe_audience_manager: {
+      type: "object",
+      properties: {
+        enabled: enabledDisabledOrDataElement,
+      },
+      required: ["enabled"],
+    },
     com_adobe_launch_ssf: {
       type: "object",
       properties: {


### PR DESCRIPTION


<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When upgrading to 2.29.0 and because of #462, a customer can be blocked because their previously-valid settings with an override of `com_adobe_audience_manager` is no longer valid (because `com_adobe_audiencemanager` is the corrected settings key).

This PR adds back `com_adobe_audience_manager` to the settings schema so that it can be upgraded away from.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
