### PR TITLE
Feature/use existing instance

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -262,7 +262,7 @@ const createExtensionManifest = ({ version }) => {
   const extensionManifest = {
     version,
     displayName: "Adobe Experience Platform Web SDK",
-    name: "adobe-alloy-eds",
+    name: "adobe-alloy",
     iconPath: "resources/images/icon.svg",
     exchangeUrl:
       "https://exchange.adobe.com/experiencecloud.details.106387.aep-web-sdk.html",

--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -262,7 +262,7 @@ const createExtensionManifest = ({ version }) => {
   const extensionManifest = {
     version,
     displayName: "Adobe Experience Platform Web SDK",
-    name: "adobe-alloy",
+    name: "adobe-alloy-eds",
     iconPath: "resources/images/icon.svg",
     exchangeUrl:
       "https://exchange.adobe.com/experiencecloud.details.106387.aep-web-sdk.html",
@@ -288,6 +288,9 @@ const createExtensionManifest = ({ version }) => {
                 name: {
                   type: "string",
                   pattern: "\\D+",
+                },
+                useExistingAlloy: {
+                  type: "boolean",
                 },
                 edgeConfigId: {
                   type: "string",
@@ -442,14 +445,40 @@ const createExtensionManifest = ({ version }) => {
                   additionalProperties: false,
                 },
               },
-              required: ["edgeConfigId", "name"],
               additionalProperties: false,
+              oneOf: [
+                {
+                  // If useExistingAlloy is true, only name is required.
+                  properties: {
+                    useExistingAlloy: {
+                      const: true,
+                    },
+                  },
+                  required: ["name"],
+                },
+                {
+                  // If useExistingAlloy is false or not defined,
+                  // then edgeConfigId is also required.
+                  properties: {
+                    useExistingAlloy: {
+                      const: false,
+                    },
+                  },
+                  required: ["name", "edgeConfigId"],
+                },
+              ],
             },
           },
           components: {
             type: "object",
             patternProperties: {
               ".*": { type: "boolean" },
+            },
+          },
+          hostedLibFiles: {
+            type: "array",
+            items: {
+              type: "string",
             },
           },
         },

--- a/src/lib/instanceManager/createInstanceManager.js
+++ b/src/lib/instanceManager/createInstanceManager.js
@@ -52,8 +52,26 @@ module.exports = ({
       stagingEdgeConfigId,
       developmentEdgeConfigId,
       onBeforeEventSend,
+      useExistingAlloy,
       ...options
     }) => {
+      if (useExistingAlloy) {
+        if (typeof window[name] === "function") {
+          instanceByName[name] = window[name];
+          if (!window.__alloyNS) {
+            window.__alloyNS = [];
+          }
+          if (window.__alloyNS.indexOf(name) === -1) {
+            window.__alloyNS.push(name);
+          }
+        } else {
+          turbine.logger.warn(
+            `Alloy instance "${name}" not found on window. Please ensure it is loaded before the Launch library.`,
+          );
+        }
+        return;
+      }
+
       const instance = createCustomInstance({ name, components });
       window[name] = instance;
       if (!window.__alloyNS) {

--- a/src/view/configuration/basicSection.jsx
+++ b/src/view/configuration/basicSection.jsx
@@ -12,11 +12,12 @@ governing permissions and limitations under the License.
 
 import React from "react";
 import { useField } from "formik";
-import { object, string } from "yup";
+import { object, string, boolean } from "yup";
 import { Flex, InlineAlert, Heading, Content } from "@adobe/react-spectrum";
 import PropTypes from "prop-types";
 import DataElementSelector from "../components/dataElementSelector";
 import FormikTextField from "../components/formikReactSpectrum3/formikTextField";
+import FormikCheckbox from "../components/formikReactSpectrum3/formikCheckbox";
 import RestoreDefaultValueButton from "../components/restoreDefaultValueButton";
 import copyPropertiesIfValueDifferentThanDefault from "./utils/copyPropertiesIfValueDifferentThanDefault";
 import copyPropertiesWithDefaultFallback from "./utils/copyPropertiesWithDefaultFallback";
@@ -29,6 +30,7 @@ export const bridge = {
     persistedName: undefined,
     orgId: initInfo.company.orgId,
     edgeDomain: "edge.adobedc.net",
+    useExistingAlloy: false,
   }),
   getInitialInstanceValues: ({ initInfo, instanceSettings }) => {
     const instanceValues = {};
@@ -37,7 +39,7 @@ export const bridge = {
       toObj: instanceValues,
       fromObj: instanceSettings,
       defaultsObj: bridge.getInstanceDefaults({ initInfo }),
-      keys: ["name", "orgId", "edgeDomain"],
+      keys: ["name", "orgId", "edgeDomain", "useExistingAlloy"],
     });
 
     instanceValues.persistedName = instanceValues.name;
@@ -60,7 +62,7 @@ export const bridge = {
       toObj: instanceSettings,
       fromObj: instanceValues,
       defaultsObj: bridge.getInstanceDefaults({ initInfo }),
-      keys: ["orgId", "edgeDomain"],
+      keys: ["orgId", "edgeDomain", "useExistingAlloy"],
     });
 
     return instanceSettings;
@@ -81,8 +83,16 @@ export const bridge = {
             return !(value in window);
           },
         }),
-      orgId: string().required("Please specify an IMS organization ID."),
-      edgeDomain: string().required("Please specify an edge domain."),
+      orgId: string().when("useExistingAlloy", {
+        is: false,
+        then: (schema) =>
+          schema.required("Please specify an IMS organization ID."),
+      }),
+      edgeDomain: string().when("useExistingAlloy", {
+        is: false,
+        then: (schema) => schema.required("Please specify an edge domain."),
+      }),
+      useExistingAlloy: boolean(),
     })
     // TestCafe doesn't allow this to be an arrow function because of
     // how it scopes "this".
@@ -122,6 +132,14 @@ const BasicSection = ({ instanceFieldName, initInfo }) => {
 
   return (
     <FormElementContainer>
+      <FormikCheckbox
+        data-test-id="useExistingAlloyField"
+        name={`${instanceFieldName}.useExistingAlloy`}
+        description="Check this box if alloy.js is already loaded on your site."
+        width="size-5000"
+      >
+        Use existing alloy.js instance
+      </FormikCheckbox>
       <DataElementSelector>
         <FormikTextField
           data-test-id="nameField"
@@ -148,43 +166,47 @@ const BasicSection = ({ instanceFieldName, initInfo }) => {
           </Content>
         </InlineAlert>
       ) : null}
-      <Flex>
-        <DataElementSelector>
-          <FormikTextField
-            data-test-id="orgIdField"
-            label="IMS organization ID"
-            name={`${instanceFieldName}.orgId`}
-            description="Your assigned Experience Cloud organization ID."
-            isRequired
-            width="size-5000"
-          />
-        </DataElementSelector>
-        <RestoreDefaultValueButton
-          data-test-id="orgIdRestoreButton"
-          name={`${instanceFieldName}.orgId`}
-          defaultValue={instanceDefaults.orgId}
-        />
-      </Flex>
-      <Flex>
-        <DataElementSelector>
-          <FormikTextField
-            data-test-id="edgeDomainField"
-            label="Edge domain"
-            name={`${instanceFieldName}.edgeDomain`}
-            description="The domain that will be used to interact with
+      {!instanceValues.useExistingAlloy && (
+        <>
+          <Flex>
+            <DataElementSelector>
+              <FormikTextField
+                data-test-id="orgIdField"
+                label="IMS organization ID"
+                name={`${instanceFieldName}.orgId`}
+                description="Your assigned Experience Cloud organization ID."
+                isRequired
+                width="size-5000"
+              />
+            </DataElementSelector>
+            <RestoreDefaultValueButton
+              data-test-id="orgIdRestoreButton"
+              name={`${instanceFieldName}.orgId`}
+              defaultValue={instanceDefaults.orgId}
+            />
+          </Flex>
+          <Flex>
+            <DataElementSelector>
+              <FormikTextField
+                data-test-id="edgeDomainField"
+                label="Edge domain"
+                name={`${instanceFieldName}.edgeDomain`}
+                description="The domain that will be used to interact with
                         Adobe services. Update this setting if you have
                         mapped one of your first-party domains (using
                         CNAME) to an Adobe-provisioned domain."
-            isRequired
-            width="size-5000"
-          />
-        </DataElementSelector>
-        <RestoreDefaultValueButton
-          data-test-id="edgeDomainRestoreButton"
-          name={`${instanceFieldName}.edgeDomain`}
-          defaultValue={instanceDefaults.edgeDomain}
-        />
-      </Flex>
+                isRequired
+                width="size-5000"
+              />
+            </DataElementSelector>
+            <RestoreDefaultValueButton
+              data-test-id="edgeDomainRestoreButton"
+              name={`${instanceFieldName}.edgeDomain`}
+              defaultValue={instanceDefaults.edgeDomain}
+            />
+          </Flex>
+        </>
+      )}
     </FormElementContainer>
   );
 };

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -15,15 +15,8 @@ import { object, array } from "yup";
 import { FieldArray, useField } from "formik";
 import {
   Button,
-  ButtonGroup,
-  Content,
-  DialogTrigger,
-  Dialog,
   Flex,
-  Heading as HeadingSlot,
   Item,
-  Divider,
-  Text,
   TabList,
   TabPanels,
   Tabs,
@@ -131,7 +124,7 @@ const getInitialValues = async ({ initInfo, context }) => {
 };
 
 const getSettings = async ({ values, initInfo }) => {
-  return {
+  const settings = {
     ...componentsBridge.getSettings({ values, initInfo }),
     instances: await Promise.all(
       values.instances.map((instanceValues) => {
@@ -143,6 +136,12 @@ const getSettings = async ({ values, initInfo }) => {
       }),
     ),
   };
+
+  if (values.instances.some((instance) => instance.useExistingAlloy)) {
+    settings.hostedLibFiles = [];
+  }
+
+  return settings;
 };
 
 const validationSchema = object().shape({
@@ -222,91 +221,67 @@ const InstancesSection = ({ initInfo, context }) => {
                           instanceFieldName={instanceFieldName}
                           initInfo={initInfo}
                         />
-                        <EdgeConfigurationsSection
-                          instanceFieldName={instanceFieldName}
-                          instanceIndex={index}
-                          initInfo={initInfo}
-                          context={context}
-                        />
-                        <PrivacySection instanceFieldName={instanceFieldName} />
-                        <IdentitySection
-                          instanceFieldName={instanceFieldName}
-                        />
-                        <PersonalizationSection
-                          instanceFieldName={instanceFieldName}
-                        />
-                        <DataCollectionSection
-                          instanceFieldName={instanceFieldName}
-                        />
-                        <StreamingMediaSection
-                          instanceFieldName={instanceFieldName}
-                        />
-                        <OverridesSection
-                          initInfo={initInfo}
-                          instanceFieldName={instanceFieldName}
-                          edgeConfigIds={edgeConfigIds}
-                          configOrgId={instance.orgId}
-                          hideFields={[FIELD_NAMES.datastreamId]}
-                        />
-                        <AdvancedSection
-                          instanceFieldName={instanceFieldName}
-                        />
-                        {instances.length > 1 && (
-                          <View marginTop="size-300">
-                            <DialogTrigger>
-                              <Button
-                                data-test-id="deleteInstanceButton"
-                                icon={<DeleteIcon />}
-                                variant="secondary"
-                                disabled={instances.length === 1}
-                              >
-                                Delete instance
-                              </Button>
-                              {(close) => (
-                                <Dialog data-test-id="resourceUsageDialog">
-                                  <HeadingSlot>Resource Usage</HeadingSlot>
-                                  <Divider />
-                                  <Content>
-                                    <Text>
-                                      Any rule components or data elements using
-                                      this instance will no longer function as
-                                      expected when running on your website. We
-                                      recommend removing these resources or
-                                      switching them to use a different instance
-                                      before publishing your next library. Would
-                                      you like to proceed?
-                                    </Text>
-                                  </Content>
-                                  <ButtonGroup>
-                                    <Button
-                                      data-test-id="cancelDeleteInstanceButton"
-                                      variant="secondary"
-                                      onPress={close}
-                                    >
-                                      Cancel
-                                    </Button>
-                                    <Button
-                                      data-test-id="confirmDeleteInstanceButton"
-                                      variant="cta"
-                                      onPress={() => {
-                                        arrayHelpers.remove(index);
-                                        setSelectedTabKey(String(index));
-                                      }}
-                                      autoFocus
-                                    >
-                                      Delete
-                                    </Button>
-                                  </ButtonGroup>
-                                </Dialog>
-                              )}
-                            </DialogTrigger>
-                          </View>
+                        {!instance.useExistingAlloy && (
+                          <>
+                            <EdgeConfigurationsSection
+                              instanceFieldName={instanceFieldName}
+                              instanceIndex={index}
+                              initInfo={initInfo}
+                              context={context}
+                            />
+                            <PrivacySection
+                              instanceFieldName={instanceFieldName}
+                            />
+                            <IdentitySection
+                              instanceFieldName={instanceFieldName}
+                            />
+                            <PersonalizationSection
+                              instanceFieldName={instanceFieldName}
+                            />
+                            <DataCollectionSection
+                              instanceFieldName={instanceFieldName}
+                            />
+                            <StreamingMediaSection
+                              instanceFieldName={instanceFieldName}
+                            />
+                            <OverridesSection
+                              initInfo={initInfo}
+                              instanceFieldName={instanceFieldName}
+                              edgeConfigIds={edgeConfigIds}
+                              configOrgId={instance.orgId}
+                              hideFields={[FIELD_NAMES.datastreamId]}
+                            />
+                            <AdvancedSection
+                              instanceFieldName={instanceFieldName}
+                            />
+                          </>
                         )}
                       </Item>
                     );
                   })}
                 </TabPanels>
               </Tabs>
+              {instances.length > 1 && (
+                <View marginTop="size-300">
+                  <Button
+                    data-test-id="deleteInstanceButton"
+                    variant="negative"
+                    onPress={() => {
+                      arrayHelpers.remove(Number(selectedTabKey));
+
+                      const newSelectedTabKey = Math.max(
+                        0,
+                        Number(selectedTabKey) - 1,
+                      ).toString();
+
+                      setSelectedTabKey(newSelectedTabKey);
+                    }}
+                    icon={<DeleteIcon />}
+                  >
+                    Delete instance
+                  </Button>
+                </View>
+              )}
             </div>
           );
         }}


### PR DESCRIPTION
## Description

This PR adds a flag to the configuration allowing to re-use a self-hosted `alloy.js` instance, so that the Launch container can extend it with data elements and rules. This is especially targeted towards the AEM EDS use cases, and to work towards better compatibility with [aem-martech](https://github.com/adobe-rnd/aem-martech/).

## Motivation and Context

In the context of EDS, where top CWV and LHS are of great importance, customers have started relying on direct `alloy.js` instrumentations. The [aem-martech](https://github.com/adobe-rnd/aem-martech/) was introduced to help with that, but we still have a gap in that we cannot easily integrate with a richer Launch container loaded async later in the page.

By allowing to re-use the existing `alloy.js` instance, we allow a seamless integration, and also align with the ACDL extension.

## Screenshots (if appropriate):

<img width="1277" height="1296" alt="Screenshot 2025-07-22 at 15 32 24" src="https://github.com/user-attachments/assets/764a2cc8-e802-4a52-8522-7cfdbaeb30de" />
<img width="1281" height="1294" alt="Screenshot 2025-07-22 at 15 32 31" src="https://github.com/user-attachments/assets/93ceadb5-6d3d-43d8-905f-e6199815484b" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.
