### PR TITLE
Restore all the streaming media fields from the configuration view with the previous stored values.

### DIFF
--- a/src/view/configuration/streamingMediaSection.jsx
+++ b/src/view/configuration/streamingMediaSection.jsx
@@ -39,18 +39,17 @@ export const bridge = {
       return bridge.getInstanceDefaults();
     }
 
-    const streamingMedia = Object.keys(getDefaultSettings()).reduce(
-      (acc, k) => {
-        if (instanceSettings.streamingMedia[k] !== undefined) {
-          acc[k] = instanceSettings.streamingMedia[k];
-        } else {
-          acc[k] = "";
-        }
+    const defaultSettings = getDefaultSettings();
+    const streamingMedia = Object.keys(defaultSettings).reduce((acc, k) => {
+      if (instanceSettings.streamingMedia[k] !== undefined) {
+        acc[k] = instanceSettings.streamingMedia[k];
+      } else {
+        acc[k] = defaultSettings[k] || "";
+      }
 
-        return acc;
-      },
-      {},
-    );
+      return acc;
+    }, {});
+
     return { streamingMedia };
   },
 
@@ -67,16 +66,20 @@ export const bridge = {
           mainPingInterval,
         },
       } = instanceValues;
+
       const streamingMedia = { channel, playerName };
       if (appVersion !== "") {
         streamingMedia.appVersion = appVersion;
       }
+
       if (adPingInterval !== 10) {
         streamingMedia.adPingInterval = adPingInterval;
       }
+
       if (mainPingInterval !== 10) {
         streamingMedia.mainPingInterval = mainPingInterval;
       }
+
       if (channel && playerName) {
         instanceSettings.streamingMedia = streamingMedia;
       }


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

The streaming media keys that match the default values are not saved in the settings object. We need to populate the fields with the default value next time when the view is loaded.

The testcafe tests are not running on my machine so I cannot change the tests.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
- [x] I've updated the schema in extension.json or no changes are necessary.
- [ ] My change requires a change to the documentation.
