### PR TITLE
Fixed autoPopulationAlert to evaluate node's absolute path

### DIFF
--- a/src/view/components/objectEditor/arrayEdit.jsx
+++ b/src/view/components/objectEditor/arrayEdit.jsx
@@ -107,10 +107,15 @@ const PartsPopulationStrategyForm = ({
                   defaultValue = "";
                 }
 
+                const itemNodePath = fieldName
+                  ? `${fieldName}.items.${items.length}`
+                  : `items.${items.length}`;
+
                 const itemFormStateNode = getInitialFormState({
                   schema: itemSchema,
                   value: defaultValue,
                   updateMode,
+                  nodePath: itemNodePath,
                 });
                 arrayHelpers.push(itemFormStateNode);
               }}

--- a/src/view/components/objectEditor/autoPopulationAlert.jsx
+++ b/src/view/components/objectEditor/autoPopulationAlert.jsx
@@ -23,7 +23,11 @@ const AutoPopulationAlert = ({ formStateNode }) => {
   const { autoPopulationSource, contextKey, schema } = formStateNode;
 
   return (
-    <InlineAlert variant="info" width="size-5000">
+    <InlineAlert
+      data-test-id="autoPopulationAlert"
+      variant="info"
+      width="size-5000"
+    >
       <Heading size="XXS">Auto-populated field</Heading>
       <Content>
         {autoPopulationSource === ALWAYS && (

--- a/src/view/components/objectEditor/helpers/getInitialFormState.js
+++ b/src/view/components/objectEditor/helpers/getInitialFormState.js
@@ -139,11 +139,12 @@ export default ({
   updateMode = false,
   transforms = {},
   existingFormStateNode,
+  nodePath = "",
 }) => {
   return getInitialFormStateNode({
     schema,
     value,
-    nodePath: "",
+    nodePath,
     updateMode,
     transforms,
     existingFormStateNode,

--- a/test/functional/specs/view/dataElements/xdmObjectAutoPopulationNotice.spec.mjs
+++ b/test/functional/specs/view/dataElements/xdmObjectAutoPopulationNotice.spec.mjs
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint-disable vitest/expect-expect */
+
+import { t } from "testcafe";
+import initializeExtensionView from "../../../helpers/objectEditor/initializeExtensionView.mjs";
+import xdmTree from "../../../helpers/objectEditor/xdmTree.mjs";
+import arrayEdit from "../../../helpers/objectEditor/arrayEdit.mjs";
+import createExtensionViewFixture from "../../../helpers/createExtensionViewFixture.mjs";
+import spectrum from "../../../helpers/spectrum.mjs";
+import { createTestIdSelector } from "../../../helpers/dataTestIdSelectors.mjs";
+
+createExtensionViewFixture({
+  title: "XDM Object Auto-Population Notice",
+  viewPath: "dataElements/xdmObject.html",
+  requiresAdobeIOIntegration: true,
+});
+
+const schemaField = spectrum.comboBox("schemaField");
+const autoPopulationAlert = createTestIdSelector("autoPopulationAlert");
+
+test("auto-population notice is shown for auto-populated fields", async () => {
+  await initializeExtensionView();
+  await schemaField.openMenu();
+  await schemaField.selectMenuOption("XDM Object Data Element Tests");
+  await xdmTree.node("environment").toggleExpansion();
+  await xdmTree.node("type").click();
+
+  await t.expect(autoPopulationAlert.exists).ok();
+  await t
+    .expect(autoPopulationAlert.textContent)
+    .contains("Auto-populated field");
+});
+
+test("auto-population notice is not shown for array items that match the name of a top-level auto-populated field", async () => {
+  await initializeExtensionView();
+  await schemaField.openMenu();
+  await schemaField.selectMenuOption("XDM Object Data Element Tests");
+  // This extensive navigation is necessary to find a field that is not auto-populated but matches the name of an auto-populated field
+  await xdmTree.node("placeContext").toggleExpansion();
+  await xdmTree.node("activePOIs").click();
+  await arrayEdit.addItem();
+  await arrayEdit.clickItem(0);
+  await xdmTree.node("geoInteractionDetails").toggleExpansion();
+  await xdmTree.node("geoShape").toggleExpansion();
+  await xdmTree.node("_schema").toggleExpansion();
+  await xdmTree.node("box").click();
+  await arrayEdit.addItem();
+  await arrayEdit.clickItem(0);
+  await xdmTree.toggleDisplayNames();
+  await xdmTree.node("Coordinates ID").click();
+
+  await t.expect(autoPopulationAlert.exists).notOk();
+});


### PR DESCRIPTION
## Description

The variable editor on the UpdateVariable action page currently has a small visual bug: after adding an item to an array, the nested object is evaluated without its absolute path when determining the autoPopulationSource. So if a field in the new nested object shares a name with a top-level auto-populating field (eg "_id"), that field will incorrectly be marked as auto-populating.

This PR addresses that issue by passing the node path to the function responsible for determining the initial state of the object when it is created in that view, so that it correctly determines the autoPopulationSource for each field.

## Related Issue

[Jira issue](https://jira.corp.adobe.com/browse/PDCL-6667)

## Motivation and Context

This change fixes a bug that would misinform users about how data is populated in certain fields.

## Screenshots (if appropriate):

(See jira issue for example of incorrect auto-population notice)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] ~My change requires a change to the documentation.~ *No*
