### PR TITLE
FEAT: flush queue on extension load

### DIFF
--- a/src/lib/instanceManager/createInstanceManager.js
+++ b/src/lib/instanceManager/createInstanceManager.js
@@ -55,6 +55,10 @@ module.exports = ({
       ...options
     }) => {
       const instance = createCustomInstance({ name, components });
+      var queue;
+      if (window[name]) {
+        queue = window[name].q;
+      }
       window[name] = instance;
       if (!window.__alloyNS) {
         window.__alloyNS = [];
@@ -80,6 +84,10 @@ module.exports = ({
       turbine.onDebugChanged((enabled) => {
         instance("setDebug", { enabled });
       });
+      if (queue) {
+        queue.push = instance;
+        queue.forEach(instance);
+      }
     },
   );
 

--- a/src/lib/instanceManager/createInstanceManager.js
+++ b/src/lib/instanceManager/createInstanceManager.js
@@ -71,7 +71,6 @@ module.exports = ({
 
       options.edgeConfigOverrides = getConfigOverrides(options);
 
-      delete options.sandbox; // FOR LOCAL TESTING, do not commit
       instance("configure", {
         ...options,
         datastreamId: computedEdgeConfigId,


### PR DESCRIPTION
## Description

Currently, when a web page has a base code instance of alloy with queued commands, those commands are run when the SDK is loaded. However, if a script built via Tags with the SDK extension is loaded, it will overwrite the existing instance (when they share a name) without running the commands. This change updates the behavior so that the loaded instance will run the commands from the queue of any instances it overwrites when it loads (assuming 1) an instance with the same name exists and 2) that instance has a queue property `q`).

## Related Issue

[Jira Issue](https://jira.corp.adobe.com/browse/PDCL-8640)

## Motivation and Context

Loading in a pre-built script is an asynchronous process that can take a few moments, this change enables users' scripts to immediately send commands to alloy that are processed once it becomes available.

## Screenshots (if appropriate):
(none)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Discussion point**: This behavior changes existing functionality but I'm unsure if this is functionality that users rely on. I suspect they don't but would like more experienced team members to weigh in.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully. *(see below)*
- [x] I've updated the schema in extension.json or no changes are necessary.
- [x] My change requires a change to the documentation.

### Sandbox Test:

This is the code I used in the `libSandbox.html` to test this functionality. It creates a "base code" instance of alloy and sends it a command, then waits 5 seconds before loading the Tags script. In conjunction with this script, in the Sandbox Library an instance must be created that shares the same name ("alloy"). After loading the sandbox page, the `getIdentity` command will run once the built script loads (after 5 seconds) and will display a message in the console with the response from the command.
```
<!DOCTYPE html>
<html>
<head lang="en">
  <meta charset="UTF-8">
  <meta name="template_version" content="2.0">
  <script>
    baseCode = (window, instanceNames) => {
      instanceNames.forEach(function (instanceName) {
        if (!window[instanceName]) {
          (window.__alloyNS = window.__alloyNS || []).push(instanceName);
          window[instanceName] = function () {
            var userProvidedArgs = arguments;
            return new Promise(function (resolve, reject) {
              window[instanceName].q.push([resolve, reject, userProvidedArgs]);
            });
          };
          window[instanceName].q = [];
        }
      });
    };
    baseCode(window, ["alloy"]);
    var alloy = window["alloy"];
    alloy("getIdentity", { namespaces: ["ECID"] }).then((resp) => console.log("getIdentity", resp));
    setTimeout(() => {
      var script = document.createElement("script");
      script.src = "launch-EN00000000000000000000000000000000.js";
      script.async = true;
      script.onload = () => {
        console.log("script loaded");
      };
      document.body.appendChild(script);
    }, 5000);
  </script>
</head>
<body>
  <h1>Reactor Extension Library Sandbox</h1>
</body>
</html>
```

