### PR TITLE
Added link to create datastream/schema where those components are selected

### DIFF
--- a/src/view/configuration/edgeConfigurationsSection.jsx
+++ b/src/view/configuration/edgeConfigurationsSection.jsx
@@ -645,7 +645,7 @@ const EdgeConfigurationsSection = ({
       <FormElementContainer>
         <Content>
           <Link
-            href="https://experience.adobe.com/#/@unifiedjslab/sname:prod/data-collection/scramjet/new"
+            href="https://experience.adobe.com/#/data-collection/scramjet/new"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/view/configuration/edgeConfigurationsSection.jsx
+++ b/src/view/configuration/edgeConfigurationsSection.jsx
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import React from "react";
 import PropTypes from "prop-types";
-import { Radio } from "@adobe/react-spectrum";
+import { Radio, Link, Content } from "@adobe/react-spectrum";
 import { object, string } from "yup";
 import { useField } from "formik";
 import SectionHeader from "../components/sectionHeader";
@@ -643,6 +643,16 @@ const EdgeConfigurationsSection = ({
         Datastreams
       </SectionHeader>
       <FormElementContainer>
+        <Content>
+          <Link
+            href="https://experience.adobe.com/#/@unifiedjslab/sname:prod/data-collection/scramjet/new"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Create a datastream first,
+          </Link>{" "}
+          or choose an existing one below.
+        </Content>
         {
           // Each instance must have a unique org ID. Typically, the first instance will have
           // the org ID that matches the Launch user's active org ID.

--- a/src/view/dataElements/variable/components/xdmVariable.jsx
+++ b/src/view/dataElements/variable/components/xdmVariable.jsx
@@ -11,7 +11,13 @@ governing permissions and limitations under the License.
 */
 
 import React from "react";
-import { Item, InlineAlert, Heading, Content } from "@adobe/react-spectrum";
+import {
+  Item,
+  InlineAlert,
+  Heading,
+  Content,
+  Link,
+} from "@adobe/react-spectrum";
 import { useField } from "formik";
 import PropTypes from "prop-types";
 import UserReportableError from "../../../errors/userReportableError";
@@ -221,6 +227,16 @@ const XdmVariable = ({
   return (
     <FieldSubset>
       <FormElementContainer>
+        <Content>
+          <Link
+            href="https://experience.adobe.com/#/data-collection/platform/workflow/schema-create"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Create a schema first,
+          </Link>{" "}
+          or choose an existing one below.
+        </Content>
         {(missingSavedSandbox || missingSavedSchema) && (
           <InlineAlert
             variant="notice"


### PR DESCRIPTION
## Description
Added link to create datastream on extension configuration page. Added link to create schema on create variable data element page.

- The mockup in the Jira ticket shows with a button, but I opted to use links instead because I thought it would be less intrusive, which felt appropriate to me but I'm open to disagreement on this point
- Also let me know if the language I used could be improved
- Overall I feel this experience would be better if it didn't require going to another page from the configuration page that the user is already on, but all the ways I could imagine doing this would be much more substantial changes that would require more planning and design, and this was meant to be a small & quick improvement.

## Related Issue
[Jira issue](https://jira.corp.adobe.com/browse/PDCL-8923)

## Motivation and Context
This is a minor usability improvement to allow users to quickly navigate to the pages for creating the resources related to the components they're configuring. EG, I am configuring the Web SDK extension but don't have a datastream set up that I'd like to use, I can quickly navigate to the creation page by clicking a link on the page rather than navigate through the sidebar.

## Screenshots (if appropriate):
<img width="672" height="322" alt="Screenshot 2025-09-23 at 11 20 38 AM" src="https://github.com/user-attachments/assets/db2ca8bc-ba95-4ea6-8aff-797f525e7020" />

Link to create datastream in extension config page

<img width="672" height="372" alt="Screenshot 2025-09-23 at 11 21 58 AM" src="https://github.com/user-attachments/assets/4e90a3a9-9323-4661-aa3d-c2be42867f32" />

Link to create schema in variable data element page

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] ~My change requires a change to the documentation.~
