### PR TITLE
Fix the get settings method from the `Send Media` action.

### DIFF
--- a/src/view/actions/sendStreamingMediaEvent.jsx
+++ b/src/view/actions/sendStreamingMediaEvent.jsx
@@ -237,6 +237,7 @@ const customMetadataSection = section(
     objectArray(
       {
         name: "customMetadata",
+        ariaLabel: "Custom metadata",
         singularLabel: "Custom Metadata",
         dataElementDescription:
           "Provide a data element that resolves to an array of objects with properties 'name' and 'value'.",

--- a/src/view/forms/dataElementSection.jsx
+++ b/src/view/forms/dataElementSection.jsx
@@ -112,6 +112,7 @@ export default function dataElementSection(
           <FormikRadioGroup
             name={`${namePrefix}${name}InputMethod`}
             orientation="horizontal"
+            aria-label="Select the input method"
           >
             <Radio data-test-id={`${namePrefix}${name}FormOption`} value={FORM}>
               Enter values manually

--- a/src/view/forms/objectArray.jsx
+++ b/src/view/forms/objectArray.jsx
@@ -87,6 +87,7 @@ export default function objectArray(
   {
     name,
     label,
+    ariaLabel,
     singularLabel,
     dataElementDescription,
     objectKey,
@@ -261,6 +262,7 @@ export default function objectArray(
               name={`${namePrefix}${name}InputMethod`}
               orientation="horizontal"
               label={label}
+              aria-label={ariaLabel}
             >
               <Radio
                 data-test-id={`${namePrefix}${name}FormOption`}

--- a/src/view/forms/requiredComponent.jsx
+++ b/src/view/forms/requiredComponent.jsx
@@ -76,7 +76,9 @@ const RequiredComponent = (
     if (!componentEnabled) {
       return {};
     }
-    return wrapped(params);
+    return formOptions.wrapGetSettings
+      ? formOptions.wrapGetSettings(wrapped)(params)
+      : wrapped(params);
   };
 
   const {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

From a report on Slack. We changed half a year ago the `Send Media Event` action to show a warning when the `Streaming Media` module is disabled. When this changed was made, we broke the getSetting.

I would have added a test, but at this moment the testcafe tests are not running anymore on my machine.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.
