### PR TITLE
Exclude Advertising and Push notification components by default when extension is upgraded

### DIFF
--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -12,11 +12,22 @@ governing permissions and limitations under the License.
 
 import getAlloyComponents from "./getAlloyComponents.mjs";
 
+const ORIGINAL_DEFAULT_COMPONENTS = new Set([
+  "activityCollector",
+  "audiences",
+  "consent",
+  "eventMerge",
+  "mediaAnalyticsBridge",
+  "personalization",
+  "rulesEngine",
+  "streamingMedia",
+]);
+
 const createPreprocessingVariables = () =>
   getAlloyComponents().map((n) => ({
     key: `ALLOY_${n.toUpperCase()}`,
     path: `components.${n}`,
-    default: true,
+    default: ORIGINAL_DEFAULT_COMPONENTS.has(n),
   }));
 
 /**
@@ -486,6 +497,13 @@ const createExtensionManifest = ({ version }) => {
           },
           components: {
             type: "object",
+            properties: {
+              version: {
+                type: "integer",
+                enum: [1, 2],
+              },
+            },
+            required: ["version"],
             patternProperties: {
               ".*": { type: "boolean" },
             },

--- a/scripts/helpers/createExtensionManifest.mjs
+++ b/scripts/helpers/createExtensionManifest.mjs
@@ -497,13 +497,6 @@ const createExtensionManifest = ({ version }) => {
           },
           components: {
             type: "object",
-            properties: {
-              version: {
-                type: "integer",
-                enum: [1, 2],
-              },
-            },
-            required: ["version"],
             patternProperties: {
               ".*": { type: "boolean" },
             },

--- a/src/view/configuration/componentsSection.jsx
+++ b/src/view/configuration/componentsSection.jsx
@@ -68,7 +68,7 @@ const webSdkComponents = Object.keys(webSdkComponentsExports)
   .map((v) => ({
     label: camelCaseToTitleCase(v),
     value: v,
-    ...(componentProperties[v] || {}),
+    ...(componentProperties[v] || { excludedByDefault: true }),
   }))
   .sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
 
@@ -89,27 +89,26 @@ export const bridge = {
     }
 
     const initialValues = {
-      components: webSdkComponents.reduce((acc, { value }) => {
-        acc[value] = components[value] !== false;
-        return acc;
-      }, {}),
+      components: webSdkComponents.reduce(
+        (acc, { value, excludedByDefault }) => {
+          if (components[value] === undefined) {
+            // If the component is not set, use true for the original set of components, false for new components.
+            acc[value] = !excludedByDefault;
+          } else {
+            // If the component is already set, use the value from the settings
+            acc[value] = components[value];
+          }
+
+          return acc;
+        },
+        {},
+      ),
     };
     return initialValues;
   },
   getSettings: ({ values: { components } }) => {
-    const excludedComponents = webSdkComponents
-      .map(({ value }) => value)
-      .filter((v) => !components[v])
-      .reduce((acc, v) => {
-        acc[v] = false;
-        return acc;
-      }, {});
-
-    if (Object.keys(excludedComponents).length > 0) {
-      return { components: excludedComponents };
-    }
-
-    return {};
+    // return all values regardless of whether they are set or not
+    return { components };
   },
 };
 


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

* For customers that are upgrading their Web SDK extension in Tags, we only want their original set of components to be used.
* Before this change we were storing just the components to exclude.
* This change will make any new components excluded by default when building and when showing the UI.
* I created an allowlist of "original" components that default to true, and then any new components default to false.
* 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
- [ ] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
