### PR TITLE
Fixed an issue where an error is thrown when a datastream override is "enabled" via data element.

### DIFF
--- a/src/lib/utils/createGetConfigOverrides.js
+++ b/src/lib/utils/createGetConfigOverrides.js
@@ -49,6 +49,13 @@ const createGetConfigOverrides = (environmentName) => (settings) => {
   }
   delete computedConfigOverrides.enabled;
 
+  // delete every child `enabled: true` key-value pair—it's the same as undefined
+  Object.keys(computedConfigOverrides).forEach((key) => {
+    if (computedConfigOverrides[key]?.enabled === true) {
+      delete computedConfigOverrides[key].enabled;
+    }
+  });
+
   if (computedConfigOverrides.com_adobe_analytics?.reportSuites?.length > 0) {
     computedConfigOverrides.com_adobe_analytics.reportSuites =
       computedConfigOverrides.com_adobe_analytics.reportSuites

--- a/test/functional/specs/runtime/sendEvent.spec.mjs
+++ b/test/functional/specs/runtime/sendEvent.spec.mjs
@@ -104,3 +104,43 @@ test("Sends an event", async () => {
   // made or a timeout is reached.
   await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
 });
+
+test.only("Sends an event with a data element to enable/disable a service via overrides", async () => {
+  const containerWithConfigOverrides = structuredClone(container);
+  containerWithConfigOverrides.extensions[
+    "adobe-alloy"
+  ].settings.instances[0].edgeConfigOverrides = {
+    development: {
+      enabled: true,
+      com_adobe_identity: {
+        enabled: "%enableIdentity%",
+      },
+    },
+  };
+  containerWithConfigOverrides.dataElements.enableIdentity = {
+    settings: {
+      path: "enableIdentity",
+    },
+    cleanText: false,
+    defaultValue: true,
+    forceLowerCase: false,
+    modulePath: "sandbox/javascriptVariable.js",
+    storageDuration: "",
+  };
+  await appendLaunchLibrary(containerWithConfigOverrides);
+  // The requestLogger.count method uses TestCafe's smart query
+  // assertion mechanism, so it will wait for the request to be
+  // made or a timeout is reached.
+  await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
+  const [request] = networkLogger.edgeEndpointLogs.requests;
+  await t.expect(request.response.statusCode).eql(200);
+  // "true" should be deleted from the response body
+  const requestBody = JSON.parse(request.request.body);
+  await t.expect(requestBody.meta?.com_adobe_identity?.enabled).eql(undefined);
+  let responseBody = request.response.body;
+  if (responseBody.type === "Buffer") {
+    responseBody = Buffer.from(responseBody.data).toString("utf-8");
+  }
+  const body = JSON.parse(responseBody);
+  await t.expect(body.meta?.com_adobe_identity?.enabled).eql(undefined);
+});

--- a/test/unit/lib/utils/createGetConfigOverrides.spec.js
+++ b/test/unit/lib/utils/createGetConfigOverrides.spec.js
@@ -148,6 +148,23 @@ describe("createGetConfigOverrides", () => {
         );
       });
 
+      it("should delete the enabled: true key-value pairs for services", () => {
+        const result = createConfigOverrides(
+          {
+            edgeConfigOverrides: {
+              [stage]: {
+                enabled: true,
+                com_adobe_identity: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+          stage,
+        );
+        expect(result).toEqual({ com_adobe_identity: {} });
+      });
+
       it("should return undefined when overrides are disabled for the given environment", () => {
         const result = createConfigOverrides(
           {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Konductor/blackbird defines the value set of values for `enabled` on a datastream override as `[false]` i.e. the only valid value is `false`. While the process of saving extension settings will filter out the `true`, this does not apply to data elements. 

With these changes, the library will delete entries that are `enabled: true`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PLATIR-51470: Issues triggered in latest AEP webSDK extension V-2.30.0](https://jira.corp.adobe.com/browse/PLATIR-51470)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
