### PR TITLE
Fixed an issue where empty idSyncContainerId overrides would throw an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch:views": "./scripts/buildViews.mjs --watch",
     "watch": "conc --pad-prefix --names \"alloy,fixtures,manifest,lib,views\" \"npm run build:alloy\" \"npm run build:componentFixtures\" \"npm run build:extensionManifest\" \"npm run watch:lib\" \"npm run watch:views\"",
     "clean": "rimraf dist extension.json package-adobe-alloy*.zip",
-    "dev": "conc --pad-prefix --names \"watch,sandbox\" \"npm run watch\" \"npm run sandbox\"",
+    "dev": "npm run build && conc --pad-prefix --names \"watch,sandbox\" \"npm run watch\" \"npm run sandbox\"",
     "format": "prettier --write \"*.{js,jsx,html,mjs,cjs}\" \"{src,test,scripts}/**/*.{js,jsx,html,mjs,cjs}\"",
     "lint": "eslint \"*.{js,jsx}\" \"{src,test,scripts}/**/*.{js,jsx}\" --cache --fix",
     "package": "NODE_ENV=production ./scripts/createExtensionPackage.mjs",

--- a/src/lib/utils/createGetConfigOverrides.js
+++ b/src/lib/utils/createGetConfigOverrides.js
@@ -57,6 +57,8 @@ const createGetConfigOverrides = (environmentName) => (settings) => {
         .filter(Boolean);
   }
 
+  // accepted input is a string that is either an integer or an empty string
+  // output is either an integer or undefined
   if (
     computedConfigOverrides.com_adobe_identity?.idSyncContainerId !==
       undefined &&
@@ -64,17 +66,25 @@ const createGetConfigOverrides = (environmentName) => (settings) => {
     typeof computedConfigOverrides.com_adobe_identity?.idSyncContainerId ===
       "string"
   ) {
-    const parsedValue = parseInt(
-      computedConfigOverrides.com_adobe_identity.idSyncContainerId.trim(),
-      10,
-    );
-    if (Number.isNaN(parsedValue)) {
-      throw new Error(
-        `The ID sync container ID "${computedConfigOverrides.com_adobe_identity.idSyncContainerId}" is not a valid integer.`,
+    if (
+      computedConfigOverrides.com_adobe_identity.idSyncContainerId.trim() === ""
+    ) {
+      delete computedConfigOverrides.com_adobe_identity.idSyncContainerId;
+    } else {
+      const parsedValue = parseInt(
+        computedConfigOverrides.com_adobe_identity.idSyncContainerId.trim(),
+        10,
       );
+      if (Number.isNaN(parsedValue)) {
+        throw new Error(
+          `The ID sync container ID "${computedConfigOverrides.com_adobe_identity.idSyncContainerId}" is not a valid integer.`,
+        );
+      }
+      computedConfigOverrides.com_adobe_identity.idSyncContainerId =
+        parsedValue;
     }
-    computedConfigOverrides.com_adobe_identity.idSyncContainerId = parsedValue;
   }
+  // alloy handles filtering out other empty strings and empty objects
   return computedConfigOverrides;
 };
 

--- a/test/unit/lib/utils/createGetConfigOverrides.spec.js
+++ b/test/unit/lib/utils/createGetConfigOverrides.spec.js
@@ -148,6 +148,24 @@ describe("createGetConfigOverrides", () => {
         );
       });
 
+      it("should delete/ignore empty strings, like those that result from data elements", () => {
+        const result = createConfigOverrides(
+          {
+            edgeConfigOverrides: {
+              [stage]: {
+                com_adobe_identity: {
+                  idSyncContainerId: "",
+                },
+              },
+            },
+          },
+          stage,
+        );
+        expect(result).toEqual({
+          com_adobe_identity: {},
+        });
+      });
+
       it("should return undefined when overrides are disabled for the given environment", () => {
         const result = createConfigOverrides(
           {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Previously, the extension would throw an error if an empty string was passed as a value for the `idSyncContainerId` override. This could happen with data elements. 

With this change, the empty string is treated the same as `undefined` or `null` and is ignored.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PLATIR-51567: idSyncContainer not working fine in latest webSDK extension](https://jira.corp.adobe.com/browse/PLATIR-51567)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
