### PR TITLE
Fixed an issue where empty strings were saved as ID sync container ID override settings

### DIFF
--- a/src/view/utils/trimValues.js
+++ b/src/view/utils/trimValues.js
@@ -20,28 +20,42 @@ governing permissions and limitations under the License.
  * If the value is an object, the object will be recursed through and returned
  * with all whitespace trimmed from each value.
  *
+ * If the resulting string is empty, the value will be undefined.
+ * If the resulting object is empty, the value will be undefined.
+ * If the resulting array is empty, the value will be undefined.
+ *
  * This is a function statement instead of an arrow function so that it can be
  * recursively called.
  * @param {T} value
- * @returns {T}
+ * @returns {T | undefined}
  */
 function trimValue(value) {
   if (
     value == null ||
-    !value ||
     (typeof value !== "object" && typeof value !== "string")
   ) {
     return value;
   }
 
   if (typeof value === "string") {
-    return value.trim();
+    return value.trim() || undefined;
   }
 
-  // Object.keys() works on both objects and arrays
+  if (Array.isArray(value)) {
+    const trimmedArray = value
+      .map(trimValue)
+      .filter((item) => item !== undefined);
+    return trimmedArray.length === 0 ? undefined : trimmedArray;
+  }
+
   Object.keys(value).forEach((key) => {
-    value[key] = trimValue(value[key]);
+    const trimmedValue = trimValue(value[key]);
+    if (trimmedValue === undefined) {
+      delete value[key];
+    } else {
+      value[key] = trimmedValue;
+    }
   });
-  return value;
+  return Object.keys(value).length === 0 ? undefined : value;
 }
 module.exports = trimValue;

--- a/test/unit/view/components/overrides/overridesBridge.spec.js
+++ b/test/unit/view/components/overrides/overridesBridge.spec.js
@@ -1283,6 +1283,149 @@ describe("overridesBridge", () => {
       });
     });
 
+    it("should exclude empty fields", () => {
+      const instanceValues = {
+        edgeConfigOverrides: {
+          development: {
+            sandbox: "",
+            datastreamId: "",
+            datastreamIdInputMethod: "freeform",
+            enabled: "Enabled",
+            com_adobe_experience_platform: {
+              enabled: "Enabled",
+              datasets: {
+                event: {
+                  datasetId: "",
+                },
+              },
+              com_adobe_edge_ode: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_segmentation: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_destinations: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_ajo: {
+                enabled: "Enabled",
+              },
+            },
+            com_adobe_analytics: {
+              enabled: "Enabled",
+              reportSuites: [""],
+            },
+            com_adobe_identity: {
+              idSyncContainerId: "",
+            },
+            com_adobe_target: {
+              enabled: "Enabled",
+              propertyToken: "",
+            },
+            com_adobe_audiencemanager: {
+              enabled: "Enabled",
+            },
+            com_adobe_launch_ssf: {
+              enabled: "Enabled",
+            },
+          },
+          staging: {
+            sandbox: "",
+            datastreamId: "",
+            datastreamIdInputMethod: "freeform",
+            enabled: "Match datastream configuration",
+            com_adobe_experience_platform: {
+              enabled: "Enabled",
+              datasets: {
+                event: {
+                  datasetId: "",
+                },
+              },
+              com_adobe_edge_ode: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_segmentation: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_destinations: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_ajo: {
+                enabled: "Enabled",
+              },
+            },
+            com_adobe_analytics: {
+              enabled: "Enabled",
+              reportSuites: [""],
+            },
+            com_adobe_identity: {},
+            com_adobe_target: {
+              enabled: "Enabled",
+              propertyToken: "",
+            },
+            com_adobe_audiencemanager: {
+              enabled: "Enabled",
+            },
+            com_adobe_launch_ssf: {
+              enabled: "Enabled",
+            },
+          },
+          production: {
+            sandbox: "",
+            datastreamId: "",
+            datastreamIdInputMethod: "freeform",
+            enabled: "Match datastream configuration",
+            com_adobe_experience_platform: {
+              enabled: "Enabled",
+              datasets: {
+                event: {
+                  datasetId: "",
+                },
+              },
+              com_adobe_edge_ode: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_segmentation: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_destinations: {
+                enabled: "Enabled",
+              },
+              com_adobe_edge_ajo: {
+                enabled: "Enabled",
+              },
+            },
+            com_adobe_analytics: {
+              enabled: "Enabled",
+              reportSuites: [""],
+            },
+            com_adobe_identity: {},
+            com_adobe_target: {
+              enabled: "Enabled",
+              propertyToken: "",
+            },
+            com_adobe_audiencemanager: {
+              enabled: "Enabled",
+            },
+            com_adobe_launch_ssf: {
+              enabled: "Enabled",
+            },
+          },
+        },
+      };
+
+      const instanceSettings = bridge.getInstanceSettings({
+        instanceValues,
+      });
+      expect(instanceSettings).toEqual({
+        edgeConfigOverrides: {
+          development: {
+            enabled: true,
+          },
+        },
+      });
+    });
+
     it("should allow for data elements", () => {
       const instanceValues = {
         edgeConfigOverrides: {

--- a/test/unit/view/utils/trimValues.spec.js
+++ b/test/unit/view/utils/trimValues.spec.js
@@ -24,6 +24,59 @@ describe("trimValues", () => {
     [null, null, "null"],
     [undefined, undefined, "undefined"],
     [NaN, NaN, "NaN"],
+    ["", undefined, "empty string"],
+    [{ test: "" }, undefined, "empty string in object"],
+    [["", "test"], ["test"], "empty string in array"],
+    [
+      { test: ["", "test"] },
+      { test: ["test"] },
+      "empty string in nested array",
+    ],
+    [{}, undefined, "empty object"],
+    [[], undefined, "empty array"],
+    [{ test: {} }, undefined, "empty object in object"],
+    [{ test: [] }, undefined, "empty array in object"],
+    [{ test: [""] }, undefined, "empty string in array in object"],
+    [
+      { test: ["", "test"] },
+      { test: ["test"] },
+      "empty string in array in object",
+    ],
+    [
+      { test: { a: true, b: {} } },
+      { test: { a: true } },
+      "empty object in object",
+    ],
+    [
+      { test: { a: true, b: [] } },
+      { test: { a: true } },
+      "empty array in object",
+    ],
+    [
+      { test: { a: true, b: [""] } },
+      { test: { a: true } },
+      "empty string in array in object",
+    ],
+    [
+      { test: { a: true, b: ["", "test"] } },
+      { test: { a: true, b: ["test"] } },
+      "empty string in array in object",
+    ],
+    [
+      { test: { a: true, b: {} } },
+      { test: { a: true } },
+      "empty object in object",
+    ],
+    [
+      { test: { a: true, b: [] } },
+      { test: { a: true } },
+      "empty array in object",
+    ],
+    [
+      { test: { a: true, b: [""] } },
+      { test: { a: true } },
+      "empty string in array in object",
+    ],
   ].forEach(([value, expected, description]) => {
     let testTitle = "should trim";
     if (description) {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

1. Open up the extension configuration
2. Add a value to the third party ID sync container ID override
3. Save
4. Remove the value from the third party ID sync container ID override
5. Save

Before this PR, an empty string would be saved as the value, i.e. `{ idSyncContainerId: "" }`. 

After this PR, it is removed (if empty). Also, empty objects and arrays and strings everywhere are removed from the override settings.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/PLATIR-51567

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
