### PR TITLE
Added doc links for variable data element and action

### DIFF
--- a/src/view/actions/updateVariable.jsx
+++ b/src/view/actions/updateVariable.jsx
@@ -21,6 +21,7 @@ import {
   Text,
   InlineAlert,
   Content,
+  Link,
 } from "@adobe/react-spectrum";
 import { useField } from "formik";
 import PropTypes from "prop-types";
@@ -358,7 +359,7 @@ const UpdateVariable = ({
 
   const {
     propertySettings: { id: propertyId } = {},
-    company: { orgId },
+    company: { id: companyId, orgId },
     tokens: { imsAccess },
   } = initInfo;
 
@@ -431,27 +432,45 @@ const UpdateVariable = ({
         >
           <Heading size="XXS">Error</Heading>
           <Content>
-            No `variable` type data elements are available. Create a variable
-            type data element first.
+            No `variable` type data elements are available.{" "}
+            <Link
+              href={`https://experience.adobe.com/#/data-collection/tags/companies/${companyId}/properties/${propertyId}/dataElements/new`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Create a `variable` type data element first
+            </Link>
+            .
           </Content>
         </InlineAlert>
       )}
       {dataElementsFirstPage.length > 0 && (
-        <FormikPagedComboBox
-          data-test-id="dataElementField"
-          name="dataElement"
-          label="Data element"
-          description="Please specify the data element you would like to update. Only `variable` type data elements are available."
-          width="size-5000"
-          isRequired
-          loadItems={loadItems}
-          getKey={(item) => item?.name}
-          getLabel={(item) => item?.name}
-          firstPage={dataElementsFirstPage}
-          firstPageCursor={dataElementsFirstPageCursor}
-        >
-          {(item) => <Item key={item.name}>{item.name}</Item>}
-        </FormikPagedComboBox>
+        <>
+          <Link>
+            <a
+              href="https://experienceleague.adobe.com/en/docs/experience-platform/tags/extensions/client/web-sdk/action-types#update-variable"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more about the Update Variable action
+            </a>
+          </Link>
+          <FormikPagedComboBox
+            data-test-id="dataElementField"
+            name="dataElement"
+            label="Data element"
+            description="Please specify the data element you would like to update. Only `variable` type data elements are available."
+            width="size-5000"
+            isRequired
+            loadItems={loadItems}
+            getKey={(item) => item?.name}
+            getLabel={(item) => item?.name}
+            firstPage={dataElementsFirstPage}
+            firstPageCursor={dataElementsFirstPageCursor}
+          >
+            {(item) => <Item key={item.name}>{item.name}</Item>}
+          </FormikPagedComboBox>
+        </>
       )}
       {context.schemaLoadFailed && dataElement && (
         <InlineAlert

--- a/src/view/dataElements/variable.jsx
+++ b/src/view/dataElements/variable.jsx
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import { useField } from "formik";
-import { Content, Radio } from "@adobe/react-spectrum";
+import { Content, Link, Radio } from "@adobe/react-spectrum";
 import ExtensionView from "../components/extensionView";
 import FormElementContainer from "../components/formElementContainer";
 import XdmVariable, {
@@ -66,7 +66,17 @@ const Schema = ({ xdmVariableContext, initInfo }) => {
         properties using Web SDK update variable actions. You can reference the
         variable data element just like any other data element. For example,
         inside of a send event action you can specify this data element as the
-        value for XDM.
+        value for XDM.{" "}
+        <Link>
+          <a
+            href="https://experienceleague.adobe.com/docs/experience-platform/edge/identity/id-sharing.html#tags-extension"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more about the Variable data element type
+          </a>
+        </Link>
+        .
       </Content>
       <FormikRadioGroup
         label="Choose the property you want to populate"


### PR DESCRIPTION
## Description

Adds links to the Experience League pages for configuring the "variable" type data element and the Update Variable action. Also adds a link to create a new data element in the error message that displays when attempting to configure an Update Variable action but no variable data elements exist.

## Related Issue

[Jira task](https://jira.corp.adobe.com/browse/PDCL-10225)

## Motivation and Context

Improves user experience by providing quick access to documentation.

## Screenshots (if appropriate):

<img width="672" height="394" alt="Screenshot 2025-09-22 at 9 05 28 AM" src="https://github.com/user-attachments/assets/da4e2957-6d9b-4355-af88-cec7422485cd" />

Documentation link on variable data element configuration

<img width="660" height="360" alt="Screenshot 2025-09-22 at 9 00 51 AM" src="https://github.com/user-attachments/assets/8b588c72-a70f-497b-b85f-934bb087c82b" />

Documentation link on Update Variable action configuration

<img width="718" height="442" alt="Screenshot 2025-09-22 at 8 58 25 AM" src="https://github.com/user-attachments/assets/2383263a-7501-4d2e-aa08-a1abcf055e2f" />

Link to create a new data element on error message that no "variable" type data element exists

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary. *Need confirmation on this*
- [x] My change requires a change to the documentation. *N/A*
