### PR TITLE
Add new validation and UI for link callbacks, add clear button to code fields

### DIFF
--- a/src/view/components/codeField.jsx
+++ b/src/view/components/codeField.jsx
@@ -61,7 +61,7 @@ const CodeField = ({
   };
 
   return (
-    <Flex direction="row" gap="size-250">
+    <Flex direction="row" gap="size-100">
       <CodePreview
         data-test-id={dataTestId}
         value={value}
@@ -73,16 +73,17 @@ const CodeField = ({
         onPress={onPress}
         beta={beta}
       />
-      <ActionButton
-        data-test-id={`${dataTestId}-clearButton`}
-        onPress={() => {
-          setValue("");
-        }}
-        marginTop={23}
-        isDisabled={!value}
-      >
-        <Text>Clear</Text>
-      </ActionButton>
+      {value && (
+        <ActionButton
+          data-test-id={`${dataTestId}-clearButton`}
+          onPress={() => {
+            setValue("");
+          }}
+          marginTop={23}
+        >
+          <Text>Clear</Text>
+        </ActionButton>
+      )}
     </Flex>
   );
 };

--- a/src/view/components/codeField.jsx
+++ b/src/view/components/codeField.jsx
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import React from "react";
 import { useField } from "formik";
 import PropTypes from "prop-types";
+import { ActionButton, Flex, Text } from "@adobe/react-spectrum";
 import CodePreview from "./codePreview";
 
 /**
@@ -60,17 +61,29 @@ const CodeField = ({
   };
 
   return (
-    <CodePreview
-      data-test-id={dataTestId}
-      value={value}
-      label={label}
-      aria-label={ariaLabel}
-      buttonLabel={`${value ? "Edit" : "Provide"} ${buttonLabelSuffix}`}
-      description={description}
-      error={touched && error ? error : undefined}
-      onPress={onPress}
-      beta={beta}
-    />
+    <Flex direction="row" gap="size-250">
+      <CodePreview
+        data-test-id={dataTestId}
+        value={value}
+        label={label}
+        aria-label={ariaLabel}
+        buttonLabel={`${value ? "Edit" : "Provide"} ${buttonLabelSuffix}`}
+        description={description}
+        error={touched && error ? error : undefined}
+        onPress={onPress}
+        beta={beta}
+      />
+      <ActionButton
+        data-test-id={`${dataTestId}-clearButton`}
+        onPress={() => {
+          setValue("");
+        }}
+        marginTop={23}
+        isDisabled={!value}
+      >
+        <Text>Clear</Text>
+      </ActionButton>
+    </Flex>
   );
 };
 

--- a/src/view/components/codePreview.css
+++ b/src/view/components/codePreview.css
@@ -17,6 +17,10 @@ governing permissions and limitations under the License.
   overflow: hidden !important;
 }
 
+.CodePreview-textArea--invalid textarea:disabled {
+  border-color: var(--spectrum-textfield-border-color-error, var(--spectrum-semantic-negative-color-default));
+}
+
 .CodePreview-openEditorButton {
   position: absolute !important;
   /* The TextArea component has been given a specific
@@ -32,7 +36,9 @@ governing permissions and limitations under the License.
 /* This is a workaround for a react-spectrum bug */
 /* https://github.com/adobe/react-spectrum/issues/2475 */
 .CodePreview-textArea {
-  > div, .spectrum-Field-field--multiline {
+
+  &>div,
+  & .spectrum-Field-field--multiline {
     flex: 1 1 auto !important;
   }
 }

--- a/src/view/components/codePreview.jsx
+++ b/src/view/components/codePreview.jsx
@@ -35,6 +35,11 @@ const CodePreview = ({
   onPress,
   beta,
 }) => {
+  const classNames = ["CodePreview-textArea"];
+  if (error) {
+    classNames.push("CodePreview-textArea--invalid");
+  }
+
   return (
     <View position="relative" UNSAFE_style={{ width: "fit-content" }}>
       <LabeledValue label={label} aria-label={ariaLabel} />
@@ -46,7 +51,7 @@ const CodePreview = ({
           height="size-1600"
           value={value}
           isDisabled
-          UNSAFE_className="CodePreview-textArea"
+          UNSAFE_className={classNames.join(" ")}
           validationState={error ? "invalid" : "valid"}
         />
       </FieldDescriptionAndError>

--- a/src/view/components/codePreview.jsx
+++ b/src/view/components/codePreview.jsx
@@ -36,13 +36,7 @@ const CodePreview = ({
   beta,
 }) => {
   return (
-    // To get this element to shrink to its contents, we had to use
-    // alignSelf="flex-start" because this is currently a child of
-    // a flex container (flex items are stretched by default).
-    // Also, we use a labeledValue element instead of putting the
-    // label on the textarea because there is a bug in react-spectrum
-    // textarea sizing when there is a label on it.
-    <View position="relative" alignSelf="flex-start">
+    <View position="relative" UNSAFE_style={{ width: "fit-content" }}>
       <LabeledValue label={label} aria-label={ariaLabel} />
       {beta && <BetaBadge />}
       <FieldDescriptionAndError description={description} error={error}>
@@ -53,6 +47,7 @@ const CodePreview = ({
           value={value}
           isDisabled
           UNSAFE_className="CodePreview-textArea"
+          validationState={error ? "invalid" : "valid"}
         />
       </FieldDescriptionAndError>
       <ActionButton

--- a/src/view/configuration/dataCollectionSection.jsx
+++ b/src/view/configuration/dataCollectionSection.jsx
@@ -249,7 +249,7 @@ export const bridge = {
         then: (schema) =>
           schema.oneOf(
             [""],
-            "Event grouping cannot be used when the onBeforeLinkClickSend callback is specified. Transfer your code to filterClickDetails or turn off event grouping.",
+            "Event grouping cannot be used when the onBeforeLinkClickSend callback is specified. Use filterClickDetails instead or turn off event grouping.",
           ),
       },
     ),
@@ -268,7 +268,9 @@ const DataCollectionSection = ({ instanceFieldName }) => {
   const [, , { setTouched }] = useField(
     `${instanceFieldName}.onBeforeLinkClickSend`,
   );
-  useEffect(() => setTouched(true), []);
+  useEffect(() => {
+    setTouched(true);
+  }, []);
 
   return (
     <>
@@ -408,8 +410,8 @@ const DataCollectionSection = ({ instanceFieldName }) => {
                 </Flex>
               )}
             {clickCollectionIsEnabled(instanceValues) &&
-              instanceValues.linkCallbackType ===
-                LINK_CALLBACK.FILTER_CLICK_DETAILS && (
+              instanceValues.linkCallbackType !==
+                LINK_CALLBACK.ON_BEFORE_LINK_CLICK_SEND && (
                 <Flex gap="size-100">
                   <CodeField
                     data-test-id="filterClickDetailsEditButton"


### PR DESCRIPTION


## Description


If you have the onBeforeLinkClickSend specified, then event grouping does not work in Web SDK. This change adds a validation so that you cannot have event grouping and the onBeforeLinkClickSend specified in the extension. Also, this adds a clear button to code fields to make it easier to not have a callback specified.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
